### PR TITLE
[cpullvm] Build Arm/AArch64 Linux libraries under the same framework as RISC-V

### DIFF
--- a/qualcomm-software/embedded/patches/llvm-project/0001-ARM-compiler-rt-Add-a-few-more-variants-for-builtins.patch
+++ b/qualcomm-software/embedded/patches/llvm-project/0001-ARM-compiler-rt-Add-a-few-more-variants-for-builtins.patch
@@ -1,16 +1,18 @@
-From 7089c6d2cfb6509b127ee2792dca1f51cc4f3cfe Mon Sep 17 00:00:00 2001
-From: Zhaoshi Zheng <zhaoshiz@quicinc.com>
-Date: Thu, 8 Jan 2026 14:19:00 -0800
+From ee4f89120d294e0ef196b8187f4bbfbd0964d1f4 Mon Sep 17 00:00:00 2001
+From: Jonathon Penix <jpenix@quicinc.com>
+Date: Tue, 20 Jan 2026 19:06:31 -0800
 Subject: [PATCH] [ARM][compiler-rt] Add a few more variants for builtins
 
 Adding following variants: pacret, pacret-bti and pacret-b-key-bti. They are
 needed by corresponding musl variants.
+
+These should build for baremetal only.
 ---
  compiler-rt/lib/builtins/CMakeLists.txt | 24 +++++++++++++++++++++++-
  1 file changed, 23 insertions(+), 1 deletion(-)
 
 diff --git a/compiler-rt/lib/builtins/CMakeLists.txt b/compiler-rt/lib/builtins/CMakeLists.txt
-index c3dbd65998f1..5f68e4fde584 100644
+index c3dbd65998f1..78735ff6ea99 100644
 --- a/compiler-rt/lib/builtins/CMakeLists.txt
 +++ b/compiler-rt/lib/builtins/CMakeLists.txt
 @@ -1029,7 +1029,29 @@ else ()
@@ -18,7 +20,7 @@ index c3dbd65998f1..5f68e4fde584 100644
                                CXX_STANDARD 17
                                PARENT_TARGET builtins)
 -
-+      if(arch MATCHES "aarch64")
++      if(arch MATCHES "aarch64" AND COMPILER_RT_BAREMETAL_BUILD)
 +        add_compiler_rt_runtime(clang_rt.builtins-pacret-b-key-bti
 +                                STATIC
 +                                ARCHS ${arch}
@@ -45,5 +47,5 @@ index c3dbd65998f1..5f68e4fde584 100644
        # an independent compiler-rt build (see: compiler-rt/test/builtins/CMakeLists.txt)
        get_compiler_rt_output_dir(${arch} BUILTIN_LIB_OUTPUT_DIR)
 -- 
-2.34.1
+2.43.0
 

--- a/qualcomm-software/embedded/patches/musl-embedded/0001-Remove-Linux-libraries-from-component_list.sh.patch
+++ b/qualcomm-software/embedded/patches/musl-embedded/0001-Remove-Linux-libraries-from-component_list.sh.patch
@@ -1,0 +1,35 @@
+From 35ba9a719e2dd0015ddae56fc130fe0cbd941be2 Mon Sep 17 00:00:00 2001
+From: Jonathon Penix <jpenix@quicinc.com>
+Date: Sun, 18 Jan 2026 17:48:21 -0800
+Subject: [PATCH] Remove Linux libraries from component_list.sh
+
+We're temporarily porting these over to a consolidated build flow with
+RISC-V prior to a larger refactor. So, don't build these as we'll do it
+elsewhere.
+
+We also don't want to merge this into upstream musl-embedded--we'll be
+removing usage of component_list.sh entirely soon enough. So, just keep
+this as a patch for now.
+
+Signed-off-by: Jonathon Penix <jpenix@quicinc.com>
+---
+ qualcomm-software/config/component_list.sh | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/qualcomm-software/config/component_list.sh b/qualcomm-software/config/component_list.sh
+index 2dd84ab1..29e4af4f 100644
+--- a/qualcomm-software/config/component_list.sh
++++ b/qualcomm-software/config/component_list.sh
+@@ -1,9 +1,5 @@
+ # musl_components
+ musl_components=(
+-armv7_linux.sh,armv7-linux-gnueabi
+-aarch64_linux.sh,aarch64-linux-gnu
+-aarch64-pacret_linux.sh,aarch64-pacret-linux-gnu
+-aarch64-pacret-bti_linux.sh,aarch64-pacret-bti-linux-gnu
+ armv7_baremetal.sh,armv7-none-eabi
+ aarch64_baremetal.sh,aarch64-none-elf
+ aarch64-pacret-b-key-bti_baremetal.sh,aarch64-pacret-b-key-bti-none-elf
+-- 
+2.43.0
+

--- a/qualcomm-software/embedded/scripts/build.sh
+++ b/qualcomm-software/embedded/scripts/build.sh
@@ -64,10 +64,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --artifact-dir) ARTIFACT_DIR="$2"; shift 2 ;;
     --skip-tests) SKIP_TESTS="true"; shift ;;
