### PR TITLE
[cpullvm] Integrate eld into cpullvm

### DIFF
--- a/qualcomm-software/embedded/CMakeLists.txt
+++ b/qualcomm-software/embedded/CMakeLists.txt
@@ -146,6 +146,10 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     clang
     dsymutil
     lld
+    ld.eld
+    LW
+    PluginAPIHeaders
+    YAMLMapParser
     llvm-ar
     llvm-config
     llvm-cov
@@ -214,6 +218,9 @@ include(ExternalProject)
 include(FetchContent)
 include(ProcessorCount)
 
+# Check out and patch eld
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_eld.cmake)
+
 # Check out and patch picolibc if required.
 #
 # If you'd rather check out and patch manually then run cmake with
@@ -247,6 +254,10 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 ##################################################################################################
 
+# Include eld
+set(LLVM_EXTERNAL_PROJECTS eld)
+set(LLVM_EXTERNAL_ELD_SOURCE_DIR "${eld_SOURCE_DIR}")
+
 set(clang_lit_xfails_path "${CMAKE_CURRENT_BINARY_DIR}/clang_lit_xfails.txt")
 set(CLANG_TEST_EXTRA_ARGS "@${clang_lit_xfails_path}")
 
@@ -254,6 +265,8 @@ set(llvmproject_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 add_subdirectory(
     ${llvmproject_src_dir}/llvm llvm
 )
+
+add_dependencies(check-all check-eld)
 
 # Update the xfail/xfail-not list before running the tests.
 add_custom_target(
@@ -373,6 +386,9 @@ add_custom_target(
     -DCPULLVMToolchain_VERSION=${CPULLVMToolchain_VERSION}
     -DCPULLVMToolchain_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
     -Dllvmproject_src_dir=${llvmproject_src_dir}
+    -Deld_SOURCE_DIR=${eld_SOURCE_DIR}
+    # at most one of picolibc and musl options is needed, but easiest to
+    # specify both definitions
     -Dpicolibc_SOURCE_DIR=${picolibc_SOURCE_DIR}
     -Dpicolibc_URL=${picolibc_URL}
     # but we do tell the script which library we're actually using
@@ -430,6 +446,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         set(lib_tool_dependencies
             clang
             lld
+            ld.eld
             llvm-ar
             llvm-config
             llvm-nm
@@ -614,6 +631,7 @@ set(third_party_license_files
     ${llvmproject_src_dir}/libunwind/LICENSE.TXT     LIBUNWIND-LICENSE.txt
 )
 
+list(APPEND third_party_license_files ${eld_SOURCE_DIR}/LICENSE eld-LICENSE.txt)
 list(APPEND third_party_license_files
     ${CMAKE_CURRENT_LIST_DIR}/ATfE-LICENSE.txt ATfE-LICENSE.txt
 )

--- a/qualcomm-software/embedded/cmake/THIRD-PARTY-LICENSES.txt.in
+++ b/qualcomm-software/embedded/cmake/THIRD-PARTY-LICENSES.txt.in
@@ -8,6 +8,7 @@ additional or alternate licenses:
  - libc++abi: third-party-licenses/LIBCXXABI-LICENSE.txt
  - libunwind: third-party-licenses/LIBUNWIND-LICENSE.txt
  - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc
+ - eld: third-party-licenses/eld-LICENSE.txt
  - Arm Toolchain for Embedded: third-party-licenses/ATfE-LICENSE.txt
 
 Picolibc licenses refer to its source files. Sources are identified in VERSION.txt.

--- a/qualcomm-software/embedded/cmake/VERSION.txt.in
+++ b/qualcomm-software/embedded/cmake/VERSION.txt.in
@@ -2,4 +2,5 @@ CPULLVM Toolchain ${cpullvm_VERSION}
 
 Sources:
 * cpullvm: https://github.com/qualcomm/cpullvm-toolchain (commit ${cpullvm_COMMIT})
+* eld: https://github.com/qualcomm/eld (commit ${eld_COMMIT})
 * ${LLVM_TOOLCHAIN_C_LIBRARY}: ${LLVM_TOOLCHAIN_C_LIBRARY_URL} (commit ${LLVM_TOOLCHAIN_C_LIBRARY_COMMIT})

--- a/qualcomm-software/embedded/cmake/fetch_eld.cmake
+++ b/qualcomm-software/embedded/cmake/fetch_eld.cmake
@@ -1,0 +1,28 @@
+# To avoid duplicating the FetchContent code, this file can be
+# included by either the top-level toolchain cmake, or the
+# embedded-runtimes sub-project.
+# FETCHCONTENT_SOURCE_DIR_ELD should be passed down from the
+# top level to any library builss to prevent repeated checkouts.
+
+include(FetchContent)
+include(${CMAKE_CURRENT_LIST_DIR}/patch_repo.cmake)
+
+if(NOT VERSIONS_JSON)
+    include(${CMAKE_CURRENT_LIST_DIR}/read_versions.cmake)
+endif()
+read_repo_version(eld eld)
+get_patch_command(${CMAKE_CURRENT_LIST_DIR}/.. eld eld_patch_command)
+
+FetchContent_Declare(eld
+    GIT_REPOSITORY "${eld_URL}"
+    GIT_TAG "${eld_TAG}"
+    GIT_SHALLOW "${eld_SHALLOW}"
+    GIT_PROGRESS TRUE
+    PATCH_COMMAND ${eld_patch_command}
+    # We only want to download the content, not configure it at this
+    # stage. eld will be built as part of LLVM using the sources checked
+    # out here.
+    SOURCE_SUBDIR do_not_add_eld_subdir
+)
+FetchContent_MakeAvailable(eld)
+FetchContent_GetProperties(eld SOURCE_DIR FETCHCONTENT_SOURCE_DIR_ELD)

--- a/qualcomm-software/embedded/cmake/generate_version_txt.cmake
+++ b/qualcomm-software/embedded/cmake/generate_version_txt.cmake
@@ -17,6 +17,13 @@ if(NOT ${cpullvm_COMMIT} MATCHES "^[a-f0-9]+$")
     )
 endif()
 
+execute_process(
+    COMMAND git -C ${eld_SOURCE_DIR} rev-parse HEAD
+    OUTPUT_VARIABLE eld_COMMIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY
+)
+
 # Supported libcs are all in a separate repo
 set(base_library ${LLVM_TOOLCHAIN_C_LIBRARY})
 

--- a/qualcomm-software/embedded/embedded-runtimes/meson-cross-build.txt.in
+++ b/qualcomm-software/embedded/embedded-runtimes/meson-cross-build.txt.in
@@ -1,8 +1,8 @@
 [binaries]
 c = [@picolibc_meson_flags@, '-nostdlib']
 cpp = [@picolibcpp_meson_flags@, '-nostdlib']
-c_ld = 'lld'
-cpp_ld = 'lld'
+c_ld = 'eld'
+cpp_ld = 'eld'
 ar = '@LLVM_BINARY_DIR@/bin/llvm-ar@CMAKE_EXECUTABLE_SUFFIX@'
 strip = '@LLVM_BINARY_DIR@/bin/llvm-strip@CMAKE_EXECUTABLE_SUFFIX@'
 # only needed to run tests

--- a/qualcomm-software/embedded/patches/eld/0001-Create-symlinks-via-llvm_add_tool_symlink-llvm_insta.patch
+++ b/qualcomm-software/embedded/patches/eld/0001-Create-symlinks-via-llvm_add_tool_symlink-llvm_insta.patch
@@ -1,0 +1,252 @@
+From 238c4c7053f6d7c2f12124c429db4bd9081d3e00 Mon Sep 17 00:00:00 2001
+From: Jonathon Penix <jpenix@quicinc.com>
+Date: Sun, 25 Jan 2026 14:15:14 -0800
+Subject: [PATCH 1/3] Create symlinks via
+ `llvm_add_tool_symlink`/`llvm_install_symlink`
+
+eld's symlink creation currently has a few issues/quirks in how it
+interacts with CPack and where symlinks are placed in builds [1][2].
+
+I think the easiest way to fix these issues is just to leverage LLVM's
+cmake utilities `llvm_add_tool_symlink` and `llvm_install_symlink`. Also,
+I think there's a few other advantages:
+- The end result (created symlinks or copied/renamed binaries) should be the
+  same as before while allowing us to simplify eld's cmake. We are already
+  tightly coupled to LLVM/LLVM's cmake anyway
+- eld should behave a bit more consistently to other LLVM tools now--for
+  example, if someone does want to force symlinks on Windows in LLVM, eld
+  will do the same
+
+The one (maybe negative, intended) functional change here is that the symlinks
+now won't have their own targets. But:
+- It isn't clear to me how helpful it is to have per-symlink targets
+  (any/all symlinks will be built/installed with ld.eld)
+- This should be similar to how ex: lld's symlinks work
+- Worst case, I think we can add them back without reverting any of this if
+  needed
+So, I omitted them for now.
+
+[1] https://github.com/qualcomm/eld/issues/737
+[2] https://github.com/qualcomm/eld/issues/710
+
+Signed-off-by: Jonathon Penix <jpenix@quicinc.com>
+---
+ CMakeLists.txt                   | 10 ++---
+ lib/LinkerWrapper/CMakeLists.txt |  2 +-
+ tools/eld/CMakeLists.txt         | 68 +++++++-------------------------
+ tools/eld/eld_install.cmake.in   |  7 ----
+ tools/eld/ld_eld_symlink.cmake   | 52 ------------------------
+ 5 files changed, 20 insertions(+), 119 deletions(-)
+ delete mode 100644 tools/eld/eld_install.cmake.in
+ delete mode 100644 tools/eld/ld_eld_symlink.cmake
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c253e9e6..c1287f20 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,6 +9,11 @@ set(ELD_BINARY_DIR
+     ${CMAKE_CURRENT_BINARY_DIR}
+     CACHE STRING "")
+ 
++# Most users probably don't want/need to change this, but it is referenced
++# by `llvm_install_symlink` (and other llvm cmake utilities).
++set(ELD_TOOLS_INSTALL_DIR "bin" CACHE PATH "Path for binary subdirectory (defaults to 'bin')")
++mark_as_advanced(ELD_TOOLS_INSTALL_DIR)
++
+ list(APPEND CMAKE_MODULE_PATH "${ELD_SOURCE_DIR}/cmake/modules")
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+ 
+@@ -61,11 +66,6 @@ set(ELD_DEFAULT_TARGET_TRIPLE
+     "${LLVM_DEFAULT_TARGET_TRIPLE}"
+     CACHE STRING "Default target for which LLVM will generate code.")
+ 
+-# ##############################################################################
+-# ELD_RUNTIME_OUTPUT_DIR is needed since CMAKE_RUNTIME_OUTPUT_DIRECTORY appends
+-# config type by default.
+-set(ELD_RUNTIME_OUTPUT_DIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin)
+-
+ # These two variables are for runnable lit tests and should be set to the
+ # 32/64-bit emulators used to run the tests.
+ set(ELD_EMULATOR "")
+diff --git a/lib/LinkerWrapper/CMakeLists.txt b/lib/LinkerWrapper/CMakeLists.txt
+index af0e7a84..87ea4603 100644
+--- a/lib/LinkerWrapper/CMakeLists.txt
++++ b/lib/LinkerWrapper/CMakeLists.txt
+@@ -109,7 +109,7 @@ endforeach()
+ # library is one of the dependent libraries of the linker.
+ if(ELD_ON_MSVC)
+   install(TARGETS LW
+-    RUNTIME DESTINATION bin
++    RUNTIME DESTINATION "${ELD_TOOLS_INSTALL_DIR}"
+     ARCHIVE DESTINATION lib)
+ else()
+   install(TARGETS LW LIBRARY DESTINATION lib)
+diff --git a/tools/eld/CMakeLists.txt b/tools/eld/CMakeLists.txt
+index 208918af..7e39b406 100644
+--- a/tools/eld/CMakeLists.txt
++++ b/tools/eld/CMakeLists.txt
+@@ -3,6 +3,11 @@ option(
+   "Enable this option to create <target>-link symlinks in the bin folder of both the build and install directories."
+   On)
+ 
++macro(add_eld_symlink name dest)
++  llvm_add_tool_symlink(ELD ${name} ${dest} ALWAYS_GENERATE)
++  llvm_install_symlink(ELD ${name} ${dest} ALWAYS_GENERATE)
++endmacro()
++
+ set(LLVM_LINK_COMPONENTS ${LLVM_TARGETS_TO_BUILD} irreader Support)
+ 
+ add_llvm_executable(ld.eld eld.cpp)
+@@ -11,24 +16,7 @@ add_dependencies(ld.eld update-eld-verinfo)
+ set(LINKER_WRAPPER_LIB "LW")
+ target_link_libraries(ld.eld PRIVATE ${LINKER_WRAPPER_LIB})
+ 
+-if(UNIX)
+-  set(LD_ELD_LINK_OR_COPY create_symlink)
+-  set(ld_eld_binary "ld.eld${CMAKE_EXECUTABLE_SUFFIX}")
+-else()
+-  set(LD_ELD_LINK_OR_COPY copy)
+-  set(ld_eld_binary
+-      "${ELD_RUNTIME_OUTPUT_DIR}/ld.eld${CMAKE_EXECUTABLE_SUFFIX}")
+-endif()
+-
+-# This is to support "install/local" from eld build directory
+-configure_file(eld_install.cmake.in
+-               ${CMAKE_CURRENT_BINARY_DIR}/eld_install.cmake)
+-
+-# We can either reconfigure or copy the same file. This is to support "install"
+-# from top level llvm build directory
+-configure_file(eld_install.cmake.in ${CMAKE_BINARY_DIR}/eld_install.cmake)
+-
+-install(TARGETS ld.eld RUNTIME DESTINATION bin)
++install(TARGETS ld.eld RUNTIME DESTINATION "${ELD_TOOLS_INSTALL_DIR}")
+ 
+ # FIXME: We need to switch to ELD_TARGETS_TO_BUILD after the buildbot upgrade
+ if("${LLVM_TARGETS_TO_BUILD}" MATCHES "Hexagon" AND "${TARGET_TRIPLE}" MATCHES
+@@ -39,44 +27,16 @@ if(ELD_CREATE_SYMLINKS)
+   foreach(target_name ${LLVM_TARGETS_TO_BUILD})
+     string(TOLOWER ${target_name} ld_eld_name)
+     if(${is_hexagon_linux})
+-      set(ld_eld_name "${ld_eld_name}-linux-link${CMAKE_EXECUTABLE_SUFFIX}")
++      set(ld_eld_name "${ld_eld_name}-linux-link")
+     else(NOT ${is_hexagon_linux})
+-      set(ld_eld_name "${ld_eld_name}-link${CMAKE_EXECUTABLE_SUFFIX}")
+-    endif(${is_hexagon_linux})
++      set(ld_eld_name "${ld_eld_name}-link")
++    endif()
+     if(${target_name} MATCHES "X86")
+-      set(ld_eld_name "x86_64-link${CMAKE_EXECUTABLE_SUFFIX}")
++      set(ld_eld_name "x86_64-link")
+     endif()
+-    add_custom_command(
+-      TARGET ld.eld
+-      POST_BUILD
+-      COMMAND ${CMAKE_COMMAND} -E ${LD_ELD_LINK_OR_COPY} "${ld_eld_binary}"
+-              "${ld_eld_name}"
+-      WORKING_DIRECTORY "${ELD_RUNTIME_OUTPUT_DIR}")
+-
+-    add_custom_target(
+-      ${ld_eld_name}
+-      DEPENDS ${ld_eld_binary}
+-      COMMAND ${CMAKE_COMMAND} -E ${LD_ELD_LINK_OR_COPY} "${ld_eld_binary}"
+-              "${ld_eld_name}"
+-      WORKING_DIRECTORY "${ELD_RUNTIME_OUTPUT_DIR}")
+-  endforeach(target_name)
++    add_eld_symlink("${ld_eld_name}" ld.eld)
++  endforeach()
+ endif()
+-if(DEFINED USE_LINKER_ALT_NAME)
+-  if(NOT "${USE_LINKER_ALT_NAME}" STREQUAL "")
+-    add_custom_command(
+-      TARGET ld.eld
+-      POST_BUILD
+-      COMMAND ${CMAKE_COMMAND} -E ${LD_ELD_LINK_OR_COPY} "${ld_eld_binary}"
+-              "${USE_LINKER_ALT_NAME}"
+-      WORKING_DIRECTORY "${ELD_RUNTIME_OUTPUT_DIR}")
+-    add_custom_target(
+-      ${USE_LINKER_ALT_NAME}
+-      DEPENDS ${ld_eld_binary}
+-      COMMAND ${CMAKE_COMMAND} -E ${LD_ELD_LINK_OR_COPY} "${ld_eld_binary}"
+-              "${USE_LINKER_ALT_NAME}"
+-      WORKING_DIRECTORY "${ELD_RUNTIME_OUTPUT_DIR}")
+-  endif()
++if(NOT "${USE_LINKER_ALT_NAME}" STREQUAL "")
++  add_eld_symlink("${USE_LINKER_ALT_NAME}" ld.eld)
+ endif()
+-
+-# Create the symlink at installation time.
+-install(SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/ld_eld_symlink.cmake)
+diff --git a/tools/eld/eld_install.cmake.in b/tools/eld/eld_install.cmake.in
+deleted file mode 100644
+index a50ce822..00000000
+--- a/tools/eld/eld_install.cmake.in
++++ /dev/null
+@@ -1,7 +0,0 @@
+-# install.cmake.in corresponding to install.cmake. The list of targets passed
+-# are used by installer to figure out the *-link shortcuts/copies for ld.eld
+-
+-set(LINK_TARGETS @LLVM_TARGETS_TO_BUILD@)
+-set(USE_LINKER_ALT_NAME @USE_LINKER_ALT_NAME@)
+-set(TARGET_TRIPLE @TARGET_TRIPLE@)
+-set(ELD_CREATE_SYMLINKS @ELD_CREATE_SYMLINKS@)
+diff --git a/tools/eld/ld_eld_symlink.cmake b/tools/eld/ld_eld_symlink.cmake
+deleted file mode 100644
+index 379481de..00000000
+--- a/tools/eld/ld_eld_symlink.cmake
++++ /dev/null
+@@ -1,52 +0,0 @@
+-# CMAKE_BINARY_DIR is context dependent
+-if(EXISTS ${CMAKE_BINARY_DIR}/eld_install.cmake)
+-  include(${CMAKE_BINARY_DIR}/eld_install.cmake)
+-else()
+-  include(${CMAKE_BINARY_DIR}/tools/eld/eld_install.cmake)
+-endif()
+-
+-if(UNIX)
+-  set(LD_ELD_LINK_OR_COPY create_symlink)
+-  set(LD_ELD_DESTDIR $ENV{DESTDIR})
+-else()
+-  set(LD_ELD_LINK_OR_COPY copy)
+-endif()
+-
+-# CMAKE_EXECUTABLE_SUFFIX is undefined on cmake scripts. See PR9286.
+-if(WIN32)
+-  set(EXECUTABLE_SUFFIX ".exe")
+-else()
+-  set(EXECUTABLE_SUFFIX "")
+-endif()
+-
+-set(bindir "${CMAKE_INSTALL_PREFIX}/bin/")
+-set(ld_eld "ld.eld${EXECUTABLE_SUFFIX}")
+-
+-if("${LINK_TARGETS}" MATCHES "Hexagon" AND "${TARGET_TRIPLE}" MATCHES
+-                                           "hexagon-unknown-linux")
+-  set(is_hexagon_linux 1)
+-endif()
+-
+-# Create symlinks at install only if ELD_CREATE_SYMLINKS is ON
+-if (ELD_CREATE_SYMLINKS)
+-  foreach(target_name ${LINK_TARGETS})
+-    string(TOLOWER ${target_name} ld_eld_name)
+-    if(${is_hexagon_linux})
+-      set(ld_eld_symlink "${ld_eld_name}-linux-link${EXECUTABLE_SUFFIX}")
+-    else(NOT ${is_hexagon_linux})
+-      set(ld_eld_symlink "${ld_eld_name}-link${EXECUTABLE_SUFFIX}")
+-    endif(${is_hexagon_linux})
+-
+-    message("Creating ${ld_eld_symlink} symlink based on ${ld_eld}")
+-    execute_process(
+-      COMMAND "${CMAKE_COMMAND}" -E ${LD_ELD_LINK_OR_COPY} "${ld_eld}"
+-              "${ld_eld_symlink}" WORKING_DIRECTORY "${bindir}")
+-  endforeach(target_name)
+-endif()
+-
+-if(NOT "${USE_LINKER_ALT_NAME}" STREQUAL "")
+-  message("Creating ${USE_LINKER_ALT_NAME} symlink based on ${ld_eld}")
+-  execute_process(
+-    COMMAND "${CMAKE_COMMAND}" -E ${LD_ELD_LINK_OR_COPY} "${ld_eld}"
+-            "${USE_LINKER_ALT_NAME}" WORKING_DIRECTORY "${bindir}")
+-endif()
+-- 
+2.43.0
+

--- a/qualcomm-software/embedded/patches/eld/0002-Add-basic-LLVM_DISTRIBUTION_COMPONENTS-compatibility.patch
+++ b/qualcomm-software/embedded/patches/eld/0002-Add-basic-LLVM_DISTRIBUTION_COMPONENTS-compatibility.patch
@@ -1,0 +1,122 @@
+From 034d25fd3d45d892aa47c5e11beb172ec52e3a2e Mon Sep 17 00:00:00 2001
+From: Jonathon Penix <jpenix@quicinc.com>
+Date: Tue, 6 Jan 2026 18:59:15 -0800
+Subject: [PATCH 2/3] Add basic LLVM_DISTRIBUTION_COMPONENTS compatibility
+
+LLVM_DISTRIBUTION_COMPONENTS seems to require that each component have
+a) install-* and install-*-stripped targets and b) a component associated with
+the things to install.
+
+So, there's a few separate changes made to add this support into eld:
+- For each of the components we want to support, `add_llvm_install_targets`
+  is used to create the install* and install-*-stripped targets. I think this
+  is the easiest (and a recommended) way to do this.
+- I think eld has five components we need to handle: ld.eld, LW,
+  PluginAPIHeaders, linker-script (templates), and YAMLMapParser. Each
+  of these had the appropriate install targets and components added, as
+  needed. Hopefully I'm not missing any additional components we need to
+  consider for distributions.
+
+  It might make sense to more aggressively couple some of these, but I
+  think the granularity here matches pretty well with available CMake
+  options (to ex: disable the YAMLMapParser) and current toolchains with
+  eld included (where the PluginAPIHeaders, templates, etc. may be stripped
+  out). So, I left this as-is.
+- A dependency was added between the ld.eld and LW install targets--without
+  these ld.eld would always fail at runtime about the missing LW library, if
+  only ex: `ninja install-ld.eld` was run. Which, doesn't seem that helpful.
+  So, make ld.eld's install depend on LW's.
+
+Expected usage looks something like:
+
+`-DLLVM_DISTRIBUTION_COMPONENTS='...;ld.eld;LW;PluginAPIHeaders;linker-script;YAMLMapParser'`
+
+and these items can generally be added/removed based on what people want in
+the distribution (modulo ld.eld's dependency on LW).
+
+And, as per the install-* target requirement mentioned above, each of
+these components can now be individually installed with ex: install-ld.eld.
+
+Fixes #693
+
+Signed-off-by: Jonathon Penix <jpenix@quicinc.com>
+---
+ CMakeLists.txt             | 17 ++++++++++++++++-
+ include/eld/CMakeLists.txt |  8 ++++++++
+ tools/eld/CMakeLists.txt   | 10 +++++++++-
+ 3 files changed, 33 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c1287f20..cec116e6 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -212,6 +212,13 @@ install(
+   PATTERN "*.template"
+   PATTERN ".git" EXCLUDE
+   PATTERN ".svn" EXCLUDE)
++if (NOT LLVM_ENABLE_IDE)
++  # LLVM_DISTRIBUTION_COMPONENTS requires that each component have both a
++  # component and an install-component target, so add appropriate dummy targets.
++  add_custom_target(linker-script)
++  add_llvm_install_targets(install-linker-script
++                           COMPONENT linker-script)
++endif()
+ 
+ set(ELD_INSTALL_YAML_MAP_PARSER
+     ON
+@@ -224,5 +231,13 @@ if(ELD_INSTALL_YAML_MAP_PARSER)
+     set(ELD_YAML_MAP_PARSER_DEST_DIR "bin")
+   endif()
+   install(PROGRAMS utils/YAMLMapParser/YAMLMapParser.py
+-          DESTINATION ${ELD_YAML_MAP_PARSER_DEST_DIR})
++          DESTINATION ${ELD_YAML_MAP_PARSER_DEST_DIR}
++          COMPONENT YAMLMapParser)
++  if (NOT LLVM_ENABLE_IDE)
++    # LLVM_DISTRIBUTION_COMPONENTS requires that each component have both a
++    # component and an install-component target, so add appropriate dummy targets.
++    add_custom_target(YAMLMapParser)
++    add_llvm_install_targets(install-YAMLMapParser
++                             COMPONENT YAMLMapParser)
++  endif()
+ endif()
+diff --git a/include/eld/CMakeLists.txt b/include/eld/CMakeLists.txt
+index f3c69b44..320889ac 100644
+--- a/include/eld/CMakeLists.txt
++++ b/include/eld/CMakeLists.txt
+@@ -21,4 +21,12 @@ if(ENABLE_ELD_PLUGIN_SUPPORT)
+       DESTINATION include/ELD/PluginAPI/
+       COMPONENT PluginAPIHeaders)
+   endif()
++
++  if (NOT LLVM_ENABLE_IDE)
++    # LLVM_DISTRIBUTION_COMPONENTS requires that each component have both a
++    # component and an install-component target, so add appropriate dummy targets.
++    add_custom_target(PluginAPIHeaders)
++    add_llvm_install_targets(install-PluginAPIHeaders
++                             COMPONENT PluginAPIHeaders)
++  endif()
+ endif()
+diff --git a/tools/eld/CMakeLists.txt b/tools/eld/CMakeLists.txt
+index 7e39b406..8f6f86b9 100644
+--- a/tools/eld/CMakeLists.txt
++++ b/tools/eld/CMakeLists.txt
+@@ -16,7 +16,15 @@ add_dependencies(ld.eld update-eld-verinfo)
+ set(LINKER_WRAPPER_LIB "LW")
+ target_link_libraries(ld.eld PRIVATE ${LINKER_WRAPPER_LIB})
+ 
+-install(TARGETS ld.eld RUNTIME DESTINATION "${ELD_TOOLS_INSTALL_DIR}")
++install(TARGETS ld.eld RUNTIME DESTINATION "${ELD_TOOLS_INSTALL_DIR}" COMPONENT ld.eld)
++if (NOT LLVM_ENABLE_IDE)
++  add_llvm_install_targets(install-ld.eld
++                           DEPENDS ld.eld
++                           COMPONENT ld.eld)
++  add_dependencies(install-ld.eld install-${LINKER_WRAPPER_LIB})
++  add_dependencies(install-ld.eld-stripped
++                   install-${LINKER_WRAPPER_LIB}-stripped)
++endif()
+ 
+ # FIXME: We need to switch to ELD_TARGETS_TO_BUILD after the buildbot upgrade
+ if("${LLVM_TARGETS_TO_BUILD}" MATCHES "Hexagon" AND "${TARGET_TRIPLE}" MATCHES
+-- 
+2.43.0
+

--- a/qualcomm-software/embedded/patches/eld/0003-Place-ELDExpectedUsage-in-LLVM_BINARY_DIR-relative-l.patch
+++ b/qualcomm-software/embedded/patches/eld/0003-Place-ELDExpectedUsage-in-LLVM_BINARY_DIR-relative-l.patch
@@ -1,0 +1,42 @@
+From 92ea1b21404d45209bf2bb0756ccc42105eec1ce Mon Sep 17 00:00:00 2001
+From: Jonathon Penix <jpenix@quicinc.com>
+Date: Sun, 25 Jan 2026 15:24:27 -0800
+Subject: [PATCH 3/3] Place ELDExpectedUsage in `LLVM_BINARY_DIR`-relative
+ location
+
+ELDExpected.test looks for ELDExpectedUsage in an `%llvmobjroot`-
+relative dir (which IIUC boils down to a `LLVM_BINARY_DIR`-relative dir).
+ELDExpectedUsage is currently installed in a `CMAKE_BINARY_DIR`-relative
+dir. `LLVM_BINARY_DIR` and `CMAKE_BINARY_DIR` aren't always the same--they
+can be different when llvm is added as a subdirectory. When this is the
+case, we see test failures due to the mismatched location--see [1] for
+details.
+
+To fix this, just place ELDExpectedUsage in a `LLVM_BINARY_DIR`-relative
+location as that is what the tests expect and it matches the behavior
+when `LLVM_BINARY_DIR == CMAKE_BINARY_DIR`.
+
+This partially fixes [1], the symlink/wrapper part is handled in [2].
+
+[1] https://github.com/qualcomm/eld/issues/710
+[2] https://github.com/qualcomm/eld/pull/738
+
+Signed-off-by: Jonathon Penix <jpenix@quicinc.com>
+---
+ test/Common/standalone/PluginAPI/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/Common/standalone/PluginAPI/CMakeLists.txt b/test/Common/standalone/PluginAPI/CMakeLists.txt
+index f19ed7e5..b37a6264 100644
+--- a/test/Common/standalone/PluginAPI/CMakeLists.txt
++++ b/test/Common/standalone/PluginAPI/CMakeLists.txt
+@@ -3,5 +3,5 @@ target_include_directories(ELDExpectedUsage
+                            PRIVATE ${CMAKE_SOURCE_DIR}/include/eld/PluginAPI)
+ target_link_libraries(ELDExpectedUsage PRIVATE LW)
+ set_target_properties(ELDExpectedUsage PROPERTIES RUNTIME_OUTPUT_DIRECTORY
+-                                                  ${CMAKE_BINARY_DIR}/bin/tests)
++                                                  ${LLVM_BINARY_DIR}/bin/tests)
+ set_target_properties(ELDExpectedUsage PROPERTIES INSTALL_RPATH "\$ORIGIN/../../lib")
+-- 
+2.43.0
+

--- a/qualcomm-software/embedded/versions.json
+++ b/qualcomm-software/embedded/versions.json
@@ -9,6 +9,11 @@
       "url": "https://github.com/picolibc/picolibc.git",
       "tagType": "tag",
       "tag": "1.8.10"
+    },
+    "eld": {
+      "url": "https://github.com/qualcomm/eld",
+      "tagType": "branch",
+      "tag": "main"
     }
   }
 }


### PR DESCRIPTION
We're adding a few patches here. For each, there are open issues and PRs in
eld--these are included as patches just to unblock further development while
the PRs are finalized. Overview of the patches:
- Currently, eld is missing some of the cmake scaffolding needed for use with
  LLVM_DISTRIBUTION_COMPONENTS. This is tracked in [1].
- A patch is added to fix ELDExpected.test. This is tracked in [2].
- The cmake that installs eld's symlinks breaks under CPack. This is tracked
  in [3].

There's a few other notable things here:
- check-eld will now be run when check-all is run
- I think more work will be needed to make it possible to run ex: compiler-rt
  and libc++ tests with eld. I briefly tried and the first issue seemed to be
  that libraries/dependencies weren't ordered in an eld/bfd-friendly way.
  There might be more issues. Leave this as future work.
- eld isn't integrated with xfails.py. I think this is best as there
  shouldn't be failures for any of our variants (and, IIUC, this is
  analogous to non-clang/compiler-rt/libc/libc++ tests).

[1] https://github.com/qualcomm/eld/issues/693
[2] https://github.com/qualcomm/eld/issues/710
[3] https://github.com/qualcomm/eld/issues/737