### PR TITLE
Enable RISC-V target in LLVM, eld

### DIFF
--- a/qualcomm-software/embedded/scripts/build.sh
+++ b/qualcomm-software/embedded/scripts/build.sh
@@ -133,7 +133,7 @@ log "Configuring LLVM"
 mkdir -p "${BUILD_DIR}/llvm"
 pushd "${BUILD_DIR}/llvm" >/dev/null
 cmake -G Ninja -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
-  -DLLVM_TARGETS_TO_BUILD="ARM;AArch64" \
+  -DLLVM_TARGETS_TO_BUILD="ARM;AArch64;RISCV" \
   -DLLVM_EXTERNAL_PROJECTS="eld" \
   -DLLVM_EXTERNAL_ELD_SOURCE_DIR="llvm/tools/eld" \
   -DLLVM_DEFAULT_TARGET_TRIPLE="aarch64-unknown-linux-gnueabi" \
@@ -162,9 +162,8 @@ if [[ "${AARCH64_BUILD}" == "true" ]]; then
     -S "${SRC_DIR}/llvm" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR_AARCH64}" \
     -DLLVM_ENABLE_PROJECTS="llvm;clang;polly;lld;mlir" \
-    -DLLVM_TARGETS_TO_BUILD="ARM;AArch64" \
+    -DLLVM_TARGETS_TO_BUILD="ARM;AArch64;RISCV" \
     -DLLVM_HOST_TRIPLE="aarch64-linux-gnu" \
-    -DELD_TARGETS_TO_BUILD="ARM;AArch64" \
     -DLLVM_EXTERNAL_PROJECTS="eld" \
     -DLLVM_EXTERNAL_ELD_SOURCE_DIR="${SRC_DIR}/llvm/tools/eld" \
     -DLLVM_DEFAULT_TARGET_TRIPLE="${AARCH64_LINUX_TRIPLE}" \


### PR DESCRIPTION
`ELD_TARGETS_TO_BUILD` is redundant at this point as we want the same set of targets. Just remove that too while I'm here rather than updating both.

RISC-V Linux runtimes will be enabled in a subsequent PR. Baremetal RISC-V runtimes won't be added for now.