### PR TITLE
[cpullvm][Github] Remove Linux AArch64 builds from our precheckin

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -38,11 +38,6 @@ jobs:
             target_os: Linux-x86_64
             runner: self-hosted
 
-          - build_script: build_no_runtimes.sh
-            test_script: test_no_runtimes.sh
-            target_os: Linux-AArch64
-            runner: ubuntu-22.04-arm
-
           - build_script: build_musl-embedded_overlay.sh
             test_script: ''
             target_os: Linux-x86_64


### PR DESCRIPTION
As we're currently using Github runners for these builds and don't have ccache setup to work between these runners (storing/fetching the ccache caches), these builds take around 2 hours to complete, which is a bit painful to wait for. And, I don't think we get that much useful additional test coverage having this in our precheckin.

So, remove this from our precheckin and rely on our nightlies to catch if anything goes awry with these configs.