### PR TITLE
[cpullvm] Add baseline musl-embedded support, configs

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -54,5 +54,8 @@ jobs:
       - name: Build
         run: ./qualcomm-software/embedded/scripts/build.sh
 
+      - name: Build musl-embedded overlay
+        run: ./qualcomm-software/embedded/scripts/build_musl-embedded_overlay.sh
+
       - name: Test
         run: ./qualcomm-software/embedded/scripts/test.sh

--- a/qualcomm-software/embedded/CMakeLists.txt
+++ b/qualcomm-software/embedded/CMakeLists.txt
@@ -120,7 +120,7 @@ set(LLVM_TOOLCHAIN_C_LIBRARY
     "Which C library to use."
 )
 set_property(CACHE LLVM_TOOLCHAIN_C_LIBRARY
-    PROPERTY STRINGS picolibc)
+    PROPERTY STRINGS picolibc musl-embedded)
 
 option(
     SHORT_BUILD_PATHS
@@ -132,7 +132,7 @@ option(
 
 
 option(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL
-    "Make cpack build an overlay package that can be unpacked over the main toolchain to install a secondary set of libraries."
+    "Make cpack build an overlay package that can be unpacked over the main toolchain to install a secondary set of libraries based on musl-embedded."
     ${overlay_install_default})
 if(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL)
   if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL "picolibc")
@@ -221,10 +221,11 @@ include(ProcessorCount)
 # Check out and patch eld
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_eld.cmake)
 
-# Check out and patch picolibc if required.
+# Check out and patch picolibc or musl-embedded if required.
 #
 # If you'd rather check out and patch manually then run cmake with
 # -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=/path/to/picolibc
+# -DFETCHCONTENT_SOURCE_DIR_MUSL=/path/to/musl
 #
 # By default check out will be silent but this can be changed by running
 # cmake with -DFETCHCONTENT_QUIET=OFF
@@ -233,6 +234,9 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_eld.cmake)
 # cmake . -DFETCHCONTENT_FULLY_DISCONNECTED=ON
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_picolibc.cmake)
+endif()
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_musl-embedded.cmake)
 endif()
 
 ##################################################################################################
@@ -253,6 +257,15 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     )
 endif()
 ##################################################################################################
+
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+    install(
+        FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/${LLVM_TOOLCHAIN_C_LIBRARY}.cfg
+        DESTINATION bin
+        COMPONENT llvm-toolchain-${LLVM_TOOLCHAIN_C_LIBRARY}-configs
+    )
+endif()
 
 # Include eld
 set(LLVM_EXTERNAL_PROJECTS eld)
@@ -391,6 +404,8 @@ add_custom_target(
     # specify both definitions
     -Dpicolibc_SOURCE_DIR=${picolibc_SOURCE_DIR}
     -Dpicolibc_URL=${picolibc_URL}
+    -Dmusl_SOURCE_DIR=${musl_SOURCE_DIR}
+    -Dmusl_URL=${musl_URL}
     # but we do tell the script which library we're actually using
     -DLLVM_TOOLCHAIN_C_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_version_txt.cmake
@@ -514,6 +529,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         -DPARALLEL_LIB_BUILD_LEVELS=${PARALLEL_LIB_BUILD_LEVELS}
         -DENABLE_QEMU_TESTING=${ENABLE_QEMU_TESTING}
         -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}
+        -DFETCHCONTENT_SOURCE_DIR_MUSL=${FETCHCONTENT_SOURCE_DIR_MUSL}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         -DPROJECT_PREFIX=${multilib_prefix}
         -DNUMERICAL_BUILD_NAMES=${SHORT_BUILD_PATHS}