-    --arm-sysroot) ARM32_SYSROOT_OPT="$2"; shift 2 ;;
     --aarch64-build) AARCH64_BUILD="true"; shift ;;
     --nightly) NIGHTLY="true"; shift ;;
-    --aarch64-sysroot) AARCH64_SYSROOT_OPT="$2"; shift 2 ;;
     --clean) CLEAN="true"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) warn "Unknown arg: $1"; usage; exit 1 ;;
@@ -77,14 +75,6 @@ done
 # --- Set the Build flags ---
 BUILD_MODE="Release"
 ASSERTION_MODE="OFF"
-ARM32_LINUX_TRIPLE="arm-linux-gnueabi"
-AARCH64_LINUX_TRIPLE="aarch64-linux-gnu"
-ARM32_SYSROOT="${ARM32_SYSROOT_OPT:-/usr/arm-linux-gnueabi}"
-AARCH64_SYSROOT="${AARCH64_SYSROOT_OPT:-/usr/aarch64-linux-gnu}"
-COMPILER_RT_ARM32_LINUX_BUILDDIR="${WORKSPACE}/build/compiler-rt/arm32/linux"
-COMPILER_RT_AARCH64_LINUX_BUILDDIR="${WORKSPACE}/build/compiler-rt/aarch64/linux"
-COMPILER_RT_ARM32_LINUX_FLAGS="--target=arm-linux-gnueabi -mcpu=cortex-a9 -mfloat-abi=softfp -mfpu=neon"
-COMPILER_RT_AARCH64_LINUX_FLAGS="--sysroot=${AARCH64_SYSROOT} --target=aarch64-linux-gnu -mcpu=cortex-a53"
 ARM32_BM_TRIPLE="arm-none-eabi"
 AARCH64_BM_TRIPLE="aarch64-none-elf"
 COMPILER_RT_ARM32_BM_BUILDDIR="${WORKSPACE}/build/compiler-rt/arm32/baremetal"
@@ -166,7 +156,7 @@ if [[ "${AARCH64_BUILD}" == "true" ]]; then
     -DLLVM_HOST_TRIPLE="aarch64-linux-gnu" \
     -DLLVM_EXTERNAL_PROJECTS="eld" \
     -DLLVM_EXTERNAL_ELD_SOURCE_DIR="${SRC_DIR}/llvm/tools/eld" \
-    -DLLVM_DEFAULT_TARGET_TRIPLE="${AARCH64_LINUX_TRIPLE}" \
+    -DLLVM_DEFAULT_TARGET_TRIPLE="aarch64-linux-gnu" \
     -DLLVM_BUILD_RUNTIME="OFF" \
     -DLIBCLANG_BUILD_STATIC="ON" \
     -DLLVM_POLLY_LINK_INTO_TOOLS="ON" \
@@ -199,37 +189,6 @@ fi
 RESOURCE_DIR="$("${INSTALL_DIR}/bin/clang" -print-resource-dir)"
 log "RESOURCE_DIR=${RESOURCE_DIR}"
 
-# --- Build compiler-rt for ARM ---
-log "Building compiler-rt for ARM"
-mkdir -p "${COMPILER_RT_ARM32_LINUX_BUILDDIR}"
-pushd "${COMPILER_RT_ARM32_LINUX_BUILDDIR}" >/dev/null
-cmake -G Ninja \
-  -DCMAKE_INSTALL_PREFIX="${RESOURCE_DIR}" \
-  -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" \
-  -DCMAKE_ASM_COMPILER_TARGET="${ARM32_LINUX_TRIPLE}" \
-  -DCMAKE_C_COMPILER_TARGET="${ARM32_LINUX_TRIPLE}" \
-  -DCMAKE_CXX_COMPILER_TARGET="${ARM32_LINUX_TRIPLE}" \
-  -DCMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
-  -DCMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
-  -DCMAKE_PREFIX_PATH="${INSTALL_DIR}" \
-  -DCMAKE_C_FLAGS="${COMPILER_RT_ARM32_LINUX_FLAGS}" \
-  -DCMAKE_CXX_FLAGS="${COMPILER_RT_ARM32_LINUX_FLAGS}" \
-  -DCMAKE_ASM_FLAGS="${COMPILER_RT_ARM32_LINUX_FLAGS}" \
-  -DCMAKE_SYSTEM_NAME="Generic" \
-  -DCOMPILER_RT_BUILD_BUILTINS="ON" \
-  -DCOMPILER_RT_BUILD_LIBFUZZER="OFF" \
-  -DCOMPILER_RT_DEFAULT_TARGET_ONLY="ON" \
-  -DCOMPILER_RT_OS_DIR="linux" \
-  -DCOMPILER_RT_TEST_TARGET_TRIPLE="${ARM32_LINUX_TRIPLE}" \
-  -DCOMPILER_RT_TEST_COMPILER_CFLAGS="${COMPILER_RT_ARM32_LINUX_FLAGS}" \
-  -DCOMPILER_RT_TEST_COMPILER="${INSTALL_DIR}/bin/clang" \
-  -DCMAKE_BUILD_TYPE="${BUILD_MODE}" \
-  -DLLVM_ENABLE_ASSERTIONS:BOOL="${ASSERTION_MODE}" \
-  -DCXX_SUPPORTS_UNWINDLIB_NONE_FLAG:BOOL="OFF" \
-  "${SRC_DIR}/compiler-rt"
-ninja install
-popd >/dev/null
-
 # --- Build compiler-rt for ARM baremetal ---
 log "Building compiler-rt for ARM baremetal"
 mkdir -p "${BUILD_DIR}/compiler-rt/arm32/baremetal"
