### PR TITLE
Don't use a specific commit for musl-embedded in mainline

### DIFF
--- a/qualcomm-software/embedded/scripts/build.sh
+++ b/qualcomm-software/embedded/scripts/build.sh
@@ -108,10 +108,6 @@ mkdir -p "${BUILD_DIR}" "${INSTALL_DIR}"
 if [[ ! -d "${WORKSPACE}/musl-embedded/.git" ]]; then
   log "Cloning musl-embedded into ${WORKSPACE}/musl-embedded"
   git clone "${MUSL_EMBEDDED_REPO_URL}" "${WORKSPACE}/musl-embedded" -b "${MUSL_EMBEDDED_BRANCH}"
-  MUSL_PINNED_COMMIT="${MUSL_PINNED_COMMIT:-760b7e8ceb9a394e575498ebf8ac79834e9a907c}"
-  pushd "${WORKSPACE}/musl-embedded" >/dev/null
-  git checkout "${MUSL_PINNED_COMMIT}"
-  popd >/dev/null
 else
   log "musl-embedded already present, leaving as-is"
 fi


### PR DESCRIPTION
Release branches can use a specific commit, but having this in mainline where we want to be using the latest musl-embedded is needlessly fiddly.

This code should all be going away soon with the refactor, so having to re-add this for branches isn't a concern at this point. Note that this is also what the Windows scripts do, and maintaining two of these in mainline isn't worth the effort.