@@ -640,6 +656,10 @@ if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
     list(APPEND third_party_license_files
         ${picolibc_SOURCE_DIR}/COPYING.NEWLIB           COPYING.NEWLIB
         ${picolibc_SOURCE_DIR}/COPYING.picolibc         COPYING.picolibc
+    )
+elseif(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+    list(APPEND third_party_license_files
+        ${musl_SOURCE_DIR}/COPYRIGHT musl-embedded-COPYRIGHT.txt
     )
 endif()
 

--- a/qualcomm-software/embedded/cmake/THIRD-PARTY-LICENSES.txt.in
+++ b/qualcomm-software/embedded/cmake/THIRD-PARTY-LICENSES.txt.in
@@ -9,6 +9,7 @@ additional or alternate licenses:
  - libunwind: third-party-licenses/LIBUNWIND-LICENSE.txt
  - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc
  - eld: third-party-licenses/eld-LICENSE.txt
+ - musl-embedded: third-party-licenses/musl-embedded-COPYRIGHT.txt
  - Arm Toolchain for Embedded: third-party-licenses/ATfE-LICENSE.txt
 
 Picolibc licenses refer to its source files. Sources are identified in VERSION.txt.

--- a/qualcomm-software/embedded/cmake/fetch_musl-embedded.cmake
+++ b/qualcomm-software/embedded/cmake/fetch_musl-embedded.cmake
@@ -1,0 +1,28 @@
+# To avoid duplicating the FetchContent code, this file can be
+# included by either the top-level toolchain cmake, or the
+# embedded-runtimes sub-project.
+# FETCHCONTENT_SOURCE_DIR_MUSL should be passed down from the
+# top level to any library builds to prevent repeated checkouts.
+
+include(FetchContent)
+include(${CMAKE_CURRENT_LIST_DIR}/patch_repo.cmake)
+
+if(NOT VERSIONS_JSON)
+    include(${CMAKE_CURRENT_LIST_DIR}/read_versions.cmake)
+endif()
+read_repo_version(musl musl-embedded)
+get_patch_command(${CMAKE_CURRENT_LIST_DIR}/.. musl-embedded musl_patch_command)
+
+FetchContent_Declare(musl
+    GIT_REPOSITORY "${musl_URL}"
+    GIT_TAG "${musl_TAG}"
+    GIT_SHALLOW "${musl_SHALLOW}"
+    GIT_PROGRESS TRUE
+    PATCH_COMMAND ${musl_patch_command}
+    # We only want to download the content, not configure it at this
+    # stage. musl-embedded will be built in many configurations using
+    # ExternalProject_Add using the sources that are checked out here.
+    SOURCE_SUBDIR do_not_add_musl_subdir
+)
+FetchContent_MakeAvailable(musl)
+FetchContent_GetProperties(musl SOURCE_DIR FETCHCONTENT_SOURCE_DIR_MUSL)

--- a/qualcomm-software/embedded/cmake/generate_version_txt.cmake
+++ b/qualcomm-software/embedded/cmake/generate_version_txt.cmake
@@ -25,7 +25,11 @@ execute_process(
 )
 
 # Supported libcs are all in a separate repo
-set(base_library ${LLVM_TOOLCHAIN_C_LIBRARY})
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+    set(base_library musl)
+else()
+    set(base_library ${LLVM_TOOLCHAIN_C_LIBRARY})
+endif()
 
 execute_process(
     COMMAND git -C ${${base_library}_SOURCE_DIR} rev-parse HEAD

--- a/qualcomm-software/embedded/embedded-multilib/CMakeLists.txt
+++ b/qualcomm-software/embedded/embedded-multilib/CMakeLists.txt
@@ -27,7 +27,7 @@ set(llvmproject_src_dir ${TOOLCHAIN_SOURCE_DIR}/../..)
 set(MULTILIB_JSON "" CACHE STRING "JSON file to load library definitions from.")
 set(ENABLE_VARIANTS "all" CACHE STRING "Semicolon separated list of variants to build, or \"all\". Must match entries in the json.")
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
-set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc)
+set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc musl-embedded)
 set(PROJECT_PREFIX "${CMAKE_BINARY_DIR}/lib-builds" CACHE STRING "Directory to build subprojects in.")
 option(
     NUMERICAL_BUILD_NAMES
@@ -85,6 +85,9 @@ include(ExternalProject)
 if(C_LIBRARY STREQUAL picolibc)
     include(${TOOLCHAIN_SOURCE_DIR}/cmake/fetch_picolibc.cmake)
     list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}")
