### PR TITLE
[cpullvm] Fix variant name

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "riscv32",
-            "VARIANT": "riscv32imac_zba_zbb_ilp32_fpic",
+            "VARIANT": "riscv32imac_zba_zbb_ilp32",
             "COMPILE_FLAGS": "-march=rv32imac_zba_zbb -mabi=ilp32 -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "ON",


### PR DESCRIPTION
There was an accidental mismatch here from when I renamed the fpic/nopic configs. Align the variant name here (used for build folders, xfail-ing tests, etc.) with the variant name in multilib.json for consistency.