### PR TITLE
Add riscv64gc_lp64d_nopic baremetal runtime variant

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -54,6 +54,12 @@
             "json": "riscv64imac_lp64_nopic.json",
             "flags": "--target=riscv64-unknown-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic -fno-exceptions",
             "libraries_supported": "picolibc"
+        },
+        {
+            "variant": "riscv64gc_lp64d_nopic",
+            "json": "riscv64gc_lp64d_nopic.json",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic -fno-exceptions",
+            "libraries_supported": "picolibc"
         }
     ]
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "riscv64",
+            "VARIANT": "riscv64gc_lp64d_nopic",
+            "COMPILE_FLAGS": "-march=rv64gc -mabi=lp64d -mcmodel=medany",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "ON",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "rv64",
+            "QEMU_PARAMS": "-bios none",
+            "FLASH_ADDRESS": "0x80000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x80400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -118,6 +118,19 @@ def main():
             project="clang",
             description="If the installed default multilib does not have a library available for -mcpu=cortex-r52, this test will fail.",
         ),
+        XFail(
+            name="picolibc_rv64gc",
+            testnames=[
+                "math_errhandling.test",
+                "test-fma.test",
+            ],
+            result=NewResult.XFAILED,
+            project="picolibc",
+            variants=[
+                "riscv64gc_lp64d_nopic",
+            ],
+            description="Disable the tests for now while the issue is being fixed upstream (https://github.com/picolibc/picolibc/pull/1072).",
+        ),
     ]
 
     tests_to_xfail = []

--- a/qualcomm-software/test/multilib/riscv64.test
+++ b/qualcomm-software/test/multilib/riscv64.test
@@ -5,6 +5,10 @@
 # CHECK-IMAC-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
+# CHECK-GC-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64d_nopic{{$}}
+# CHECK-GC-LP64D-FNO-PIC-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic -fno-exceptions  2>&1| FileCheck %s --check-prefix=NOT-FOUND


### PR DESCRIPTION
This patch adds the riscv64gc_lp64d_nopic variant. We xfail two picolibc tests (math_errhandling.test and test-fma.test) for now. These are known issues and being fixed upstream.