@@ -261,30 +220,6 @@ cmake -G Ninja \
     -DCMAKE_BUILD_TYPE="${BUILD_MODE}" \
     -DLLVM_ENABLE_ASSERTIONS:BOOL="${ASSERTION_MODE}" \
     -DCXX_SUPPORTS_UNWINDLIB_NONE_FLAG:BOOL="OFF" \
-    "${SRC_DIR}/compiler-rt"
-ninja install
-popd >/dev/null
-
-# --- Build compiler-rt for AArch64 ---
-log "Building compiler-rt for AArch64"
-mkdir -p "${COMPILER_RT_AARCH64_LINUX_BUILDDIR}"
-pushd "${COMPILER_RT_AARCH64_LINUX_BUILDDIR}" >/dev/null
-cmake -G Ninja \
-    -DCMAKE_INSTALL_PREFIX="${RESOURCE_DIR}" \
-    -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" \
-    -DCMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
-    -DCMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
-    -DCMAKE_PREFIX_PATH="${INSTALL_DIR}" \
-    -DCMAKE_C_FLAGS="${COMPILER_RT_AARCH64_LINUX_FLAGS}" \
-    -DCMAKE_CXX_FLAGS="${COMPILER_RT_AARCH64_LINUX_FLAGS}" \
-    -DCMAKE_ASM_FLAGS="${COMPILER_RT_AARCH64_LINUX_FLAGS}" \
-    -DCMAKE_SYSTEM_NAME="Generic" \
-    -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE="${AARCH64_LINUX_TRIPLE}" \
-    -DCOMPILER_RT_OS_DIR="linux" \
-    -DCOMPILER_RT_TEST_COMPILER_CFLAGS="${COMPILER_RT_AARCH64_LINUX_FLAGS}" \
-    -DCOMPILER_RT_TEST_COMPILER="${INSTALL_DIR}/bin/clang" \
-    -DCMAKE_BUILD_TYPE="${BUILD_MODE}" \
-    -DLLVM_ENABLE_ASSERTIONS:BOOL="${ASSERTION_MODE}" \
     "${SRC_DIR}/compiler-rt"
 ninja install
 popd >/dev/null
@@ -395,58 +330,14 @@ for VARIANT in "aarch64-none-elf" "aarch64-pacret-b-key-bti-none-elf" "armv7-non
     log "c++ libs install ..."
 done
 
-# Linux libc++ configs
-declare -A LINUX_TRIPLES
-LINUX_TRIPLES["aarch64-linux-gnu"]="aarch64-linux-gnu"
-LINUX_TRIPLES["aarch64-pacret-linux-gnu"]="aarch64-linux-gnu"
-LINUX_TRIPLES["aarch64-pacret-bti-linux-gnu"]="aarch64-linux-gnu"
-LINUX_TRIPLES["armv7-linux-gnueabi"]="armv7-linux-gnueabi"
-declare -A LINUX_CFLAGS
-LINUX_CFLAGS["aarch64-linux-gnu"]="-mcpu=cortex-a53"
-LINUX_CFLAGS["aarch64-pacret-linux-gnu"]="-mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf"
-LINUX_CFLAGS["aarch64-pacret-bti-linux-gnu"]="-mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf+bti"
-LINUX_CFLAGS["armv7-linux-gnueabi"]="-mcpu=cortex-a9 -mfloat-abi=softfp -mfpu=neon"
-for VARIANT in "${!LINUX_TRIPLES[@]}"; do
-    TRIPLE="${LINUX_TRIPLES[${VARIANT}]}"
-    SYSROOT="${AARCH64_SYSROOT}"
-    if [[ "${TRIPLE}" = "armv7-linux-gnueabi" ]]; then
-      SYSROOT="${ARM32_SYSROOT}"
-    fi
-    MUSL_INC="${INSTALL_DIR}/${TRIPLE}/libc/include"
-    CMAKE_CFLAGS="--target=${TRIPLE} -nostdlib -nostdinc -isystem ${MUSL_INC} -isystem ${SYSROOT}/include -ccc-gcc-name ${TRIPLE}-g++ -ffunction-sections -fdata-sections -D_GNU_SOURCE ${LINUX_CFLAGS[${VARIANT}]}"
-    mkdir -p "${BUILD_DIR}/${VARIANT}"
-    pushd "${BUILD_DIR}/${VARIANT}" >/dev/null
-    cmake -G Ninja -S "${SRC_DIR}/runtimes" \
-        -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}/${VARIANT}" \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DCMAKE_C_COMPILER="clang" \
-        -DCMAKE_CXX_COMPILER="clang++" \
-        -DCMAKE_SYSTEM_NAME="Linux" \
-        -DCMAKE_C_FLAGS_RELEASE="${CFLAGS_RELEASE}" \
-        -DCMAKE_CXX_FLAGS_RELEASE="${CFLAGS_RELEASE}" \
-        -DCMAKE_C_FLAGS="${CMAKE_CFLAGS}" \
-        -DCMAKE_CXX_FLAGS="${CMAKE_CFLAGS}" \
-        -DCMAKE_ASM_FLAGS="${CMAKE_CFLAGS}" \
-        -DLIBCXX_ENABLE_SHARED="False" \
-        -DLIBCXX_HAS_MUSL_LIBC="True" \
-        -DLIBCXX_ENABLE_ABI_LINKER_SCRIPT="False" \
-        -DLIBCXXABI_USE_LLVM_UNWINDER="True" \
-        -DLIBCXXABI_ENABLE_SHARED="False" \
-        -DLIBCXXABI_ENABLE_WERROR="True" \
-        -DLIBUNWIND_ENABLE_SHARED="False" \
-        -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind"
-    ninja install
-    popd >/dev/null
-    log "Linux C++ libs install ..."
-done
-
-# RISC-V Linux libraries
+# Linux libraries
 log "Install RISC-V Linux libraries"