+elseif(C_LIBRARY STREQUAL musl-embedded)
+    include(${TOOLCHAIN_SOURCE_DIR}/cmake/fetch_musl-embedded.cmake)
+    list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_MUSL=${FETCHCONTENT_SOURCE_DIR_MUSL}")
 endif()
 
 # Target for any dependencies to build the runtimes project.

--- a/qualcomm-software/embedded/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/multilib.json
@@ -4,6 +4,30 @@
             "variant": "aarch64a",
             "json": "aarch64a.json",
             "flags": "--target=aarch64-unknown-none-elf -fno-exceptions"
+        },
+        {
+            "variant": "aarch64a_soft_nofp",
+            "json": "aarch64a_soft_nofp.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -fno-exceptions",
+            "libraries_supported": "musl-embedded"
+        },
+        {
+            "variant": "aarch64a_soft_nofp_pacret_bti",
+            "json": "aarch64a_soft_nofp_pacret_bti.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions",
+            "libraries_supported": "musl-embedded"
+        },
+        {
+            "variant": "aarch64a_pacret_bkey_bti",
+            "json": "aarch64a_pacret_bkey_bti.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti -fno-exceptions",
+            "libraries_supported": "musl-embedded"
+        },
+        {
+            "variant": "armv7a_soft_neon",
+            "json": "armv7a_soft_neon.json",
+            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=neon -fno-exceptions",
+            "libraries_supported": "musl-embedded"
         }
     ]
 }

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
@@ -2,8 +2,8 @@
     "args": {
         "common": {
             "TARGET_ARCH": "aarch64a",
-            "VARIANT": "aarch64a",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "VARIANT": "aarch64a_pacret_bkey_bti",
+            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "qemu",
@@ -14,12 +14,6 @@
             "RAM_ADDRESS": "0x40400000",
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
-        },
-        "picolibc": {
-            "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp.json
@@ -2,8 +2,8 @@
     "args": {
         "common": {
             "TARGET_ARCH": "aarch64a",
-            "VARIANT": "aarch64a",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "VARIANT": "aarch64a_soft_nofp",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "qemu",
@@ -15,18 +15,13 @@
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
-        "picolibc": {
-            "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
-        },
         "musl-embedded": {
-            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_CXX_LIBS": "OFF",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL_CFLAGS": "-mstrict-align -D__QUIC_ENABLE_FLT_FOR_PRINT"
+            "EXTRA_MUSL_CONFIG_FLAGS": "--quic-aarch64-nofp",
+            "EXTRA_MUSL_CFLAGS": "-mstrict-align"
         }
     }
 }

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
@@ -2,8 +2,8 @@
     "args": {
         "common": {
             "TARGET_ARCH": "aarch64a",
-            "VARIANT": "aarch64a",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "VARIANT": "aarch64a_soft_nofp_pacret_bti",
+            "COMPILE_FLAGS": "-march=armv8.3a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "qemu",
@@ -15,18 +15,13 @@
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
-        "picolibc": {
-            "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
-        },
         "musl-embedded": {
-            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_CXX_LIBS": "OFF",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL_CFLAGS": "-mstrict-align -D__QUIC_ENABLE_FLT_FOR_PRINT"
+            "EXTRA_MUSL_CONFIG_FLAGS": "--quic-aarch64-nofp",
+            "EXTRA_MUSL_CFLAGS": "-mstrict-align"
         }
     }
 }

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/armv7a_soft_neon.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/armv7a_soft_neon.json
@@ -1,0 +1,27 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv7a",
+            "VARIANT": "armv7a_soft_neon",
+            "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7a -mthumb -mfpu=neon -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "none",
+            "QEMU_CPU": "cortex-a7",
+            "QEMU_PARAMS": "-m 1G",
+            "FLASH_ADDRESS": "0x00000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x20000000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "musl-embedded": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "EXTRA_MUSL_CFLAGS": "-mno-unaligned-access"
+        }
+    }
+}

