### PR TITLE
[cpullvm] Integrate Linux builds into our refactored workflow

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -129,14 +129,23 @@ option(
     index numbers, which is shorter but less descriptive."
     OFF
 )
-
-
+option(
+    ENABLE_LINUX_LIBRARIES
+    "Include additional library variants for use on Linux targets"
+    OFF
+)
+if(ENABLE_LINUX_LIBRARIES AND WIN32)
+    message(FATAL_ERROR "ENABLE_LINUX_LIBRARIES is not permitted on Windows")
+endif()
 option(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL
     "Make cpack build an overlay package that can be unpacked over the main toolchain to install a secondary set of libraries based on musl-embedded."
     ${overlay_install_default})
 if(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL)
   if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL "picolibc")
     message(FATAL_ERROR "LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL is only permitted for C libraries other than the default picolibc")
+  endif()
+  if(ENABLE_LINUX_LIBRARIES)
+    message(FATAL_ERROR "ENABLE_LINUX_LIBRARIES is not permitted with LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL")
   endif()
 endif()
 
@@ -238,8 +247,11 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_eld.cmake)
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_picolibc.cmake)
 endif()
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded OR ENABLE_LINUX_LIBRARIES)
     include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_musl-embedded.cmake)
+endif()
+if(ENABLE_LINUX_LIBRARIES)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/fetch_musl.cmake)
 endif()
 
 ##################################################################################################
@@ -411,6 +423,9 @@ add_custom_target(
     -Dmusl-embedded_URL=${musl-embedded_URL}
     # but we do tell the script which library we're actually using
     -DLLVM_TOOLCHAIN_C_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
+    -Dmusl_SOURCE_DIR=${musl_SOURCE_DIR}
+    -Dmusl_URL=${musl_URL}
+    -DENABLE_LINUX_LIBRARIES=${ENABLE_LINUX_LIBRARIES}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/generate_version_txt.cmake
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/VERSION.txt
 )
@@ -596,6 +611,41 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
             add_dependencies(${check_target}-${variant} multilib-${LLVM_TOOLCHAIN_C_LIBRARY}-${check_target}-${variant})
         endforeach()
     endforeach()
+
+    # Linux
+    if(ENABLE_LINUX_LIBRARIES)
+        set(linux_library_prefix ${CMAKE_BINARY_DIR}/linux-library-builds)
+        ExternalProject_Add(
+            linux-libraries
+            STAMP_DIR ${linux_library_prefix}/stamp
+            BINARY_DIR ${linux_library_prefix}/build
+            DOWNLOAD_DIR ${linux_library_prefix}/dl
+            TMP_DIR ${linux_library_prefix}/tmp
+            SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/scripts
+            INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/llvm/linux-libraries
+            DEPENDS ${lib_tool_dependencies}
+            CONFIGURE_COMMAND ""
+            BUILD_COMMAND
+                <SOURCE_DIR>/build_linux_runtimes.sh
+                    --tools-path ${CMAKE_CURRENT_BINARY_DIR}/llvm/bin
+                    --base-build-dir <BINARY_DIR>
+                    --base-install-dir <INSTALL_DIR>
+                    --llvm-src-dir ${llvmproject_src_dir}
+                    --musl-src-dir ${musl_SOURCE_DIR}
+                    --musl-emb-src-dir ${musl-embedded_SOURCE_DIR}
+                    --download-dir <DOWNLOAD_DIR>
+            INSTALL_COMMAND ""
+            USES_TERMINAL_CONFIGURE TRUE
+            USES_TERMINAL_BUILD TRUE
+            USES_TERMINAL_INSTALL TRUE
+            STEP_TARGETS build install
+        )
+
+        add_dependencies(
+            llvm-toolchain-runtimes
+            linux-libraries-install
+        )
+    endif()
 endif()
 
 FILE(WRITE "${CMAKE_BINARY_DIR}/llvm/${TARGET_CFI_DIR}/cfi_ignorelist.txt" "")
@@ -611,6 +661,22 @@ install(
     DESTINATION ${TARGET_LIBRARIES_DIR}
     COMPONENT llvm-toolchain-libs
 )
