### PR TITLE
Fix riscv64gc_lp64d_nopic variant build error

### DIFF
--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -203,7 +203,10 @@ if(ENABLE_LIBC_TESTS OR ENABLE_COMPILER_RT_TESTS OR ENABLE_LIBCXX_TESTS)
     list(JOIN lit_test_executor " " lit_test_executor)
 endif()
 
-set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS} --sysroot ${TEMP_LIB_DIR}")
+# Adding "-isystem ${TEMP_LIB_DIR}/include" to work around a sysroot issue for
+# RISC-V baremetal. We may not need this workaround in the future if the issue
+# is fixed upstream.
+set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS} --sysroot ${TEMP_LIB_DIR} -isystem ${TEMP_LIB_DIR}/include")
 # Compiling the libraries benefits from some extra optimization
 # flags, and requires a sysroot.
 set(lib_compile_flags "${compile_arch_flags} -ffunction-sections -fdata-sections")


### PR DESCRIPTION
While adding the riscv64gc_lp64d_nopic variant, the following build error was observed.
```
In file included from
/local/mnt/workspace/actions-runner-2/_work/cpullvm-toolchain/cpullvm-toolchain/libunwind/src/Unwind-wasm.c:15: /local/mnt/workspace/actions-runner-2/_work/cpullvm-toolchain/cpullvm-toolchain/libunwind/src/config.h:16:10: fatal error: 'assert.h' file not found
   16 | #include <assert.h>
      |          ^~~~~~~~~~
1 error generated.
```
Adding `-isystem` fixes the error.