### PR TITLE
[cpullvm] Fix our precheckin

### DIFF
--- a/.github/workflows/pre-checkin.yml
+++ b/.github/workflows/pre-checkin.yml
@@ -2,10 +2,10 @@ name: pre-checkin
 
 on:
   pull_request:
-  paths-ignore:
-    - 'qualcomm-software/embedded/scripts/build.ps1'
-    - '.github/workflows/nightly-win-x86.yml'
-    - '.github/workflows/nightly-woa.yml'
+    paths-ignore:
+      - 'qualcomm-software/embedded/scripts/build.ps1'
+      - '.github/workflows/nightly-win-x86.yml'
+      - '.github/workflows/nightly-woa.yml'
 
 
 jobs:


### PR DESCRIPTION
After [1] I think our precheckin has been broken with errors like below:

Invalid workflow file: .github/workflows/pre-checkin.yml#L1
(Line: 5, Col: 3): Unexpected value 'paths-ignore', (Line: 6, Col: 5): A sequence was not expected

See [2] as an example.

I think we just need to indent this an extra level.

[1] https://github.com/qualcomm/cpullvm-toolchain/commit/afd6201fe9f1aea9f5b9aa94827a3a7b03b1cd6e
[2] https://github.com/qualcomm/cpullvm-toolchain/actions/runs/21226832691