--- a/qualcomm-software/embedded/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded/embedded-runtimes/CMakeLists.txt
@@ -25,7 +25,7 @@ set(llvmproject_src_dir ${TOOLCHAIN_SOURCE_DIR}/../..)
 # CMake arguments are loaded from the JSON file depending on which C
 # library is used, so this must be set before the JSON is processed.
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
-set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc)
+set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc musl-embedded)
 
 set(VARIANT_JSON "" CACHE STRING "JSON file to load args from.")
 if(VARIANT_JSON)
@@ -85,6 +85,13 @@ set(ENABLE_LIBC_TESTS ${ENABLE_LIBC_TESTS_def} CACHE BOOL "Enable libc tests (pi
 set(ENABLE_COMPILER_RT_TESTS ${ENABLE_COMPILER_RT_TESTS_def} CACHE BOOL "Enable compiler-rt tests.")
 set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tests.")
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
+
+# Set up a few arbitrary pass-through flags for MUSL. This probably isn't the best idea,
+# but historically, our flag usage is such that it is a bit unclear how to do this in
+# a more princicpled way. This should be revisited and probably clean up, but for now
+# just mirror what we used to do.
+set(EXTRA_MUSL_CONFIG_FLAGS ${EXTRA_MUSL_CONFIG_FLAGS_def} CACHE BOOL "Extra configure options for musl-embedded.")
+set(EXTRA_MUSL_CFLAGS ${EXTRA_MUSL_CFLAGS_def} CACHE BOOL "Extra flags to be used when compiling musl-embedded.")
 
 set(PROJECT_PREFIX "subproj" CACHE STRING "Directory to build subprojects in.")
 set(VARIANT_BUILD_ID "${VARIANT}" CACHE STRING "Name to use to identify build directories." )
@@ -509,6 +516,72 @@ if(C_LIBRARY STREQUAL picolibc)
 
 endif()
 
+###############################################################################
+# musl-embedded
+###############################################################################
+if(C_LIBRARY STREQUAL musl-embedded)
+    if(ENABLE_LIBC_TESTS)
+        message(FATAL_ERROR "Tests cannot be enabled using musl-embedded.")
+    endif()
+
+    if(WIN32)
+        message(FATAL_ERROR "Building MUSL is not supported on Windows hosts")
+    endif()
+
+    include(${TOOLCHAIN_SOURCE_DIR}/cmake/fetch_musl-embedded.cmake)
+
+    include(ProcessorCount)
+    set(make_flags)
+    ProcessorCount(nproc)
+    if(NOT nproc EQUAL 0)
+        set(make_flags -j${nproc})
+    endif()
+
+    if(LIBRARY_BUILD_TYPE STREQUAL minsizerelease)
+        set(musl_opt_flags "-Os")
+    elseif((LIBRARY_BUILD_TYPE STREQUAL release) OR (LIBRARY_BUILD_TYPE STREQUAL releasewithdebuginfo))
+        set(musl_opt_flags "-O3")
+    endif()
+
+    # FIXME: if we need the extra `uselocks`/`standalone` variants, we
+    # can add a passthrough here and make them separate variants.
+    set(musl_embedded_flags
+        --disable-wrapper
+        --quic-arm-baremetal
+        --disable-visibility
+        ${EXTRA_MUSL_CONFIG_FLAGS}
+        "CROSS_COMPILE=${LLVM_BINARY_DIR}/bin/llvm-"
+        "CC=${LLVM_BINARY_DIR}/bin/clang --target=${target_triple} -fuse-ld=eld"
+        "CFLAGS=${lib_compile_flags} ${musl_opt_flags} -fPIC -fvisibility=hidden -DVISIBILITY_HIDDEN -fno-rounding-math ${EXTRA_MUSL_CFLAGS}"
+        "LIBCC=${TEMP_LIB_DIR}/libclang_rt.builtins.a")
+
+    ExternalProject_Add(
+        ${C_LIBRARY}
+        STAMP_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/stamp
+        BINARY_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/build
+        DOWNLOAD_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/dl
+        TMP_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/tmp
+        SOURCE_DIR ${musl_SOURCE_DIR}
+        INSTALL_DIR ${TEMP_LIB_DIR}
+        DEPENDS compiler_rt-install
+        CONFIGURE_COMMAND
+            <SOURCE_DIR>/configure
+            --prefix=${TEMP_LIB_DIR}
+            ${musl_embedded_flags}
+        BUILD_COMMAND
+            make ${make_flags}
+        INSTALL_COMMAND
+            make install
+        USES_TERMINAL_CONFIGURE TRUE
+        USES_TERMINAL_BUILD TRUE
+        USES_TERMINAL_INSTALL TRUE
+        # Always run the build command so that incremental builds are correct.
+        CONFIGURE_HANDLED_BY_BUILD TRUE
+        TEST_EXCLUDE_FROM_MAIN TRUE
+        STEP_TARGETS configure build install
+    )
+endif()
+
 
 add_dependencies(clib-configure ${C_LIBRARY}-configure)
 add_dependencies(clib-build ${C_LIBRARY}-build)
@@ -560,6 +633,21 @@ if(ENABLE_CXX_LIBS)
                 -DLLVM_EXTERNAL_LIT=${external_lit_path}
             )
         endif()