-"${SCRIPT_DIR}"/build_riscv_linux_runtimes.sh \
+"${SCRIPT_DIR}"/build_linux_runtimes.sh \
                     --base-build-dir "${BUILD_DIR}" \
                     --base-install-dir "${INSTALL_DIR}" \
                     --resource-dir "${RESOURCE_DIR}" \
                     --llvm-src-dir "${SRC_DIR}" \
+                    --musl-emb-src-dir "${MUSL_BUILDDIR}" \
                     --download-dir "${WORKSPACE}"
 
 log "Build and installation complete."

--- a/qualcomm-software/embedded/scripts/build_linux_runtimes.sh
+++ b/qualcomm-software/embedded/scripts/build_linux_runtimes.sh
@@ -15,21 +15,51 @@ Options:
   --base-install-dir <path>   Directory for the install
   --resource-dir <path>       Resource directory for installing runtimes
   --llvm-src-dir <path>       Directory of the LLVM sources
+  --musl-emb-src-dir <path>   Directory of the musl-embedded source dir
   --download-dir <path>       Directory where extra projects are downloaded into
 EOF
 }
 
 # Given a string containing compile flags (hopefully containing a
-# `--target<triple>`), echo the `<triple>` or exit if not found.
+# `--target=<triple>`), echo the `<triple>` or exit if not found.
 get_target_from_flags() {
   local target_flag_regex="--target=([a-z0-9-]+)"
   [[ "$1" =~ ${target_flag_regex} ]]
   local target="${BASH_REMATCH[1]}"
   if [ -z "${target}" ]; then
-    echo "Could not parse --target from string $1!"
+    echo "Could not parse target from string ${1}!"
     exit 1
   fi
   echo "${target}"
+}
+
+# Given a string containing compile flags (hopefully containing a
+# `--target=<triple>`), echo the arch or exit if not found.
+get_arch_from_flags() {
+  local target=$(get_target_from_flags "$1")
+  local arch="$(echo ${target} | cut -d '-' -f1)"
+  if [ -z "${arch[0]}" ]; then
+    echo "Could not parse arch from string $1!"
+    exit 1
+  fi
+  echo "${arch[0]}"
+}
+
+# Given an arch appropriate for clang (from something like
+# `--target=<arch>-linux-gnu`), echo the appropriate arch for installing
+# kernel headers.
+get_kernel_arch() {
+  if [[ "$1" == "aarch64" ]]; then
+    echo "arm64"
+  elif [[ "$1" == "arm" ]]; then
+    echo "arm"
+  # Seems riscv is the only supported RISC-V ARCH?
+  elif [[ "$1" =~ riscv ]]; then
+    echo "riscv"
+  else
+    echo "UNKNOWN_ARCH"
+    exit 1
+  fi
 }
 
 while [[ $# -gt 0 ]]; do
@@ -38,6 +68,7 @@ while [[ $# -gt 0 ]]; do
     --base-install-dir) BASE_INSTALL_DIR="$2"; shift 2;;
     --resource-dir) RESOURCE_DIR="$2"; shift 2 ;;
     --llvm-src-dir) LLVM_BASE_DIR="$2"; shift 2 ;;
+    --musl-emb-src-dir) MUSL_EMB_SRC_DIR="$2"; shift 2 ;;
     --download-dir) DOWNLOAD_DIR="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Unknown arg: $1"; usage; exit 1 ;;
@@ -49,13 +80,14 @@ if [ -z "${BASE_BUILD_DIR}" ] ||
    [ -z "${BASE_INSTALL_DIR}" ] ||
    [ -z "${RESOURCE_DIR}" ] ||
    [ -z "${LLVM_BASE_DIR}" ] ||
