### PR TITLE
[cpullvm][Github] Move extra dependencies into an install script. NFC

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,26 +33,31 @@ jobs:
         include:
           - build_script: build.sh
             test_script: test.sh
+            install_script: ''
             target_os: Linux-x86_64
             runner: self-hosted
 
           - build_script: build_no_runtimes.sh
             test_script: test_no_runtimes.sh
+            install_script: ''
             target_os: Linux-AArch64
             runner: ubuntu-22.04-arm
 
           - build_script: build_musl-embedded_overlay.sh
             test_script: ''
+            install_script: ''
             target_os: Linux-x86_64
             runner: self-hosted
 
           - build_script: build.ps1
             test_script: test.ps1
+            install_script: install_dependencies.ps1
             target_os: Windows-x86_64
             runner: windows-latest
 
           - build_script: build.ps1
             test_script: test.ps1
+            install_script: install_dependencies.ps1
             target_os: Windows-AArch64
             runner: windows-11-arm
 
@@ -73,14 +78,12 @@ jobs:
           # old build products if the runner doesn't do it itself.
           clean: true
 
+      - name: Install dependencies
+        if: matrix.install_script != ''
+        run: ./qualcomm-software/scripts/${{ matrix.install_script }}
+
       - name: Apply llvm-project patches
         run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
-
-      # Needed for eld tests.
-      # If there are more dependencies, add an install script.
-      - name: Install PyYAML (Windows)
-        if: runner.os == 'Windows'
-        run: pip install pyyaml
 
       - name: Build
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}

--- a/qualcomm-software/scripts/install_dependencies.ps1
+++ b/qualcomm-software/scripts/install_dependencies.ps1
@@ -1,0 +1,5 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Install pyyaml
+pip install pyyaml


### PR DESCRIPTION
We're getting ready to add additional build(er)s that will build runtimes
natively on non-self-hosted runners, which means we'll have more dependencies
we need to install each run. Move our existing dependency installation into
standalone scripts to create a consistent way of handling this and cutting
down on the number of places we have to maintain these dependencies.