### PR TITLE
[cpullvm] Expand usages of 'musl' to 'musl-embedded'. NFCI

### DIFF
--- a/qualcomm-software/embedded/CMakeLists.txt
+++ b/qualcomm-software/embedded/CMakeLists.txt
@@ -225,7 +225,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_eld.cmake)
 #
 # If you'd rather check out and patch manually then run cmake with
 # -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=/path/to/picolibc
-# -DFETCHCONTENT_SOURCE_DIR_MUSL=/path/to/musl
+# -DFETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED=/path/to/musl-embedded
 #
 # By default check out will be silent but this can be changed by running
 # cmake with -DFETCHCONTENT_QUIET=OFF
@@ -404,8 +404,8 @@ add_custom_target(
     # specify both definitions
     -Dpicolibc_SOURCE_DIR=${picolibc_SOURCE_DIR}
     -Dpicolibc_URL=${picolibc_URL}
-    -Dmusl_SOURCE_DIR=${musl_SOURCE_DIR}
-    -Dmusl_URL=${musl_URL}
+    -Dmusl-embedded_SOURCE_DIR=${musl-embedded_SOURCE_DIR}
+    -Dmusl-embedded_URL=${musl-embedded_URL}
     # but we do tell the script which library we're actually using
     -DLLVM_TOOLCHAIN_C_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_version_txt.cmake
@@ -529,7 +529,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         -DPARALLEL_LIB_BUILD_LEVELS=${PARALLEL_LIB_BUILD_LEVELS}
         -DENABLE_QEMU_TESTING=${ENABLE_QEMU_TESTING}
         -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}