+   [ -z "${MUSL_EMB_SRC_DIR}" ] ||
    [ -z "${DOWNLOAD_DIR}" ]; then
   echo "All options must be specified"; usage; exit 1
 fi
 
 # Double check that the resource dirs match. We could remove the flag,
-# but I want something that prevents accidentally installing things to
-# random other toolchains during testing.
+# but having something that prevents accidentally installing things to
+# random other toolchains during testing is helpful.
 if [[ "$(clang -print-resource-dir)" != "${RESOURCE_DIR}" ]]; then
   echo "clang's resource dir does not match --resource-dir"; usage; exit 1
 fi
@@ -89,11 +121,55 @@ popd >/dev/null
 # Variants to build and the basic set of compile flags to use for each. There's
 # surely more elegant ways of doing this, but this doesn't require any extra
 # dependencies and is intended as temporary code.
-VARIANTS=("rv32imac_ilp32" "rv64imac_lp64" "rv64gc_lp64d")
+VARIANTS=(
+  "rv32imac_ilp32"
+  "rv64imac_lp64"
+  "rv64gc_lp64d"
+  "aarch64a"
+  "aarch64a_pacret"
+  "aarch64a_pacret_bti"
+  "armv7_softfp_neon"
+)
+
+# We place things into folders based on the target here (which maybe isn't
+# ideal) so prefer the mostly-normalized form that clang seems to search for
+# builtins, default libs, etc.
 declare -A VARIANT_BUILD_FLAGS
 VARIANT_BUILD_FLAGS["rv32imac_ilp32"]="--target=riscv32-unknown-linux-gnu -march=rv32imac -mabi=ilp32"
 VARIANT_BUILD_FLAGS["rv64imac_lp64"]="--target=riscv64-unknown-linux-gnu -march=rv64imac -mabi=lp64"
 VARIANT_BUILD_FLAGS["rv64gc_lp64d"]="--target=riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d"
+# Note that there's minor devations in the flags here--in the past, only musl
+# either was not built with -mcpu=cortex-a53 (aarch64) or was built with
+# ex: -mcpu=krait (arm). There was also some odd mixing of armv8.3 vs armv8.5
+# across libraries. Intentionally aligning these across libraries for each
+# variant.
+VARIANT_BUILD_FLAGS["aarch64a"]="--target=aarch64-unknown-linux-gnu -mcpu=cortex-a53"
+VARIANT_BUILD_FLAGS["aarch64a_pacret"]="--target=aarch64-unknown-linux-gnu -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf"
+VARIANT_BUILD_FLAGS["aarch64a_pacret_bti"]="--target=aarch64-unknown-linux-gnu -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf+bti"
+# The full normalized form here seems to be "thumbv7-unknown-linux-gnueabi" but
+# that doesn't seem to be what clang searches--use "arm-unknown-linux-gnueabi"
+# instead.
+VARIANT_BUILD_FLAGS["armv7_softfp_neon"]="--target=arm-unknown-linux-gnueabi -mcpu=cortex-a9 -mfloat-abi=softfp -mfpu=neon"
+
+# Our musl builds in the past have used different "base" sets of compile flags
+# for each target arch. Build out that mapping here.
+declare -A ARCH_MUSL_CFLAGS
+ARCH_MUSL_CFLAGS["riscv32"]="-Os"
+ARCH_MUSL_CFLAGS["riscv64"]="-Os"
+ARCH_MUSL_CFLAGS["aarch64"]="-mstrict-align -fPIC -fno-rounding-math -O3"
+ARCH_MUSL_CFLAGS["arm"]="-mno-unaligned-access -fPIC -fno-rounding-math -O3"
+
+# We also have some new variant-specific configuration going on. Map that out
+# as well. Just list all variants--it'll be cleaned up later.
+declare -A VARIANT_MUSL_CONFIGS
+VARIANT_MUSL_CONFIGS["rv32imac_ilp32"]=""
+VARIANT_MUSL_CONFIGS["rv64imac_lp64"]=""
+VARIANT_MUSL_CONFIGS["rv64gc_lp64d"]=""
+VARIANT_MUSL_CONFIGS["aarch64a"]="--quic-aarch64-optmem"
+VARIANT_MUSL_CONFIGS["aarch64a_pacret"]="--quic-aarch64-optmem"
+VARIANT_MUSL_CONFIGS["aarch64a_pacret_bti"]="--quic-aarch64-optmem \
+                                             --quic-aarch64-mark-bti"
+VARIANT_MUSL_CONFIGS["armv7_softfp_neon"]=""
 
 for VARIANT in "${VARIANTS[@]}"; do
   echo "Building libraries for ${VARIANT}"
@@ -107,38 +183,52 @@ for VARIANT in "${VARIANTS[@]}"; do
   VARIANT_TMP_SYSROOT="${VARIANT_BASE_BUILD_DIR}/tmp_sysroot"
   mkdir -p "${VARIANT_TMP_SYSROOT}"
 
