### PR TITLE
[cpullvm] Add picolibc equivalents of our musl-embedded configs

### DIFF
--- a/qualcomm-software/embedded/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/multilib.json
@@ -8,26 +8,22 @@
         {
             "variant": "aarch64a_soft_nofp",
             "json": "aarch64a_soft_nofp.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -fno-exceptions",
-            "libraries_supported": "musl-embedded"
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -fno-exceptions"
         },
         {
             "variant": "aarch64a_soft_nofp_pacret_bti",
             "json": "aarch64a_soft_nofp_pacret_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions",
-            "libraries_supported": "musl-embedded"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions"
         },
         {
             "variant": "aarch64a_pacret_bkey_bti",
             "json": "aarch64a_pacret_bkey_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti -fno-exceptions",
-            "libraries_supported": "musl-embedded"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti -fno-exceptions"
         },
         {
             "variant": "armv7a_soft_neon",
             "json": "armv7a_soft_neon.json",
-            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=neon -fno-exceptions",
-            "libraries_supported": "musl-embedded"
+            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=neon -fno-exceptions"
         },
         {
             "variant": "riscv32imac_ilp32_nopic",

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
@@ -15,6 +15,12 @@
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp.json
@@ -15,6 +15,12 @@
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "OFF",
             "ENABLE_LIBC_TESTS": "OFF",

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
@@ -15,6 +15,12 @@
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "OFF",
             "ENABLE_LIBC_TESTS": "OFF",

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/armv7a_soft_neon.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/armv7a_soft_neon.json
@@ -16,6 +16,12 @@
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",

--- a/qualcomm-software/embedded/test/multilib/aarch64.test
+++ b/qualcomm-software/embedded/test/multilib/aarch64.test
@@ -7,3 +7,20 @@
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -fno-exceptions | FileCheck %s --check-prefix=CHECK-AARCH64
 # CHECK-AARCH64: aarch64-none-elf/aarch64a{{$}}
 # CHECK-AARCH64-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP
+# CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp{{$}}
+# CHECK-NOFP-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.3a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# CHECK-NOFP-PACRET-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti{{$}}
+# CHECK-NOFP-PACRET-BTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fno-exceptions | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fno-exceptions | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti{{$}}
+# CHECK-PACRET-BKEY-BTI-EMPTY:

--- a/qualcomm-software/embedded/test/multilib/armv7.test
+++ b/qualcomm-software/embedded/test/multilib/armv7.test
@@ -1,0 +1,3 @@
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -fno-exceptions | FileCheck %s --check-prefix=CHECK-ARMV7
+# CHECK-ARMV7: arm-none-eabi/armv7a_soft_neon{{$}}
+# CHECK-ARMV7-EMPTY:


### PR DESCRIPTION
In theory this way people using the musl configs have a (relatively) direct equivalent that they can try out before we fully deprecate/remove musl.

The pacret configs both have tests disabled for picolibc as there are test failures/faults--these need to be investigated at some point.

Note also that the shared musl/picolibc variant scheme here might fall apart once we add a) musl subvariants (use-locks, etc.) and b) non-TLS/thread/atomic picolibc variants as their multilib custom flags might start to diverge. But, I think that is an issue best sorted out later/separately