### PR TITLE
[cpullvm][Github] Remove explicit clean steps from workflows

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -53,19 +53,13 @@ jobs:
             runner: self-hosted
 
     steps:
-      - name: Cleanup workspace
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Cleaning workspace: ${GITHUB_WORKSPACE}"
-          shopt -s dotglob nullglob
-          rm -rf "${GITHUB_WORKSPACE:?}/"*
-
       - name: Checkout source
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          # We build in the repository and rely on clean to cleanup possible
+          # old build products if the runner doesn't do it itself.
           clean: true
 
       - name: Apply llvm-project patches

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,18 +59,12 @@ jobs:
             runner: windows-11-arm
 
     steps:
-      # FIXME: Need to discuss if this is actually needed.
-      - name: Cleanup workspace
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Cleaning workspace: ${GITHUB_WORKSPACE}"
-          shopt -s dotglob nullglob
-          rm -rf "${GITHUB_WORKSPACE:?}/"*
-
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          # We build in the repository and rely on clean to cleanup possible
+          # old build products if the runner doesn't do it itself.
+          clean: true
 
       - name: Apply llvm-project patches
         run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project


### PR DESCRIPTION
Our Linux workflows have generally had a "clean" step as our self hosted builders would otherwise be doing incremental builds between workflows, which isn't good. Our old Windows build.ps1 scripts also did this to some degree pre-emptively (currently we use Github runners which are "fresh" run-to-run).

After the refactor, our builds changed slightly--rather than defaulting to building *out* of the repo (so build/ install/ cpullvm-toolchain/ are all separate), our build scripts now prefer builds *in* the repo (cpullvm-toolchain/build* is the path used). As a result, when 'clean' is true when running actions/checkout (it is true by default, and we explicitly set it to true in some workflows), the various build folders will be cleaned up as part of the checkout step.

I think relying on this behavior is nice in that it lets us handle Linux/Windows and self-hosted/Github runners consistently in this regard with less code.