### PR TITLE
Enable manual triggering for nightly workflows via workflow_dispatch

### DIFF
--- a/.github/workflows/nightly-aarch64.yml
+++ b/.github/workflows/nightly-aarch64.yml
@@ -1,6 +1,7 @@
 name: Nightly-Linux-AArch64
 
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: [trigger-nightly-aarch64-linux]
 

--- a/.github/workflows/nightly-x86-linux.yml
+++ b/.github/workflows/nightly-x86-linux.yml
@@ -1,6 +1,7 @@
 name: Nightly-Linux-x86_64
 
 on:
+  workflow_dispatch:
   repository_dispatch:
     types: [trigger-nightly-x86-linux]
 


### PR DESCRIPTION
Added `workflow_dispatch` to nightly-aarch64.yml and nightly-x86-linux.yml
to allow manual runs from GitHub Actions UI and CLI. This makes it possible
to trigger builds on non-default branches without relying on cron or repository_dispatch.