+  VARIANT_TARGET="$(get_target_from_flags ${BUILD_FLAGS})"
+  VARIANT_ARCH="$(get_arch_from_flags ${VARIANT_BUILD_FLAGS[$VARIANT]})"
+  VARIANT_KERNEL_ARCH="$(get_kernel_arch ${VARIANT_ARCH})"
+
+  # Historically, our RISC-V and Arm/AArch64 builds use slightly different
+  # flags, sources, etc. Sort that all out here so we can treat the two
+  # consistently below.
+  MUSL_DIR="${MUSL_EMB_SRC_DIR}"
+  EXTRA_MUSL_CONFIGS="${VARIANT_MUSL_CONFIGS[$VARIANT]}"
+  CMAKE_OPT_LEVEL="Release"
+  if [[ "${VARIANT_ARCH}" =~ riscv ]]; then
+    MUSL_DIR="${MUSL_SOURCE_BASE_DIR}"
+    EXTRA_MUSL_CONFIGS="${EXTRA_MUSL_CONFIGS} \
+                        --disable-shared"
+    CMAKE_OPT_LEVEL="MinSizeRel"
+  fi
+
   # Install kernel headers. They get their own folder so they aren't added to
   # the distribution
   echo "Installing kernel headers for ${VARIANT}"
   KERNEL_BUILD_BASE="${VARIANT_BASE_BUILD_DIR}/kernel"
   make -C "${KERNEL_SOURCE_BASE_DIR}" clean
-  # Seems riscv is the only supported RISC-V ARCH?
   make -C "${KERNEL_SOURCE_BASE_DIR}" \
           headers_install \
           INSTALL_HDR_PATH="${KERNEL_BUILD_BASE}" \
-          ARCH=riscv
+          ARCH="${VARIANT_KERNEL_ARCH}"
 
   # Flags common to all libraries.
   LIB_BUILD_FLAGS="${BUILD_FLAGS} -isystem${KERNEL_BUILD_BASE}/include --sysroot=${VARIANT_TMP_SYSROOT}"
   LIB_BUILD_FLAGS="${LIB_BUILD_FLAGS} -ffunction-sections -fdata-sections"
 
-  # Parse out the --target flag rather than map it above
-  VARIANT_TARGET="$(get_target_from_flags ${BUILD_FLAGS})"
-
   # Install musl headers
   # This is probably overkill for headers-only (nothing should be compiled)
-  # but just use our normal configure step.
+  # but just use our normal configure step, minus the builtins (as they
+  # don't exist yet anyway)
   echo "Installing musl headers for ${VARIANT}"
   VARIANT_MUSL_BUILD_DIR="${VARIANT_BASE_BUILD_DIR}"/musl
   mkdir -p "${VARIANT_MUSL_BUILD_DIR}"
   pushd "${VARIANT_MUSL_BUILD_DIR}" >/dev/null
-  "${MUSL_SOURCE_BASE_DIR}"/configure \
-                            --disable-shared \
+  "${MUSL_DIR}"/configure \
+                            ${EXTRA_MUSL_CONFIGS} \
                             --disable-wrapper \
                             --prefix="${VARIANT_TMP_SYSROOT}" \
                             CROSS_COMPILE="llvm-" \
                             CC="clang --target=${VARIANT_TARGET} -fuse-ld=eld" \
-                            CFLAGS="${LIB_BUILD_FLAGS} -Os"
+                            CFLAGS="${LIB_BUILD_FLAGS} ${ARCH_MUSL_CFLAGS[$VARIANT_ARCH]}"
   make install-headers
   popd >/dev/null
 
@@ -151,7 +241,7 @@ for VARIANT in "${VARIANTS[@]}"; do
   cmake -G Ninja \
       -DCMAKE_INSTALL_PREFIX="${RESOURCE_DIR}" \
       -DCMAKE_SYSROOT="${TMP_RESOURCE_DIR}" \
-      -DCMAKE_BUILD_TYPE="MinSizeRel" \
+      -DCMAKE_BUILD_TYPE="${CMAKE_OPT_LEVEL}" \
       -DCMAKE_C_COMPILER="clang" \
       -DCMAKE_CXX_COMPILER="clang++" \
       -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" \
@@ -189,8 +279,8 @@ for VARIANT in "${VARIANTS[@]}"; do
   #      `clang --target=<arch>-linux-gnu test.c <extra flags>`
   #   2. Locating the builtins through `--print-libgcc-file-name`. This can
   #      happen in ex: `add_compiler_rt_runtime`.
-  # We have lots of options to work around the first case. In the second case, I
-  # can't find any way to actually influence where clang looks for compiler-rt
+  # We have lots of options to work around the first case. In the second case,
+  # there doesn't seem to be a way to influence where clang looks for compiler-rt
   # (without source changes) in a way that helps us--it always looks into
   # some "fixed" path that, at best, is common for variants of the same triple.
   #
@@ -201,27 +291,32 @@ for VARIANT in "${VARIANTS[@]}"; do
   # the next variant. Once all variants are built, we can go through and install
   # everything in the correct location again.
   #
