### PR TITLE
[cpullvm] Enable x86 target support and build against libstdc++

### DIFF
--- a/qualcomm-software/embedded/CMakeLists.txt
+++ b/qualcomm-software/embedded/CMakeLists.txt
@@ -178,11 +178,14 @@ set(LLVM_TOOLCHAIN_DISTRIBUTION_COMPONENTS
 installed by the install-llvm-toolchain target"
 )
 set(LLVM_ENABLE_PROJECTS clang;lld;polly CACHE STRING "")
-set(LLVM_TARGETS_TO_BUILD AArch64;ARM;RISCV CACHE STRING "")
+set(LLVM_TARGETS_TO_BUILD AArch64;ARM;RISCV;X86 CACHE STRING "")
+# There's test failures when enabling x86 support and testing on native
+# AArch64 Linux machines. Just disable x86 in eld until these are
+# resolved.
+set(ELD_TARGETS_TO_BUILD AArch64;ARM;RISCV CACHE STRING "")
 set(LLVM_DEFAULT_TARGET_TRIPLE aarch64-unknown-linux-gnu CACHE STRING "")
 set(LLVM_BUILD_RUNTIME OFF CACHE BOOL "")
 set(LIBCLANG_BUILD_STATIC ON CACHE BOOL "")
-set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "")
 set(LLVM_POLLY_LINK_INTO_TOOLS ON CACHE BOOL "")
 set(CLANG_DEFAULT_LINKER lld CACHE STRING "")
 


### PR DESCRIPTION
The x86 change is largely just to enable additional testing and reach
parity with our past releases.

The libstdc++ change has a few motivations:
- Work around test failures when enabling x86 when building against libc++
  that use libunwind.
- This should hopefully be a better experience for most of our expected Linux
  users (on something close to Ubuntu 22+) in that they shouldn't have to
  additionally source libc++ to run the toolchain.

Long term, we'd like to head towards building/packaging a libc++ built from
the same sources, but that's a next step.

x86 support is disabled in eld for now as there are test failures when
building/testing on native AArch64 machines. This can be re-enabled when
https://github.com/qualcomm/eld/issues/764 is resolved.