### PR TITLE
[cpullvm] Add nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,99 @@
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This workflow runs all build scripts in parallel for multiple operating
+# systems and architectures.
+# It is intended to be triggered as part of a **nightly build** to
+# validate all build configurations and test them automatically.
+
+name: Nightly Build and Test
+
+on:
+  workflow_dispatch: 
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    # Don't run on forks
+    if: github.repository == 'qualcomm/cpullvm-toolchain'
+    name: ${{ matrix.build_script }} on ${{ matrix.target_os }}
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build_script: build.sh
+            test_script: test.sh
+            target_os: Linux-x86_64
+            runner: self-hosted
+
+          - build_script: build_no_runtimes.sh
+            test_script: test_no_runtimes.sh
+            target_os: Linux-AArch64
+            runner: ubuntu-22.04-arm
+
+          - build_script: build_musl-embedded_overlay.sh
+            test_script: ''
+            target_os: Linux-x86_64
+            runner: self-hosted
+
+          # FIXME: there's lit failures in Windows, probably from missing some
+          # dependency. Just disable testing for now for both x64/AArch64
+          - build_script: build.ps1
+            test_script: ''
+            target_os: Windows-x86_64
+            runner: windows-latest
+
+          - build_script: build.ps1
+            test_script: ''
+            target_os: Windows-AArch64
+            runner: windows-11-arm
+
+    steps:
+      # FIXME: Need to discuss if this is actually needed.
+      - name: Cleanup workspace
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Cleaning workspace: ${GITHUB_WORKSPACE}"
+          shopt -s dotglob nullglob
+          rm -rf "${GITHUB_WORKSPACE:?}/"*
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Apply llvm-project patches
+        run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
+
+      # Needed for eld tests.
+      # If there are more dependencies, add an install script.
+      - name: Install PyYAML (Windows)
+        if: runner.os == 'Windows'
+        run: pip install pyyaml
+
+      - name: Build
+        run: ./qualcomm-software/scripts/${{ matrix.build_script }}
+
+      - name: Test
+        if: matrix.test_script != ''
+        run: ./qualcomm-software/scripts/${{ matrix.test_script }}
+
+      - name: Upload built packages
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}
+          path: |
+            build*/cpullvm-*.tar.xz
+            build*/cpullvm-*.zip
+          retention-days: 7

--- a/qualcomm-software/scripts/build.ps1
+++ b/qualcomm-software/scripts/build.ps1
@@ -1,0 +1,35 @@
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A Powershell script to build the toolchain
+
+# The script creates a build of the toolchain in the 'build' directory, inside
+# the repository tree.
+
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot\init_win_env.ps1"
+Set-VS-Env
+
+$repoRoot = git -C $PSScriptRoot rev-parse --show-toplevel
+$buildDir = (Join-Path $repoRoot build)
+
+mkdir $buildDir
+cd $buildDir
+
+# Omit target runtimes on Windows builds.
+cmake ..\qualcomm-software `
+  -GNinja `
+  -DFETCHCONTENT_QUIET=OFF `
+  -DLLVM_TOOLCHAIN_DISTRIBUTION_COMPONENTS="llvm-toolchain-docs;llvm-toolchain-third-party-licenses" `
+  -DPREBUILT_TARGET_LIBRARIES=ON `
+  -DCMAKE_C_COMPILER=clang-cl `
+  -DCMAKE_CXX_COMPILER=clang-cl
+
+ninja package-llvm-toolchain

--- a/qualcomm-software/scripts/init_win_env.ps1
+++ b/qualcomm-software/scripts/init_win_env.ps1
@@ -1,0 +1,49 @@
+# A Powershell script to find and call vcvarsall to setup the environment for
+# building with Visual Studio tools and libraries.
+function Set-VS-Env {
+  # Host architecture detection
+  $hostArch = $env:PROCESSOR_ARCHITECTURE
+  switch -Regex ($hostArch) {
+    'ARM64' { $hostArch = 'ARM64' }
+    'AMD64' { $hostArch = 'x64' }
+    default {
+        Write-Error "*** ERROR: unrecognized PROCESSOR_ARCHITECTURE ***"
+        exit 1
+    }
+  }
+
+  $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+
+  # Choose VS component and vcvars target
+  $vsRequires  = $null
+  $vcvarsTarget = $null
+  if ($hostArch -eq 'ARM64') {
+      $vsRequires   = 'Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+      $vcvarsTarget = 'arm64'
+  } else {
+      $vsRequires   = 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+      $vcvarsTarget = 'x64'
+  }
+
+  # Query the latest VS with required component
+  $VS_INSTALL = & $vswhere -latest -products * `
+    -requires $vsRequires `
+    -property installationPath
+  if (-not $VS_INSTALL) {
+    Write-Error "*** ERROR: Visual Studio installation with '$vsRequires' not found via vswhere ***"
+    exit 1
+  }
+
+  # Get vcvarsall.bat and import the environment for selected host
+  $VCVARSALL = Join-Path $VS_INSTALL "VC\Auxiliary\Build\vcvarsall.bat"
+  if (-not (Test-Path $VCVARSALL)) {
+    Write-Error "*** ERROR: vcvarsall.bat not found at $VCVARSALL ***"
+    exit 1
+  }
+
+  cmd /c "call `"$VCVARSALL`" $vcvarsTarget && set" | ForEach-Object {
+    if ($_ -match '^(.*?)=(.*)$') {
+      [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2], 'Process')
+    }
+  }
+}

--- a/qualcomm-software/scripts/test.ps1
+++ b/qualcomm-software/scripts/test.ps1
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+
+# A Powershell script to run the tests for the toolchain. The script assumes a
+# successful build of the toolchain exists in the 'build' directory inside the
+# repository tree.
+
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot\init_win_env.ps1"
+Set-VS-Env
+
+$repoRoot = git -C $PSScriptRoot rev-parse --show-toplevel
+$buildDir = (Join-Path $repoRoot build)
+
+cd $buildDir
+
+ninja check-all


### PR DESCRIPTION
This covers Windows x64/AArch64 and Linux x64/AArch64.

Make this workflow_dispatch-able only (and not scheduled) as we have
scheduled workflow_dispatch-ed runs.

For now, all Windows configs and AArch64 Linux are built and packaged
without runtimes. We'll address this in subsequent PRs.

Also, there's (I think) dependencies that need sorting out/are missing when
I started porting from our old build.ps1. Disable tests for now to unblock
other work and we'll come back to this.