-  # UPDATE/FIXME: I've since learned `--resource-dir <dir>` is a thing--I think
-  # this improves the situation a bit in that we can set up per-variant
-  # resource dirs for building rather than share the single "real" one in clang.
-  # I *think* that should at least allow us to relax the sequential ordering
-  # between same-target variants. This script is throwaway code so I'm not
-  # going to make this change here--I'll address this post refactor.
+  # UPDATE/FIXME: Apparently `--resource-dir <dir>` is a thing--this improves
+  # the situation a bit in that we can set up per-variant resource dirs for
+  # building rather than share the single "real" one in clang. That should
+  # at least allow us to relax the sequential ordering between same-target
+  # variants. This script is throwaway code so don't make this change here--
+  # we'll address this post refactor.
   mkdir -p "${VARIANT_TMP_SYSROOT}/lib"
-  cp -r "${RESOURCE_DIR}/lib/${VARIANT_TARGET}" "${VARIANT_TMP_SYSROOT}/lib"
+  VARIANT_RESOURCE_DIR="${RESOURCE_DIR}/lib/${VARIANT_TARGET}"
+  cp -r "${VARIANT_RESOURCE_DIR}" "${VARIANT_TMP_SYSROOT}/lib"
 
   # Install musl, including the libraries this time.
+  # FIXME: we already configured above, is reconfiguring actually helpful? (Does
+  # it matter that the builtin path didn't exist previously?)
   echo "Installing musl libraries for ${VARIANT}"
   pushd "${VARIANT_MUSL_BUILD_DIR}" >/dev/null
+  make distclean
   # TODO: we should probably standardize which linker we're using (lld vs eld)
   # but that can wait--this matches what we've done in the past.
-  "${MUSL_SOURCE_BASE_DIR}"/configure \
-                            --disable-shared \
-                            --disable-wrapper \
-                            --prefix="${VARIANT_TMP_SYSROOT}" \
-                            CROSS_COMPILE="llvm-" \
-                            CC="clang --target=${VARIANT_TARGET} -fuse-ld=eld" \
-                            CFLAGS="${LIB_BUILD_FLAGS} -Os"
+  "${MUSL_DIR}"/configure \
+      ${EXTRA_MUSL_CONFIGS} \
+      --disable-wrapper \
+      --prefix="${VARIANT_TMP_SYSROOT}" \
+      CROSS_COMPILE="llvm-" \
+      CC="clang --target=${VARIANT_TARGET} -fuse-ld=eld" \
+      CFLAGS="${LIB_BUILD_FLAGS} ${ARCH_MUSL_CFLAGS[$VARIANT_ARCH]}" \
+      LIBCC="${VARIANT_RESOURCE_DIR}/libclang_rt.builtins.a"
   make -j"${JOBS}"
   make install
   popd >/dev/null
@@ -236,7 +331,7 @@ for VARIANT in "${VARIANTS[@]}"; do
   cmake -G Ninja \
       -DCMAKE_INSTALL_PREFIX="${VARIANT_TMP_SYSROOT}" \
       -DCMAKE_SYSROOT="${TMP_RESOURCE_DIR}" \
-      -DCMAKE_BUILD_TYPE="MinSizeRel" \
+      -DCMAKE_BUILD_TYPE="${CMAKE_OPT_LEVEL}" \
       -DCMAKE_C_COMPILER="clang" \
       -DCMAKE_CXX_COMPILER="clang++" \
       -DCMAKE_SYSTEM_NAME="Linux" \
@@ -263,9 +358,36 @@ for VARIANT in "${VARIANTS[@]}"; do
   ninja -C "${LIBCXX_BUILD_DIR}" install
 
   # Install the rest of compiler-rt now.
+
+  # The goal here is to disable rtsan and gwp_asan:
+  #   * For rtsan, our musl-embedded is too old to support the fopencookie
+  #     extension, which rtsan relies on.
+  #   * For gwp_asan, it requires execinfo.h which is a glibc-specific
+  #     header--no musl version ships this (or an equivalent).
+  # The actual list corresponds to `ALL_SANITIZERS` in LLVM, minus rtsan and
+  # gwp_asan. Just do this for all targets since aarch64 is the only arch that
+  # rtsan supports that we care about and gwp_asan seems to be generally broken
+  # when building against musl. Might be worth trying to pull the list out of
+  # LLVM sources, but for now this should be sufficient.
+  SAN_TO_BUILD="asan;dfsan;msan;hwasan;tsan;tysan;safestack;cfi;scudo_standalone;ubsan_minimal;nsan;asan_abi"
+
+  # For Arm specifically, we need to disable anything that touches sanitizer
+  # common. Our musl-embedded is old enough that time_t is 32bits and the
+  # sanitizer common code thinks we should have a 64bit time_t (see
+  # https://github.com/llvm/llvm-project/blob/c94739a5d523883663d237ad9072275ff6c847b1/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h#L393-L398)
+  # and this disagreement causes issues down the line in ex:
+  # https://github.com/llvm/llvm-project/blob/c94739a5d523883663d237ad9072275ff6c847b1/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp#L1292
+  # and we fail the static asserts.
+  EXTRA_CRT_CONFIGS=""
+  if [[ "${VARIANT_ARCH}" =~ arm ]]; then
+    EXTRA_CRT_CONFIGS="-DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+                       -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF \
+                       -DCOMPILER_RT_BUILD_MEMPROF=OFF"
+  fi
+
   # As a continuation of the hack above, just install these into the temp
   # sysroot and we'll move them later.