-        -DFETCHCONTENT_SOURCE_DIR_MUSL=${FETCHCONTENT_SOURCE_DIR_MUSL}
+        -DFETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED=${FETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         -DPROJECT_PREFIX=${multilib_prefix}
         -DNUMERICAL_BUILD_NAMES=${SHORT_BUILD_PATHS}
@@ -659,7 +659,7 @@ if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
     )
 elseif(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
     list(APPEND third_party_license_files
-        ${musl_SOURCE_DIR}/COPYRIGHT musl-embedded-COPYRIGHT.txt
+        ${musl-embedded_SOURCE_DIR}/COPYRIGHT musl-embedded-COPYRIGHT.txt
     )
 endif()
 

--- a/qualcomm-software/embedded/cmake/fetch_musl-embedded.cmake
+++ b/qualcomm-software/embedded/cmake/fetch_musl-embedded.cmake
@@ -1,7 +1,7 @@
 # To avoid duplicating the FetchContent code, this file can be
 # included by either the top-level toolchain cmake, or the
 # embedded-runtimes sub-project.
-# FETCHCONTENT_SOURCE_DIR_MUSL should be passed down from the
+# FETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED should be passed down from the
 # top level to any library builds to prevent repeated checkouts.
 
 include(FetchContent)
@@ -10,19 +10,19 @@ include(${CMAKE_CURRENT_LIST_DIR}/patch_repo.cmake)
 if(NOT VERSIONS_JSON)
     include(${CMAKE_CURRENT_LIST_DIR}/read_versions.cmake)
 endif()
-read_repo_version(musl musl-embedded)
-get_patch_command(${CMAKE_CURRENT_LIST_DIR}/.. musl-embedded musl_patch_command)
+read_repo_version(musl-embedded musl-embedded)
+get_patch_command(${CMAKE_CURRENT_LIST_DIR}/.. musl-embedded musl-embedded_patch_command)
 
-FetchContent_Declare(musl
-    GIT_REPOSITORY "${musl_URL}"
-    GIT_TAG "${musl_TAG}"
-    GIT_SHALLOW "${musl_SHALLOW}"
+FetchContent_Declare(musl-embedded
+    GIT_REPOSITORY "${musl-embedded_URL}"
+    GIT_TAG "${musl-embedded_TAG}"
+    GIT_SHALLOW "${musl-embedded_SHALLOW}"
     GIT_PROGRESS TRUE
-    PATCH_COMMAND ${musl_patch_command}
+    PATCH_COMMAND ${musl-embedded_patch_command}
     # We only want to download the content, not configure it at this
     # stage. musl-embedded will be built in many configurations using
     # ExternalProject_Add using the sources that are checked out here.
-    SOURCE_SUBDIR do_not_add_musl_subdir
+    SOURCE_SUBDIR do_not_add_musl-embedded_subdir
 )
-FetchContent_MakeAvailable(musl)
-FetchContent_GetProperties(musl SOURCE_DIR FETCHCONTENT_SOURCE_DIR_MUSL)
+FetchContent_MakeAvailable(musl-embedded)
+FetchContent_GetProperties(musl-embedded SOURCE_DIR FETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED)

--- a/qualcomm-software/embedded/cmake/generate_version_txt.cmake
+++ b/qualcomm-software/embedded/cmake/generate_version_txt.cmake
@@ -25,11 +25,7 @@ execute_process(
 )
 
 # Supported libcs are all in a separate repo
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
-    set(base_library musl)
-else()
-    set(base_library ${LLVM_TOOLCHAIN_C_LIBRARY})
-endif()
+set(base_library ${LLVM_TOOLCHAIN_C_LIBRARY})
 
 execute_process(
     COMMAND git -C ${${base_library}_SOURCE_DIR} rev-parse HEAD

--- a/qualcomm-software/embedded/embedded-multilib/CMakeLists.txt
+++ b/qualcomm-software/embedded/embedded-multilib/CMakeLists.txt
@@ -87,7 +87,7 @@ if(C_LIBRARY STREQUAL picolibc)
     list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}")
 elseif(C_LIBRARY STREQUAL musl-embedded)
     include(${TOOLCHAIN_SOURCE_DIR}/cmake/fetch_musl-embedded.cmake)
-    list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_MUSL=${FETCHCONTENT_SOURCE_DIR_MUSL}")
+    list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED=${FETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED}")
 endif()
 
 # Target for any dependencies to build the runtimes project.

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a.json
@@ -26,7 +26,7 @@
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL_CFLAGS": "-mstrict-align -D__QUIC_ENABLE_FLT_FOR_PRINT"
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align -D__QUIC_ENABLE_FLT_FOR_PRINT"
         }
     }
 }

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
@@ -26,7 +26,7 @@
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL_CFLAGS": "-mstrict-align -D__QUIC_ENABLE_FLT_FOR_PRINT"
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align -D__QUIC_ENABLE_FLT_FOR_PRINT"
         }
     }
 }

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp.json
@@ -26,8 +26,8 @@
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL_CONFIG_FLAGS": "--quic-aarch64-nofp",
-            "EXTRA_MUSL_CFLAGS": "-mstrict-align"
+            "EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS": "--quic-aarch64-nofp",
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
         }
     }
 }

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
@@ -26,8 +26,8 @@
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL_CONFIG_FLAGS": "--quic-aarch64-nofp",
-            "EXTRA_MUSL_CFLAGS": "-mstrict-align"
+            "EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS": "--quic-aarch64-nofp",
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
         }
     }
 }

--- a/qualcomm-software/embedded/embedded-multilib/json/variants/armv7a_soft_neon.json
+++ b/qualcomm-software/embedded/embedded-multilib/json/variants/armv7a_soft_neon.json
@@ -27,7 +27,7 @@
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL_CFLAGS": "-mno-unaligned-access"
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mno-unaligned-access"
         }
     }
 }

