### PR TITLE
[cpullvm][Github] Restore our old nightly workflows

### DIFF
--- a/.github/workflows/nightly-aarch64.yml
+++ b/.github/workflows/nightly-aarch64.yml
@@ -1,0 +1,14 @@
+name: Nightly-Linux-AArch64
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [trigger-nightly-aarch64-linux]
+
+jobs:
+  base:
+    uses: ./.github/workflows/base-build.yml
+    with:
+      build-script: "src/qualcomm-software/embedded/scripts/build.sh --aarch64-build"
+      is-nightly: true
+      arch: AArch64

--- a/.github/workflows/nightly-win-x86.yml
+++ b/.github/workflows/nightly-win-x86.yml
@@ -1,0 +1,51 @@
+name: nightly-win-x86_64
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    env:
+      ARTIFACT_DIR: ${{ github.workspace }}/nightly-toolchain
+
+    steps:
+      - name: Preconfigure Git (LF line endings, long paths)
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          git config --global core.longpaths true
+
+      - name: Checkout source (to src/)
+        uses: actions/checkout@v4
+        with:
+          path: src
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Verify PyYAML
+        run: python -c "import yaml; print('PyYAML OK:', yaml.__version__)"
+
+      - name: Build
+        working-directory: src
+        shell: pwsh
+        env:
+          GIT_AUTHOR_NAME: Qualcomm CI
+          GIT_AUTHOR_EMAIL: ci@qti.qualcomm.com
+          GIT_COMMITTER_NAME: Qualcomm CI
+          GIT_COMMITTER_EMAIL: ci@qti.qualcomm.com
+        run: |
+          ./qualcomm-software/embedded/scripts/build.ps1
+          
+      - name: Upload Artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpullvm-toolchain-${{ github.run_id }}-Windows-x86
+          path: |
+            ${{ env.ARTIFACT_DIR }}/*.txz
+            ${{ env.ARTIFACT_DIR }}/*.tgz
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/nightly-woa.yml
+++ b/.github/workflows/nightly-woa.yml
@@ -1,0 +1,51 @@
+name: nightly-win-arm64
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-windows-on-aarch64 :
+    runs-on: windows-11-arm
+    env:
+      ARTIFACT_DIR: ${{ github.workspace }}/nightly-toolchain
+
+    steps:
+      - name: Preconfigure Git (LF line endings, long paths)
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          git config --global core.longpaths true
+
+      - name: Checkout source (to src/)
+        uses: actions/checkout@v4
+        with:
+          path: src
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Verify PyYAML
+        run: python -c "import yaml; print('PyYAML OK:', yaml.__version__)"
+
+      - name: Build
+        working-directory: src
+        shell: pwsh
+        env:
+          GIT_AUTHOR_NAME: Qualcomm CI
+          GIT_AUTHOR_EMAIL: ci@qti.qualcomm.com
+          GIT_COMMITTER_NAME: Qualcomm CI
+          GIT_COMMITTER_EMAIL: ci@qti.qualcomm.com
+        run: |
+          ./qualcomm-software/embedded/scripts/build.ps1
+
+      - name: Upload Artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpullvm-toolchain-${{ github.run_id }}-Windows-arm64
+          path: |
+            ${{ env.ARTIFACT_DIR }}/*.txz
+            ${{ env.ARTIFACT_DIR }}/*.tgz
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/nightly-x86-linux.yml
+++ b/.github/workflows/nightly-x86-linux.yml
@@ -1,0 +1,14 @@
+name: Nightly-Linux-x86_64
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [trigger-nightly-x86-linux]
+
+jobs:
+  base:
+    uses: ./.github/workflows/base-build.yml
+    with:
+      build-script: "src/qualcomm-software/embedded/scripts/build.sh"
+      is-nightly: true
+      arch: x86_64


### PR DESCRIPTION
I removed these in [1] forgetting that that meant that the workflows can't be triggered anymore, even from the branch.

Restore only the nightly configs and not the actual build scripts--I think this should be sufficient for enabling nightly testing on the branch (I'm hoping the actual build scripts that are invoked are the ones on the branch, *not* the ones on qualcomm-software).

I also removed the scheduled runs for now as this is essentially restricted to the 22.x branch at this point (and, these should be updated/removed soon).

[1] https://github.com/qualcomm/cpullvm-toolchain/commit/4ff4312b1f7f603849f2a5a33979e9a249551ea4