### PR TITLE
Add riscv32imac_ilp32 baremetal runtime variant

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -26,6 +26,12 @@
             "flags": "--target=thumbv7-unknown-none-eabi -mfpu=neon -fno-exceptions"
         },
         {
+            "variant": "riscv32imac_ilp32",
+            "json": "riscv32imac_ilp32.json",
+            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac -mabi=ilp32 -fno-exceptions",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "riscv32imac_ilp32_nopic",
             "json": "riscv32imac_ilp32_nopic.json",
             "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fno-exceptions",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "riscv32",
+            "VARIANT": "riscv32imac_ilp32",
+            "COMPILE_FLAGS": "-march=rv32imac -mabi=ilp32",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "rv32",
+            "QEMU_PARAMS": "-bios none",
+            "FLASH_ADDRESS": "0x80000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x80400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/test/multilib/riscv32.test
+++ b/qualcomm-software/test/multilib/riscv32.test
@@ -6,6 +6,10 @@
 # CHECK-IMAC-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
+# CHECK-IMAC-PIC: riscv32-unknown-elf/riscv32imac_ilp32{{$}}
+# CHECK-IMAC-PIC-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
 # CHECK-IMAC-ZBA-ZBB: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32{{$}}
 # CHECK-IMAC-ZBA-ZBB-EMPTY:
@@ -15,7 +19,6 @@
 # CHECK-IMAC-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags


### PR DESCRIPTION
This patch adds the riscv32imac_ilp32 PIC variant.