--- a/qualcomm-software/embedded/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded/embedded-runtimes/CMakeLists.txt
@@ -86,12 +86,12 @@ set(ENABLE_COMPILER_RT_TESTS ${ENABLE_COMPILER_RT_TESTS_def} CACHE BOOL "Enable 
 set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tests.")
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
 
-# Set up a few arbitrary pass-through flags for MUSL. This probably isn't the best idea,
-# but historically, our flag usage is such that it is a bit unclear how to do this in
-# a more princicpled way. This should be revisited and probably clean up, but for now
-# just mirror what we used to do.
-set(EXTRA_MUSL_CONFIG_FLAGS ${EXTRA_MUSL_CONFIG_FLAGS_def} CACHE BOOL "Extra configure options for musl-embedded.")
-set(EXTRA_MUSL_CFLAGS ${EXTRA_MUSL_CFLAGS_def} CACHE BOOL "Extra flags to be used when compiling musl-embedded.")
+# Set up a few arbitrary pass-through flags for musl-embedded. This probably
+# isn't the best idea, but historically, our flag usage is such that it is a
+# bit unclear how to do this in a more princicpled way. This should be
+# revisited and probably cleaned up, but for now just mirror what we used to do.
+set(EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS ${EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS_def} CACHE BOOL "Extra configure options for musl-embedded.")
+set(EXTRA_MUSL-EMBEDDED_CFLAGS ${EXTRA_MUSL-EMBEDDED_CFLAGS_def} CACHE BOOL "Extra flags to be used when compiling musl-embedded.")
 
 set(PROJECT_PREFIX "subproj" CACHE STRING "Directory to build subprojects in.")
 set(VARIANT_BUILD_ID "${VARIANT}" CACHE STRING "Name to use to identify build directories." )
@@ -539,7 +539,7 @@ if(C_LIBRARY STREQUAL musl-embedded)
     endif()
 
     if(WIN32)
-        message(FATAL_ERROR "Building MUSL is not supported on Windows hosts")
+        message(FATAL_ERROR "Building musl-embedded is not supported on Windows hosts")
     endif()
 
     if(TARGET_ARCH MATCHES "^riscv")
@@ -556,9 +556,9 @@ if(C_LIBRARY STREQUAL musl-embedded)
     endif()
 
     if(LIBRARY_BUILD_TYPE STREQUAL minsizerelease)
-        set(musl_opt_flags "-Os")
+        set(musl-embedded_opt_flags "-Os")
     elseif((LIBRARY_BUILD_TYPE STREQUAL release) OR (LIBRARY_BUILD_TYPE STREQUAL releasewithdebuginfo))
-        set(musl_opt_flags "-O3")
+        set(musl-embedded_opt_flags "-O3")
     endif()
 
     # FIXME: if we need the extra `uselocks`/`standalone` variants, we
@@ -567,10 +567,10 @@ if(C_LIBRARY STREQUAL musl-embedded)
         --disable-wrapper
         --quic-arm-baremetal
         --disable-visibility
-        ${EXTRA_MUSL_CONFIG_FLAGS}
+        ${EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS}
         "CROSS_COMPILE=${LLVM_BINARY_DIR}/bin/llvm-"
         "CC=${LLVM_BINARY_DIR}/bin/clang --target=${target_triple} -fuse-ld=eld"
-        "CFLAGS=${lib_compile_flags} ${musl_opt_flags} -fPIC -fvisibility=hidden -DVISIBILITY_HIDDEN -fno-rounding-math ${EXTRA_MUSL_CFLAGS}"
+        "CFLAGS=${lib_compile_flags} ${musl-embedded_opt_flags} -fPIC -fvisibility=hidden -DVISIBILITY_HIDDEN -fno-rounding-math ${EXTRA_MUSL-EMBEDDED_CFLAGS}"
         "LIBCC=${TEMP_LIB_DIR}/libclang_rt.builtins.a")
 
     ExternalProject_Add(
@@ -579,7 +579,7 @@ if(C_LIBRARY STREQUAL musl-embedded)
         BINARY_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/build
         DOWNLOAD_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/dl
         TMP_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/tmp
-        SOURCE_DIR ${musl_SOURCE_DIR}
+        SOURCE_DIR ${musl-embedded_SOURCE_DIR}
         INSTALL_DIR ${TEMP_LIB_DIR}
         DEPENDS compiler_rt-install
         CONFIGURE_COMMAND


### PR DESCRIPTION
I thought there were some sharp edges around '-' in variable names [1][2] in cmake so originally I tried to avoid this sort of thing when adding musl-embedded support. But, based on [3] I think this is actually fine for what we do (and experimentally things seem to be working as expected). We're getting ready to add upstream musl as a dependency for our linux configs, so the shorthand 'musl' to refer to musl-embedded needs to change. Just use 'musl-embedded' in full to make things as clear as possible.

[1] https://cmake.org/cmake/help/book/mastering-cmake/chapter/Writing%20CMakeLists%20Files.html#variables
[2] https://gitlab.kitware.com/cmake/cmake/-/issues/23075
[3] https://cmake.org/cmake/help/v3.20/manual/cmake-language.7.html#variables