### PR TITLE
[cpullvm] Add AArch64 Linux build to our premerge builds

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -7,7 +7,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: Linux x86_64 Premerge Checks
+name: Linux Premerge Checks
 
 on:
   pull_request:
@@ -30,7 +30,27 @@ jobs:
   build-and-test:
     # Don't run on forks
     if: github.repository == 'qualcomm/cpullvm-toolchain'
-    runs-on: self-hosted
+    name: ${{ matrix.build_script }} on ${{ matrix.target_os }}
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build_script: build.sh
+            test_script: test.sh
+            target_os: Linux-x86_64
+            runner: self-hosted
+
+          - build_script: build_no_runtimes.sh
+            test_script: test_no_runtimes.sh
+            target_os: Linux-AArch64
+            runner: ubuntu-22.04-arm
+
+          - build_script: build_musl-embedded_overlay.sh
+            test_script: ''
+            target_os: Linux-x86_64
+            runner: self-hosted
 
     steps:
       - name: Cleanup workspace
@@ -51,11 +71,9 @@ jobs:
       - name: Apply llvm-project patches
         run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
 
-      - name: Build
-        run: ./qualcomm-software/scripts/build.sh
-
-      - name: Build musl-embedded overlay
-        run: ./qualcomm-software/scripts/build_musl-embedded_overlay.sh
+      - name: Build toolchain
+        run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Test
-        run: ./qualcomm-software/scripts/test.sh
+        if: matrix.test_script != ''
+        run: ./qualcomm-software/scripts/${{ matrix.test_script }}

--- a/qualcomm-software/scripts/build_no_runtimes.sh
+++ b/qualcomm-software/scripts/build_no_runtimes.sh
@@ -10,7 +10,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # The script creates a build of the toolchain in the 'build' directory, inside
-# the repository tree.
+# the repository tree *excluding* all of the target runtime libraries.
+#
+# FIXME: This is intended as a convenience script while dependencies on various
+# builders are sorted out. This probably should be removed.
 
 set -ex
 
@@ -25,6 +28,11 @@ export CXX=clang++
 mkdir -p "${REPO_ROOT}"/build
 cd "${REPO_ROOT}"/build
 
-cmake ../qualcomm-software -GNinja -DFETCHCONTENT_QUIET=OFF -DENABLE_LINUX_LIBRARIES=ON ${EXTRA_CMAKE_ARGS}
+cmake ../qualcomm-software \
+ -GNinja \
+ -DFETCHCONTENT_QUIET=OFF \
+ -DLLVM_TOOLCHAIN_DISTRIBUTION_COMPONENTS="llvm-toolchain-docs;llvm-toolchain-third-party-licenses" \
+ -DPREBUILT_TARGET_LIBRARIES=ON \
+ ${EXTRA_CMAKE_ARGS}
 
 ninja package-llvm-toolchain

--- a/qualcomm-software/scripts/test_no_runtimes.sh
+++ b/qualcomm-software/scripts/test_no_runtimes.sh
@@ -9,22 +9,14 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# The script creates a build of the toolchain in the 'build' directory, inside
-# the repository tree.
+# The script assumes a successful build of the toolchain exists in the 'build'
+# directory inside the repository tree and will only run tests that do not
+# require the runtime libraries be present.
 
 set -ex
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
-clang --version
-
-export CC=clang
-export CXX=clang++
-
-mkdir -p "${REPO_ROOT}"/build
 cd "${REPO_ROOT}"/build
-
-cmake ../qualcomm-software -GNinja -DFETCHCONTENT_QUIET=OFF -DENABLE_LINUX_LIBRARIES=ON ${EXTRA_CMAKE_ARGS}
-
-ninja package-llvm-toolchain
+ninja check-all


### PR DESCRIPTION
There's dependencies that need to be sorted out in the AArch64 builder (meson, etc.). So for now, just disable building the runtimes on AArch64. build_no_runtimes.sh should be deleted once this is resolved.

Also add an EXTRA_CMAKE_ARGS passthrough in our scripts--this is helpful even when working locally to modify things as appropriate.