+
+if(ENABLE_LINUX_LIBRARIES)
+    # libc, libc++/libc++abi/libunwind only
+    install(
+        DIRECTORY ${LLVM_BINARY_DIR}/linux-libraries/.
+        DESTINATION .
+        COMPONENT llvm-toolchain-libs
+        REGEX "resource-dir" EXCLUDE
+    )
+    # compiler-rt
+    install(
+        DIRECTORY ${LLVM_BINARY_DIR}/linux-libraries/resource-dir/.
+        DESTINATION lib/clang/${LLVM_VERSION_MAJOR}
+        COMPONENT llvm-toolchain-libs
+    )
+endif()
 
 install(
     FILES CHANGELOG.md LICENSE.txt README.md
@@ -664,6 +730,16 @@ elseif(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
     list(APPEND third_party_license_files
         ${musl-embedded_SOURCE_DIR}/COPYRIGHT musl-embedded-COPYRIGHT.txt
     )
+endif()
+if(ENABLE_LINUX_LIBRARIES)
+    list(APPEND third_party_license_files
+        ${musl_SOURCE_DIR}/COPYRIGHT musl-COPYRIGHT.txt)
+
+    # We added this above if musl-embedded was selected.
+    if(NOT LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+        list(APPEND third_party_license_files
+             ${musl-embedded_SOURCE_DIR}/COPYRIGHT musl-embedded-COPYRIGHT.txt)
+    endif()
 endif()
 
 while(third_party_license_files)

--- a/qualcomm-software/cmake/THIRD-PARTY-LICENSES.txt.in
+++ b/qualcomm-software/cmake/THIRD-PARTY-LICENSES.txt.in
@@ -10,6 +10,7 @@ additional or alternate licenses:
  - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc
  - eld: third-party-licenses/eld-LICENSE.txt
  - musl-embedded: third-party-licenses/musl-embedded-COPYRIGHT.txt
+ - musl: third-party-licenses/musl-COPYRIGHT.txt
  - Arm Toolchain for Embedded: third-party-licenses/ATfE-LICENSE.txt
 
 Picolibc licenses refer to its source files. Sources are identified in VERSION.txt.

--- a/qualcomm-software/cmake/VERSION.txt.in
+++ b/qualcomm-software/cmake/VERSION.txt.in
@@ -2,5 +2,6 @@ CPULLVM Toolchain ${cpullvm_VERSION}
 
 Sources:
 * cpullvm: https://github.com/qualcomm/cpullvm-toolchain (commit ${cpullvm_COMMIT})
-* eld: https://github.com/qualcomm/eld (commit ${eld_COMMIT})
+* eld: ${eld_URL} (commit ${eld_COMMIT})
 * ${LLVM_TOOLCHAIN_C_LIBRARY}: ${LLVM_TOOLCHAIN_C_LIBRARY_URL} (commit ${LLVM_TOOLCHAIN_C_LIBRARY_COMMIT})
+${musl_version_string}${musl-embedded_version_string}

--- a/qualcomm-software/cmake/fetch_musl.cmake
+++ b/qualcomm-software/cmake/fetch_musl.cmake
@@ -1,0 +1,28 @@
+# To avoid duplicating the FetchContent code, this file can be
+# included by either the top-level toolchain cmake, or the
+# runtimes sub-project.
+# FETCHCONTENT_SOURCE_DIR_MUSL should be passed down from the
+# top level to any library builds to prevent repeated checkouts.
+
+include(FetchContent)
+include(${CMAKE_CURRENT_LIST_DIR}/patch_repo.cmake)
+
+if(NOT VERSIONS_JSON)
+    include(${CMAKE_CURRENT_LIST_DIR}/read_versions.cmake)
+endif()
+read_repo_version(musl musl)
+get_patch_command(${CMAKE_CURRENT_LIST_DIR}/.. musl musl_patch_command)
+
+FetchContent_Declare(musl
+    GIT_REPOSITORY "${musl_URL}"
+    GIT_TAG "${musl_TAG}"
+    GIT_SHALLOW "${musl_SHALLOW}"
+    GIT_PROGRESS TRUE
+    PATCH_COMMAND ${musl_patch_command}
+    # We only want to download the content, not configure it at this
+    # stage. musl will be built in many configurations using
+    # ExternalProject_Add using the sources that are checked out here.
+    SOURCE_SUBDIR do_not_add_musl_subdir
+)
+FetchContent_MakeAvailable(musl)
+FetchContent_GetProperties(musl SOURCE_DIR FETCHCONTENT_SOURCE_DIR_MUSL)

--- a/qualcomm-software/cmake/generate_version_txt.cmake
+++ b/qualcomm-software/cmake/generate_version_txt.cmake
@@ -8,31 +8,37 @@
 # current revision. In the latter case the revision will be used as is.
 set(cpullvm_COMMIT "$Format:%H$")
 
-if(NOT ${cpullvm_COMMIT} MATCHES "^[a-f0-9]+$")
+function(get_commit_from_dir source_dir commit)
     execute_process(
-        COMMAND git -C ${CPULLVMToolchain_SOURCE_DIR} rev-parse HEAD
-        OUTPUT_VARIABLE cpullvm_COMMIT
+        COMMAND git -C ${source_dir} rev-parse HEAD
+        OUTPUT_VARIABLE temp_commit
         OUTPUT_STRIP_TRAILING_WHITESPACE
         COMMAND_ERROR_IS_FATAL ANY
     )
+    set(${commit} ${temp_commit} PARENT_SCOPE)
+endfunction()
+
+if(NOT ${cpullvm_COMMIT} MATCHES "^[a-f0-9]+$")
+    get_commit_from_dir("${CPULLVMToolchain_SOURCE_DIR}" cpullvm_COMMIT)
 endif()
 
-execute_process(
-    COMMAND git -C ${eld_SOURCE_DIR} rev-parse HEAD
-    OUTPUT_VARIABLE eld_COMMIT
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    COMMAND_ERROR_IS_FATAL ANY
-)
+get_commit_from_dir("${eld_SOURCE_DIR}" eld_COMMIT)
+
+if(ENABLE_LINUX_LIBRARIES)
+    get_commit_from_dir("${musl_SOURCE_DIR}" musl_COMMIT)
+    set(musl_version_string "* musl: ${musl_URL} (commit ${musl_COMMIT})\n")
+
+    if(NOT LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+        get_commit_from_dir("${musl-embedded_SOURCE_DIR}" musl-embedded_COMMIT)
+        set(musl-embedded_version_string "* musl-embedded: ${musl-embedded_URL} (commit ${musl-embedded_COMMIT})\n")
+    endif()
+endif()
 
 # Supported libcs are all in a separate repo
 set(base_library ${LLVM_TOOLCHAIN_C_LIBRARY})
 
-execute_process(
-    COMMAND git -C ${${base_library}_SOURCE_DIR} rev-parse HEAD
-    OUTPUT_VARIABLE ${base_library}_COMMIT
-    OUTPUT_STRIP_TRAILING_WHITESPACE 
-    COMMAND_ERROR_IS_FATAL ANY
-)
+get_commit_from_dir("${${base_library}_SOURCE_DIR}" ${base_library}_COMMIT)
+
 set(LLVM_TOOLCHAIN_C_LIBRARY_URL ${${base_library}_URL})
 set(LLVM_TOOLCHAIN_C_LIBRARY_COMMIT ${${base_library}_COMMIT})
 

--- a/qualcomm-software/scripts/build.sh
+++ b/qualcomm-software/scripts/build.sh
@@ -25,5 +25,5 @@ export CXX=clang++
 mkdir -p "${REPO_ROOT}"/build
 cd "${REPO_ROOT}"/build
 
-cmake ../qualcomm-software -GNinja -DFETCHCONTENT_QUIET=OFF
+cmake ../qualcomm-software -GNinja -DFETCHCONTENT_QUIET=OFF -DENABLE_LINUX_LIBRARIES=ON
 ninja package-llvm-toolchain

--- a/qualcomm-software/scripts/build_linux_runtimes.sh
+++ b/qualcomm-software/scripts/build_linux_runtimes.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  build_riscv_linux_runtimes.sh [options]
+
+  !!!! Note that all options must be specified
+
+Options:
+  --tools-path <path>         Path to directory to find Clang/LLVM tools
+  --base-build-dir <path>     Directory for the build
+  --base-install-dir <path>   Directory for the install
+  --llvm-src-dir <path>       Directory of the LLVM sources
+  --musl-src-dir <path>       Directory of the musl source dir
+  --musl-emb-src-dir <path>   Directory of the musl-embedded source dir
+  --download-dir <path>       Directory where extra projects are downloaded into
+EOF
+}
+
+# Given a string containing compile flags (hopefully containing a
+# `--target=<triple>`), echo the `<triple>` or exit if not found.
+get_target_from_flags() {
+  local target_flag_regex="--target=([a-z0-9-]+)"
+  [[ "$1" =~ ${target_flag_regex} ]]
+  local target="${BASH_REMATCH[1]}"
+  if [ -z "${target}" ]; then
+    echo "Could not parse target from string ${1}!"
+    exit 1
+  fi
+  echo "${target}"
+}
+
+# Given a string containing compile flags (hopefully containing a
+# `--target=<triple>`), echo the arch or exit if not found.
+get_arch_from_flags() {
+  local target=$(get_target_from_flags "$1")
+  local arch="$(echo ${target} | cut -d '-' -f1)"
+  if [ -z "${arch[0]}" ]; then
+    echo "Could not parse arch from string $1!"
+    exit 1
+  fi
+  echo "${arch[0]}"
+}
+
+# Given an arch appropriate for clang (from something like
+# `--target=<arch>-linux-gnu`), echo the appropriate arch for installing
+# kernel headers.
+get_kernel_arch() {
+  if [[ "$1" == "aarch64" ]]; then
+    echo "arm64"
+  elif [[ "$1" == "arm" ]]; then
+    echo "arm"
+  # Seems riscv is the only supported RISC-V ARCH?
+  elif [[ "$1" =~ riscv ]]; then
+    echo "riscv"
+  else
+    echo "UNKNOWN_ARCH"
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tools-path) TOOLS_PATH="$2"; shift 2 ;;
+    --base-build-dir) BASE_BUILD_DIR="$2"; shift 2 ;;
+    --base-install-dir) BASE_INSTALL_DIR="$2"; shift 2;;
+    --llvm-src-dir) LLVM_BASE_DIR="$2"; shift 2 ;;
+    --musl-src-dir) MUSL_SRC_DIR="$2"; shift 2 ;;
+    --musl-emb-src-dir) MUSL_EMB_SRC_DIR="$2"; shift 2 ;;
+    --download-dir) DOWNLOAD_DIR="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1"; usage; exit 1 ;;
+  esac
+done
+
+# Require all flags be passed.
+if [ -z "${TOOLS_PATH}" ] ||
+   [ -z "${BASE_BUILD_DIR}" ] ||
+   [ -z "${BASE_INSTALL_DIR}" ] ||
+   [ -z "${LLVM_BASE_DIR}" ] ||
+   [ -z "${MUSL_SRC_DIR}" ] ||
+   [ -z "${MUSL_EMB_SRC_DIR}" ] ||
+   [ -z "${DOWNLOAD_DIR}" ]; then
+  echo "All options must be specified"; usage; exit 1
+fi
+
+export PATH="${TOOLS_PATH}:${PATH}"
+
+JOBS=$(nproc)
+
+pushd "${DOWNLOAD_DIR}" >/dev/null
+# Source kernel headers. This version was chosen as it is the closest, still
+# supported, longterm version compared to what we've used historically.
+KERNEL_SOURCE_BASE="linux-5.10.247"
+KERNEL_SOURCE_BASE_DIR="${DOWNLOAD_DIR}/${KERNEL_SOURCE_BASE}"
+if [[ ! -d "${KERNEL_SOURCE_BASE_DIR}" ]]; then
+  wget https://cdn.kernel.org/pub/linux/kernel/v5.x/${KERNEL_SOURCE_BASE}.tar.xz
+  tar xvf "${KERNEL_SOURCE_BASE}.tar.xz"
+  rm "${KERNEL_SOURCE_BASE}.tar.xz"
+fi
+
+CLANG_RESOURCE_DIR="$(clang --print-resource-dir)"
+
+# Variants to build and the basic set of compile flags to use for each. There's
+# surely more elegant ways of doing this, but this doesn't require any extra
+# dependencies and is intended as temporary code.
+VARIANTS=(
+  "rv32imac_ilp32"
+  "rv64imac_lp64"
+  "rv64gc_lp64d"
+  "aarch64a"
+  "aarch64a_pacret"
+  "aarch64a_pacret_bti"
+  "armv7_softfp_neon"
+)
+
+# We place things into folders based on the target here (which maybe isn't
+# ideal) so prefer the mostly-normalized form that clang seems to search for
+# builtins, default libs, etc.
+declare -A VARIANT_BUILD_FLAGS
+VARIANT_BUILD_FLAGS["rv32imac_ilp32"]="--target=riscv32-unknown-linux-gnu -march=rv32imac -mabi=ilp32"
+VARIANT_BUILD_FLAGS["rv64imac_lp64"]="--target=riscv64-unknown-linux-gnu -march=rv64imac -mabi=lp64"
+VARIANT_BUILD_FLAGS["rv64gc_lp64d"]="--target=riscv64-unknown-linux-gnu -march=rv64gc -mabi=lp64d"
+# Note that there's minor devations in the flags here--in the past, only musl
+# either was not built with -mcpu=cortex-a53 (aarch64) or was built with
+# ex: -mcpu=krait (arm). There was also some odd mixing of armv8.3 vs armv8.5
+# across libraries. Intentionally aligning these across libraries for each
+# variant.
+VARIANT_BUILD_FLAGS["aarch64a"]="--target=aarch64-unknown-linux-gnu -mcpu=cortex-a53"
+VARIANT_BUILD_FLAGS["aarch64a_pacret"]="--target=aarch64-unknown-linux-gnu -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf"
+VARIANT_BUILD_FLAGS["aarch64a_pacret_bti"]="--target=aarch64-unknown-linux-gnu -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf+bti"
+# The full normalized form here seems to be "thumbv7-unknown-linux-gnueabi" but
+# that doesn't seem to be what clang searches--use "arm-unknown-linux-gnueabi"
+# instead.
+VARIANT_BUILD_FLAGS["armv7_softfp_neon"]="--target=arm-unknown-linux-gnueabi -mcpu=cortex-a9 -mfloat-abi=softfp -mfpu=neon"
+
+# Our musl builds in the past have used different "base" sets of compile flags
+# for each target arch. Build out that mapping here.
+declare -A ARCH_MUSL_CFLAGS
+ARCH_MUSL_CFLAGS["riscv32"]="-Os"
+ARCH_MUSL_CFLAGS["riscv64"]="-Os"
+ARCH_MUSL_CFLAGS["aarch64"]="-mstrict-align -fPIC -fno-rounding-math -O3"
+ARCH_MUSL_CFLAGS["arm"]="-mno-unaligned-access -fPIC -fno-rounding-math -O3"
+
+# We also have some new variant-specific configuration going on. Map that out
+# as well. Just list all variants--it'll be cleaned up later.
+declare -A VARIANT_MUSL_CONFIGS
+VARIANT_MUSL_CONFIGS["rv32imac_ilp32"]=""
+VARIANT_MUSL_CONFIGS["rv64imac_lp64"]=""
+VARIANT_MUSL_CONFIGS["rv64gc_lp64d"]=""
+VARIANT_MUSL_CONFIGS["aarch64a"]="--quic-aarch64-optmem"
+VARIANT_MUSL_CONFIGS["aarch64a_pacret"]="--quic-aarch64-optmem"
+VARIANT_MUSL_CONFIGS["aarch64a_pacret_bti"]="--quic-aarch64-optmem \
+                                             --quic-aarch64-mark-bti"
+VARIANT_MUSL_CONFIGS["armv7_softfp_neon"]=""
+
+for VARIANT in "${VARIANTS[@]}"; do
+  echo "Building libraries for ${VARIANT}"
+  VARIANT_BASE_BUILD_DIR="${BASE_BUILD_DIR}/${VARIANT}"
+  mkdir -p "${VARIANT_BASE_BUILD_DIR}"
+
+  BUILD_FLAGS="${VARIANT_BUILD_FLAGS[$VARIANT]}"
+
+  # Create a temporary sysroot to dump our libraries into--we'll sort out the
+  # final install location later.
+  VARIANT_TMP_SYSROOT="${VARIANT_BASE_BUILD_DIR}/sysroot"
+  mkdir -p "${VARIANT_TMP_SYSROOT}"
+
+  # We have an issue in that we want to build/install/distribute
+  # multiple, possibly conficting (different ABIs, etc.) variants. Parts of the
+  # subsequent build steps need to be able to find the correct set of libraries
+  # for the given variant being built out--basically, we need multilib or to
+  # be able to manually point to the correct set of libraries. There's two
+  # situations where this causes issues (assuming conflicting variants of the
+  # same triple):
+  #   1. Basic "can we compile/link a simple thing" tests (roughly) of the form:
+  #      `clang --target=<arch>-linux-gnu test.c <extra flags>`
+  #   2. Locating the builtins through `--print-libgcc-file-name`. This can
+  #      happen in ex: `add_compiler_rt_runtime`.
+  # We have lots of options to work around the first case. For the second,
+  # `-resource-dir` seems to be the only option. So, setup a temporary
+  # resource dir per variant that we can build out and point to using
+  # `-resource-dir` in subsequent steps. We'll copy libraries to the appropriate
+  # places at the end.
+  VARIANT_TMP_RESOURCE_DIR="${VARIANT_TMP_SYSROOT}/resource-dir"
+  cp -r "${CLANG_RESOURCE_DIR}" "${VARIANT_TMP_RESOURCE_DIR}"
+
+  VARIANT_TARGET="$(get_target_from_flags ${BUILD_FLAGS})"
+  VARIANT_ARCH="$(get_arch_from_flags ${VARIANT_BUILD_FLAGS[$VARIANT]})"
+  VARIANT_KERNEL_ARCH="$(get_kernel_arch ${VARIANT_ARCH})"
+
+  # Historically, our RISC-V and Arm/AArch64 builds use slightly different
+  # flags, sources, etc. Sort that all out here so we can treat the two
+  # consistently below.
+  MUSL_DIR="${MUSL_EMB_SRC_DIR}"
+  EXTRA_MUSL_CONFIGS="${VARIANT_MUSL_CONFIGS[$VARIANT]}"
+  CMAKE_OPT_LEVEL="Release"
+  if [[ "${VARIANT_ARCH}" =~ riscv ]]; then
+    MUSL_DIR="${MUSL_SRC_DIR}"
+    EXTRA_MUSL_CONFIGS="${EXTRA_MUSL_CONFIGS} \
+                        --disable-shared"
+    CMAKE_OPT_LEVEL="MinSizeRel"
+  fi
+
+  # Install kernel headers. They get their own folder so they aren't added to
+  # the distribution
+  echo "Installing kernel headers for ${VARIANT}"
+  KERNEL_BUILD_BASE="${VARIANT_BASE_BUILD_DIR}/kernel"
+  make -C "${KERNEL_SOURCE_BASE_DIR}" clean
+  make -C "${KERNEL_SOURCE_BASE_DIR}" \
+          headers_install \
+          INSTALL_HDR_PATH="${KERNEL_BUILD_BASE}" \
+          ARCH="${VARIANT_KERNEL_ARCH}"
+
+  # Flags common to all libraries.
+  LIB_BUILD_FLAGS="${BUILD_FLAGS} -isystem${KERNEL_BUILD_BASE}/include -resource-dir ${VARIANT_TMP_RESOURCE_DIR} --sysroot=${VARIANT_TMP_SYSROOT}"
+  LIB_BUILD_FLAGS="${LIB_BUILD_FLAGS} -ffunction-sections -fdata-sections"
+
+  # Install musl headers
+  # This is probably overkill for headers-only (nothing should be compiled)
+  # but just use our normal configure step, minus the builtins (as they
+  # don't exist yet anyway)
+  echo "Installing musl headers for ${VARIANT}"
+  VARIANT_MUSL_BUILD_DIR="${VARIANT_BASE_BUILD_DIR}"/musl
+  mkdir -p "${VARIANT_MUSL_BUILD_DIR}"
+  pushd "${VARIANT_MUSL_BUILD_DIR}" >/dev/null
+  "${MUSL_DIR}"/configure \
+                            ${EXTRA_MUSL_CONFIGS} \
+                            --disable-wrapper \
+                            --prefix="${VARIANT_TMP_SYSROOT}" \
+                            CROSS_COMPILE="llvm-" \
+                            CC="clang --target=${VARIANT_TARGET} -fuse-ld=eld" \
+                            CFLAGS="${LIB_BUILD_FLAGS} ${ARCH_MUSL_CFLAGS[$VARIANT_ARCH]}"
+  make install-headers
+  popd >/dev/null
+
+  # Install *only* the builtins
+  echo "Installing builtins for ${VARIANT}"
+  BUILTINS_BUILD_DIR="${VARIANT_BASE_BUILD_DIR}/builtins"
+  # Setting CMAKE_TRY_COMPILE_TARGET_TYPE as we have no other libraries
+  # at the moment so test links won't end well. And, we're only building
+  # the builtins.
+  cmake -G Ninja \
+      -DCMAKE_INSTALL_PREFIX="${VARIANT_TMP_RESOURCE_DIR}" \
+      -DCMAKE_SYSROOT="${VARIANT_TMP_SYSROOT}" \
+      -DCMAKE_BUILD_TYPE="${CMAKE_OPT_LEVEL}" \
+      -DCMAKE_C_COMPILER="clang" \
+      -DCMAKE_CXX_COMPILER="clang++" \
+      -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" \
+      -DCMAKE_SYSTEM_NAME=Linux \
+      -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+      -DCMAKE_ASM_COMPILER_TARGET="${VARIANT_TARGET}" \
+      -DCMAKE_C_COMPILER_TARGET="${VARIANT_TARGET}" \
+      -DCMAKE_CXX_COMPILER_TARGET="${VARIANT_TARGET}" \
+      -DCMAKE_ASM_FLAGS="${LIB_BUILD_FLAGS}" \
+      -DCMAKE_C_FLAGS="${LIB_BUILD_FLAGS}" \
+      -DCMAKE_CXX_FLAGS="${LIB_BUILD_FLAGS}" \
+      -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON \
+      -DCOMPILER_RT_BUILD_BUILTINS=ON \
+      -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+      -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+      -DCOMPILER_RT_BUILD_PROFILE=OFF \
+      -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF \
+      -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+      -DCOMPILER_RT_BUILD_XRAY=OFF \
+      -DCOMPILER_RT_BUILD_ORC=OFF \
+      -DLLVM_ENABLE_RUNTIMES=compiler-rt \
+      -B "${BUILTINS_BUILD_DIR}" \
+      -S "${LLVM_BASE_DIR}/runtimes"
+  ninja -C "${BUILTINS_BUILD_DIR}" install
+
+  # Install musl, including the libraries this time.
+  echo "Installing musl libraries for ${VARIANT}"
+  pushd "${VARIANT_MUSL_BUILD_DIR}" >/dev/null
+  make distclean
+  # TODO: we should probably standardize which linker we're using (lld vs eld)
+  # but that can wait--this matches what we've done in the past.
+  "${MUSL_DIR}"/configure \
+      ${EXTRA_MUSL_CONFIGS} \
+      --disable-wrapper \
+      --prefix="${VARIANT_TMP_SYSROOT}" \
+      CROSS_COMPILE="llvm-" \
+      CC="clang --target=${VARIANT_TARGET} -fuse-ld=eld" \
+      CFLAGS="${LIB_BUILD_FLAGS} ${ARCH_MUSL_CFLAGS[$VARIANT_ARCH]}" \
+      LIBCC="${VARIANT_TMP_RESOURCE_DIR}/lib/${VARIANT_TARGET}/libclang_rt.builtins.a"
+  make -j"${JOBS}"
+  make install
+  popd >/dev/null
+
+  # Install libc++
+  echo "Installing libc++ for ${VARIANT}"
+  LIBCXX_BUILD_DIR="${VARIANT_BASE_BUILD_DIR}/libcxx"
+  LIBCXX_COMPILE_FLAGS="${LIB_BUILD_FLAGS} -D_GNU_SOURCE"
+  # Setting CMAKE_TRY_COMPILE_TARGET_TYPE here as we explicitly disable
+  # shared libraries and CMake link checks fail since we can't find
+  # -lc++.
+  cmake -G Ninja \
+      -DCMAKE_INSTALL_PREFIX="${VARIANT_TMP_SYSROOT}" \
+      -DCMAKE_SYSROOT="${VARIANT_TMP_SYSROOT}" \
+      -DCMAKE_BUILD_TYPE="${CMAKE_OPT_LEVEL}" \
+      -DCMAKE_C_COMPILER="clang" \
+      -DCMAKE_CXX_COMPILER="clang++" \
+      -DCMAKE_SYSTEM_NAME="Linux" \
+      -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" \
+      -DCMAKE_ASM_COMPILER_TARGET="${VARIANT_TARGET}" \
+      -DCMAKE_C_COMPILER_TARGET="${VARIANT_TARGET}" \
+      -DCMAKE_CXX_COMPILER_TARGET="${VARIANT_TARGET}" \
+      -DCMAKE_ASM_FLAGS="${LIBCXX_COMPILE_FLAGS}" \
+      -DCMAKE_C_FLAGS="${LIBCXX_COMPILE_FLAGS}" \
+      -DCMAKE_CXX_FLAGS="${LIBCXX_COMPILE_FLAGS}" \
+      -DLIBCXX_ENABLE_SHARED="False" \
+      -DLIBCXX_HAS_MUSL_LIBC="True" \
+      -DLIBCXXABI_USE_LLVM_UNWINDER="True" \
+      -DLIBCXXABI_ENABLE_SHARED="False" \
+      -DLIBCXXABI_ENABLE_WERROR="True" \
+      -DLIBCXX_USE_COMPILER_RT="ON" \
+      -DLIBUNWIND_ENABLE_SHARED="False" \
+      -DLIBCXXABI_USE_COMPILER_RT="ON" \
+      -DLIBCXXABI_USE_LLVM_UNWINDER="ON" \
+      -DLIBUNWIND_USE_COMPILER_RT="ON" \
+      -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+      -B "${LIBCXX_BUILD_DIR}" \
+      -S "${LLVM_BASE_DIR}/runtimes"
+  ninja -C "${LIBCXX_BUILD_DIR}" install
+
+  # Install the rest of compiler-rt now.
+
+  # The goal here is to disable rtsan and gwp_asan:
+  #   * For rtsan, our musl-embedded is too old to support the fopencookie
+  #     extension, which rtsan relies on.
+  #   * For gwp_asan, it requires execinfo.h which is a glibc-specific
+  #     header--no musl version ships this (or an equivalent).
+  # The actual list corresponds to `ALL_SANITIZERS` in LLVM, minus rtsan and
+  # gwp_asan. Just do this for all targets since aarch64 is the only arch that
+  # rtsan supports that we care about and gwp_asan seems to be generally broken
+  # when building against musl. Might be worth trying to pull the list out of
+  # LLVM sources, but for now this should be sufficient.
+  SAN_TO_BUILD="asan;dfsan;msan;hwasan;tsan;tysan;safestack;cfi;scudo_standalone;ubsan_minimal;nsan;asan_abi"
+
+  # For Arm specifically, we need to disable anything that touches sanitizer
+  # common. Our musl-embedded is old enough that time_t is 32bits and the
+  # sanitizer common code thinks we should have a 64bit time_t (see
+  # https://github.com/llvm/llvm-project/blob/c94739a5d523883663d237ad9072275ff6c847b1/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h#L393-L398)
+  # and this disagreement causes issues down the line in ex:
+  # https://github.com/llvm/llvm-project/blob/c94739a5d523883663d237ad9072275ff6c847b1/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp#L1292
+  # and we fail the static asserts.
+  EXTRA_CRT_CONFIGS=""
+  if [[ "${VARIANT_ARCH}" =~ arm ]]; then
+    EXTRA_CRT_CONFIGS="-DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+                       -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF \
+                       -DCOMPILER_RT_BUILD_MEMPROF=OFF"
+  fi
+
+  # FIXME: Disable fuzzers as well to work around (seemingly) an upstream bug.
+  # `partially_link_libcxx` in fuzzer/CMakeLists.txt has a custom command that
+  # invokes the linker, but it just uses the toolchain default. So, we get
+  # errors as it picks up the host ld.bfd when linking for riscv64 rather than
+  # our just-built lld with no way to override this. Note that re-enabling
+  # this also requires messing with some libc++ configuration similar to
+  # above.
+  # FIXME: Investigate if we can merge this with the libc++ build above as
+  # it'd simplify things a bit. Not sure how that works with install dirs
+  echo "Installing compiler-rt for ${VARIANT}"
+  COMPILER_RT_BUILD_DIR="${VARIANT_BASE_BUILD_DIR}/compiler-rt"
+  cmake -G Ninja \
+      -DCMAKE_INSTALL_PREFIX="${VARIANT_TMP_RESOURCE_DIR}" \
+      -DCMAKE_SYSROOT="${VARIANT_TMP_SYSROOT}" \
+      -DCMAKE_BUILD_TYPE="${CMAKE_OPT_LEVEL}" \
+      -DCMAKE_C_COMPILER="clang" \
+      -DCMAKE_CXX_COMPILER="clang++" \
+      -DCMAKE_SYSTEM_NAME="Linux" \
+      -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+      -DCMAKE_ASM_COMPILER_TARGET="${VARIANT_TARGET}" \
+      -DCMAKE_C_COMPILER_TARGET="${VARIANT_TARGET}" \
+      -DCMAKE_CXX_COMPILER_TARGET="${VARIANT_TARGET}" \
+      -DCMAKE_ASM_FLAGS="${LIB_BUILD_FLAGS}" \
+      -DCMAKE_C_FLAGS="${LIB_BUILD_FLAGS}" \
+      -DCMAKE_CXX_FLAGS="${LIB_BUILD_FLAGS}" \
+      -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON \
+      -DCOMPILER_RT_CXX_LIBRARY="libcxx" \
+      -DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON \
+      -DCOMPILER_RT_BUILD_BUILTINS=OFF \
+      -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+      -DCOMPILER_RT_SANITIZERS_TO_BUILD="${SAN_TO_BUILD}" \
+      -DCOMPILER_RT_BUILD_ORC=OFF \
+      -DCOMPILER_RT_BUILD_XRAY=OFF \
+      -DLLVM_ENABLE_RUNTIMES=compiler-rt \
+      -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld --rtlib=compiler-rt -stdlib=libc++" \
+      -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld --rtlib=compiler-rt -stdlib=libc++" \
+      -DCMAKE_MODULE_LINKER_FLAGS="-fuse-ld=lld --rtlib=compiler-rt -stdlib=libc++" \
+      ${EXTRA_CRT_CONFIGS} \
+      -B "${COMPILER_RT_BUILD_DIR}" \
+      -S "${LLVM_BASE_DIR}/runtimes"
+  ninja -C "${COMPILER_RT_BUILD_DIR}" install
+done
+
+# Move libraries into the final layout/install. The layout looks something
+# like this:
+#   - libc/libc++: <install>/<target>/<variant>
+#   - compiler-rt: <resource dir>/lib/<target>/<variant>
+# This layout isn't ideal, but it is close to what we had in the
+# past. When we know what to do with the installed libc++ module files
+# and sanitizer binaries we can revisit this.
+echo "Copying libraries to their final locations"
+for VARIANT in "${VARIANTS[@]}"; do
+  VARIANT_TMP_SYSROOT="${BASE_BUILD_DIR}/${VARIANT}/sysroot"
+  VARIANT_TARGET="$(get_target_from_flags ${VARIANT_BUILD_FLAGS[$VARIANT]})"
+  mkdir -p "${BASE_INSTALL_DIR}/${VARIANT_TARGET}/${VARIANT}"
+  cp -r "${VARIANT_TMP_SYSROOT}"/include \
+        "${VARIANT_TMP_SYSROOT}"/lib \
+        -t "${BASE_INSTALL_DIR}/${VARIANT_TARGET}/${VARIANT}"
+
+  mv "${VARIANT_TMP_SYSROOT}/resource-dir/lib/${VARIANT_TARGET}" \
+     "${VARIANT_TMP_SYSROOT}/resource-dir/lib/temp"
+  mkdir -p "${VARIANT_TMP_SYSROOT}/resource-dir/lib/${VARIANT_TARGET}"
+  mv "${VARIANT_TMP_SYSROOT}/resource-dir/lib/temp" \
+     "${VARIANT_TMP_SYSROOT}/resource-dir/lib/${VARIANT_TARGET}/${VARIANT}"
+  cp -r "${VARIANT_TMP_SYSROOT}/resource-dir" "${BASE_INSTALL_DIR}"
+done

--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -10,6 +10,11 @@
       "tagType": "tag",
       "tag": "1.8.10"
     },
+    "musl": {
+      "url": "https://git.musl-libc.org/git/musl",
+      "tagType": "tag",
+      "tag": "v1.2.5"
+    },
     "musl-embedded": {
       "url": "https://github.com/qualcomm/musl-embedded",
       "tagType": "branch",


### PR DESCRIPTION
For now, this just brings back our old build_linux_runtimes.sh script with a
few minor changes and improvements. This isn't ideal, but it is going to
take more time to neatly integrate Linux builds with how embedded works. So,
use this as a stopgap for now.

Notable changes to build_linux_runtimes.sh since it last appeared:
* The script no longer installs directly into the toolchain. It now
  assembles things into a temporary layout that we can then use in CMake.
* Similarly, the script now uses -resource dir to create and use a temporary
  resource dir rather than installing into the toolchain directly.
* Upstream musl is now a dependency like musl-embedded, etc. (it can
  be patched). Note that the Linux headers still are not.
* There's a bug fix where we were passing an empty target into the
  libc++ build. I'm surprised that hasn't caused us any failures.