-  # FIXME: Disable fuzzers as well to work around (I think) an upstream bug.
+  # FIXME: Disable fuzzers as well to work around (seemingly) an upstream bug.
   # `partially_link_libcxx` in fuzzer/CMakeLists.txt has a custom command that
   # invokes the linker, but it just uses the toolchain default. So, we get
   # errors as it picks up the host ld.bfd when linking for riscv64 rather than
@@ -277,9 +399,9 @@ for VARIANT in "${VARIANTS[@]}"; do
   echo "Installing compiler-rt for ${VARIANT}"
   COMPILER_RT_BUILD_DIR="${VARIANT_BASE_BUILD_DIR}/compiler-rt"
   cmake -G Ninja \
-      -DCMAKE_INSTALL_PREFIX="${RESOURCE_DIR}" \
+      -DCMAKE_INSTALL_PREFIX="${VARIANT_TMP_SYSROOT}" \
       -DCMAKE_SYSROOT="${TMP_RESOURCE_DIR}" \
-      -DCMAKE_BUILD_TYPE="MinSizeRel" \
+      -DCMAKE_BUILD_TYPE="${CMAKE_OPT_LEVEL}" \
       -DCMAKE_C_COMPILER="clang" \
       -DCMAKE_CXX_COMPILER="clang++" \
       -DCMAKE_SYSTEM_NAME="Linux" \
@@ -295,11 +417,14 @@ for VARIANT in "${VARIANTS[@]}"; do
       -DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON \
       -DCOMPILER_RT_BUILD_BUILTINS=OFF \
       -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+      -DCOMPILER_RT_SANITIZERS_TO_BUILD="${SAN_TO_BUILD}" \
+      -DCOMPILER_RT_BUILD_ORC=OFF \
       -DCOMPILER_RT_BUILD_XRAY=OFF \
       -DLLVM_ENABLE_RUNTIMES=compiler-rt \
       -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld --rtlib=compiler-rt -stdlib=libc++" \
       -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld --rtlib=compiler-rt -stdlib=libc++" \
       -DCMAKE_MODULE_LINKER_FLAGS="-fuse-ld=lld --rtlib=compiler-rt -stdlib=libc++" \
+      ${EXTRA_CRT_CONFIGS} \
       -B "${COMPILER_RT_BUILD_DIR}" \
       -S "${LLVM_BASE_DIR}/runtimes"
   ninja -C "${COMPILER_RT_BUILD_DIR}" install
@@ -313,9 +438,9 @@ done
 # like this:
 #   - libc/libc++: <install>/<target>/<variant>
 #   - compiler-rt: <resource dir>/lib/<target>/<variant>
-# I don't think this layout is ideal, but it is close to what we had in the
+# This layout isn't ideal, but it is close to what we had in the
 # past. When we know what to do with the installed libc++ module files
-# we can revisit this.
+# and sanitizer binaries we can revisit this.
 echo "Copying libraries to their final locations"
 for VARIANT in "${VARIANTS[@]}"; do
   VARIANT_TMP_SYSROOT="${BASE_BUILD_DIR}/${VARIANT}/tmp_sysroot"


### PR DESCRIPTION
Arm/AArch64 now follow the same general pattern as RISC-V and are building
against our own tools (llvm tools, musl, etc.)

Note that this again isn't a 1:1 port of our old cpullvm Arm/AArch64
libraries (or what we used to do downstream) even besides the llvm/musl
changes:
* Baseline C flags used to build compiler-rt/musl/libc++ have changed
  slightly--musl used to have slightly different variations, but these
  have been made consistent across the projects.
* The subset of compiler-rt builtins we build for AArch64 Linux is now
  slightly different--we build only the same variants as we build for
  musl/libc++ (rather than sharing some of the same configs with
  baremetal).
* Profile, sanitizer libraries are now building for Arm/AArch64 (they were
  coincidentally disabled in cpullvm previously). There's caveats though,
  see next point.
* We are disabling a few sanitizers/sanitizer-related projects in
  compiler-rt due to either a) upstream issues between LLVM and musl or
  b) our musl version underlying musl-embedded being particularly old. A
  brief survey of the issues (see inline comments for details):
    * sanitizer_common dependent projects have issues for Arm due to
      disagreement about the size of time_t. I don't think this is worth
      fixing, so just disable the projects.
    * rtsan relies on fopencookie, which our musl-embedded is too old to
      support. I don't think this is worth backporting, so disable this.
    * gwp_asan relies on execinfo.h and musl (even upstream musl) does not
      have this header or an equivalent. This is a known issue in upstream
      LLVM. Just disable the project.
* Fix a bug (that also impacts RISC-V!) that meant the extra (non-builtins)
  compiler-rt libraries weren't making it into the final install.