### PR TITLE
[NFC] Remove zero width space unicode

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #

--- a/qualcomm-software/embedded-multilib/CMakeLists.txt
+++ b/qualcomm-software/embedded-multilib/CMakeLists.txt
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #

--- a/qualcomm-software/embedded-multilib/multilib.yaml.in
+++ b/qualcomm-software/embedded-multilib/multilib.yaml.in
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #

--- a/qualcomm-software/embedded-runtimes/test-support/picolibc-test-wrapper.py
+++ b/qualcomm-software/embedded-runtimes/test-support/picolibc-test-wrapper.py
@@ -2,7 +2,7 @@
 
 # SPDX-FileCopyrightText: Copyright 2023-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -2,7 +2,7 @@
 
 # SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 

--- a/qualcomm-software/scripts/build.ps1
+++ b/qualcomm-software/scripts/build.ps1
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 

--- a/qualcomm-software/scripts/build.sh
+++ b/qualcomm-software/scripts/build.sh
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 

--- a/qualcomm-software/scripts/build_musl-embedded_overlay.sh
+++ b/qualcomm-software/scripts/build_musl-embedded_overlay.sh
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 

--- a/qualcomm-software/scripts/build_no_runtimes.sh
+++ b/qualcomm-software/scripts/build_no_runtimes.sh
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 

--- a/qualcomm-software/scripts/test.ps1
+++ b/qualcomm-software/scripts/test.ps1
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 

--- a/qualcomm-software/scripts/test.sh
+++ b/qualcomm-software/scripts/test.sh
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 

--- a/qualcomm-software/scripts/test_no_runtimes.sh
+++ b/qualcomm-software/scripts/test_no_runtimes.sh
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# ​​​​​Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 


### PR DESCRIPTION
They don't seem to show up in the commit diff but this is how git diff looks like locally for one of the files:

```
diff --git a/qualcomm-software/scripts/build_no_runtimes.sh b/qualcomm-software/scripts/build_no_run
times.sh
index 41ea4ac5928e..0bf9035ca793 100755
--- a/qualcomm-software/scripts/build_no_runtimes.sh
+++ b/qualcomm-software/scripts/build_no_runtimes.sh
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# <U+200B><U+200B><U+200B><U+200B><U+200B>Changes from Qualcomm Technologies, Inc. are provided und
er the following license:
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
```