+    elseif(C_LIBRARY STREQUAL musl-embedded)
+        set(cxxlibs_extra_cmake_options
+            -DLIBCXX_HAS_MUSL_LIBC=ON
+            -DLIBCXXABI_ENABLE_THREADS=OFF
+            -DLIBCXX_ENABLE_RANDOM_DEVICE=OFF
+            -DLIBCXX_ENABLE_THREADS=OFF
+            -DLIBCXX_ENABLE_FILESYSTEM=OFF
+            -DLIBCXX_ENABLE_LOCALIZATION=OFF
+            -DLIBUNWIND_ENABLE_THREADS=OFF
+            -DLIBCXXABI_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
+            -DLIBCXXABI_ENABLE_STATIC_UNWINDER=${ENABLE_EXCEPTIONS}
+            -DLIBCXX_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
+            -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
+            )
+        set(lib_compile_flags "${lib_compile_flags} -fno-unroll-loops -fno-optimize-sibling-calls -D_GNU_SOURCE")
     endif()
 
     ExternalProject_Add(

--- a/qualcomm-software/embedded/musl-embedded.cfg
+++ b/qualcomm-software/embedded/musl-embedded.cfg
@@ -1,0 +1,1 @@
+--sysroot <CFGDIR>/../lib/clang-runtimes/musl-embedded

--- a/qualcomm-software/embedded/scripts/build_musl-embedded_overlay.sh
+++ b/qualcomm-software/embedded/scripts/build_musl-embedded_overlay.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to build the musl-embedded overlay.
+
+# The script creates a build of the toolchain in the 'build_musl-embedded_overlay'
+# directory, inside the repository tree.
+
+set -ex
+
+export CC=clang
+export CXX=clang++
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+BUILD_DIR=${REPO_ROOT}/build_musl-embedded_overlay
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+cmake ../qualcomm-software/embedded -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=musl-embedded -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
+ninja package-llvm-toolchain
+
+# The package-llvm-toolchain target will produce a .tar.xz package, but we also
+# want a zip version for Windows users
+cpack -G ZIP

--- a/qualcomm-software/embedded/versions.json
+++ b/qualcomm-software/embedded/versions.json
@@ -10,6 +10,11 @@
       "tagType": "tag",
       "tag": "1.8.10"
     },
+    "musl-embedded": {
+      "url": "https://github.com/qualcomm/musl-embedded",
+      "tagType": "branch",
+      "tag": "main"
+    },
     "eld": {
       "url": "https://github.com/qualcomm/eld",
       "tagType": "branch",


### PR DESCRIPTION
This covers only the basic Arm/AArch64 configs that we added in our initial cpullvm prototype. RISC-V configs will never be added and the various "subvariants" (standalone, uselock, etc.) will be added in a subsequent patch.

Also, build this as part of our precheckin as this is still a fairly core component of our toolchain--long term we can revisit this. I also think the current setup is a bit wasteful in that we build the tools twice, but ccache should make this quick I guess--we can revisit this later.