### PR TITLE
[cpullvm] Don't ignore fails in the test script

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -7,7 +7,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: Linux Premerge Build and Test
+name: Linux x86_64 Premerge Checks
 
 on:
   pull_request:
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-refactor:
+  build-and-test:
     # Don't run on forks
     if: github.repository == 'qualcomm/cpullvm-toolchain'
     runs-on: self-hosted

--- a/qualcomm-software/embedded/scripts/test.sh
+++ b/qualcomm-software/embedded/scripts/test.sh
@@ -17,16 +17,6 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
-# If a test fails, lit will ordinarily return a non-zero result,
-# which prevents further testing. Setting the --ignore-fail option
-# will cause testing to continue, so that CI systems can get a
-# full set of results.
-# The lit test suites do not generate xml results by default.
-# This can be enabled with the --xunit-xml-output option. The file
-# written will be relative to the individual suite's build directly,
-# so the same name can be used for all files for consistency.
-export LIT_OPTS="--ignore-fail --xunit-xml-output=lit_results.junit.xml"
-
 # Run all relevant test targets. This might be too broad eventually,
 # but while we have a limited number of variants (and no compiler-rt
 # or libc++ testing enabled) we can run everything.


### PR DESCRIPTION
Long term, ignoring fails and dumping the .xml might be better if we process the results and have a convenient way of being alerted to issues. But, we don't. And, for now, having the build outright fail in precheckins, etc. is helpful. So, remove the `--ignore-fails` and xml output flags.

While here, also rename a few things in the precheckin to make it more clear what is running/going on.