### PR TITLE
[cpullvm][Github] Add Windows native runtimes builds

### DIFF
--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -47,7 +47,28 @@ jobs:
             target_os: Linux-AArch64
             runner: ubuntu-22.04-arm
 
+          - build_script: build.ps1
+            test_script: test.ps1
+            install_script: install_dependencies.ps1
+            target_os: Windows-x86_64
+            runner: windows-latest
+
+          - build_script: build.ps1
+            test_script: test.ps1
+            install_script: install_dependencies.ps1
+            target_os: Windows-AArch64
+            runner: windows-11-arm
+
     steps:
+      # Not setting these can cause lit test failures on Windows machines when
+      # files with ex: different line endings are compared.
+      - name: Preconfigure git
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          git config --global core.longpaths true
+
       - name: Checkout source
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,14 +51,14 @@ jobs:
             target_os: Linux-x86_64
             runner: self-hosted
 
-          - build_script: build.ps1
-            test_script: test.ps1
+          - build_script: build_no_runtimes.ps1
+            test_script: test_no_runtimes.ps1
             install_script: install_dependencies.ps1
             target_os: Windows-x86_64
             runner: windows-latest
 
-          - build_script: build.ps1
-            test_script: test.ps1
+          - build_script: build_no_runtimes.ps1
+            test_script: test_no_runtimes.ps1
             install_script: install_dependencies.ps1
             target_os: Windows-AArch64
             runner: windows-11-arm

--- a/qualcomm-software/scripts/build_no_runtimes.ps1
+++ b/qualcomm-software/scripts/build_no_runtimes.ps1
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # Changes from Qualcomm Technologies, Inc. are provided under the following license:
-# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # A Powershell script to build the toolchain
@@ -23,11 +23,12 @@ $buildDir = (Join-Path $repoRoot build)
 mkdir $buildDir
 cd $buildDir
 
-# Omit Linux runtimes, QEMU testing on Windows builds.
+# Omit target runtimes on Windows builds.
 cmake ..\qualcomm-software `
   -GNinja `
   -DFETCHCONTENT_QUIET=OFF `
-  -DENABLE_QEMU_TESTING=OFF `
+  -DLLVM_TOOLCHAIN_DISTRIBUTION_COMPONENTS="llvm-toolchain-docs;llvm-toolchain-third-party-licenses" `
+  -DPREBUILT_TARGET_LIBRARIES=ON `
   -DCMAKE_C_COMPILER=clang-cl `
   -DCMAKE_CXX_COMPILER=clang-cl
 

--- a/qualcomm-software/scripts/install_dependencies.ps1
+++ b/qualcomm-software/scripts/install_dependencies.ps1
@@ -3,3 +3,6 @@
 
 # Install pyyaml
 pip install pyyaml
+
+# Install meson. eld support was added in v1.9.0, so we need at least that.
+pip install meson==1.10.0

--- a/qualcomm-software/scripts/test.ps1
+++ b/qualcomm-software/scripts/test.ps1
@@ -22,4 +22,4 @@ $buildDir = (Join-Path $repoRoot build)
 
 cd $buildDir
 
-ninja check-all
+ninja check-all-llvm-toolchain

--- a/qualcomm-software/scripts/test_no_runtimes.ps1
+++ b/qualcomm-software/scripts/test_no_runtimes.ps1
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # Changes from Qualcomm Technologies, Inc. are provided under the following license:
-# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# A Powershell script to build the toolchain
 
-# The script creates a build of the toolchain in the 'build' directory, inside
-# the repository tree.
+# A Powershell script to run the tests for the toolchain. The script assumes a
+# successful build of the toolchain exists in the 'build' directory inside the
+# repository tree.
 
 $ErrorActionPreference = 'Stop'
 
@@ -20,15 +20,6 @@ Set-VS-Env
 $repoRoot = git -C $PSScriptRoot rev-parse --show-toplevel
 $buildDir = (Join-Path $repoRoot build)
 
-mkdir $buildDir
 cd $buildDir
 
-# Omit Linux runtimes, QEMU testing on Windows builds.
-cmake ..\qualcomm-software `
-  -GNinja `
-  -DFETCHCONTENT_QUIET=OFF `
-  -DENABLE_QEMU_TESTING=OFF `
-  -DCMAKE_C_COMPILER=clang-cl `
-  -DCMAKE_CXX_COMPILER=clang-cl
-
-ninja package-llvm-toolchain
+ninja check-all


### PR DESCRIPTION
QEMU tests are left disabled until we can sort out how to handle that
(both in terms of Windows, and in terms of Github-hosted runners).