### PR TITLE
[cpullvm] Minor correctness, completeness, verbiage fixups in our READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,8 @@
 
 ## Welcome to the CPULLVM Toolchain project!
 This repository provides the source code and build scripts for CPULLVM, a customized fork
-of LLVM designed to build toolchains targeting Arm, AArch64 and RISC-V (coming soon)
-bare-metal and linux environments.
-
-## Project Goal
-Our mission is to deliver a robust LLVM-based platform with all the essential libraries and tools
-required for building C and C++ toolchains optimized for linux and embedded development.
+of LLVM designed to build toolchains targeting Arm, AArch64, and RISC-V embedded environments.
 
 ## Quick Links
-* [Building CPULLVM Toolchain for Embedded](qualcomm-software/embedded/README.md)
-* [Getting binary releases](https://github.com/qualcomm/cpullvm-toolchain/releases) 
+* [Building CPULLVM](qualcomm-software/README.md)
+* [Binary releases](https://github.com/qualcomm/cpullvm-toolchain/releases)

--- a/qualcomm-software/README.md
+++ b/qualcomm-software/README.md
@@ -1,42 +1,49 @@
 
-# CPULLVM Toolchain for Embedded
+# CPULLVM Toolchain
 
-This repository contains build scripts and auxiliary material for building Linux and bare-metal LLVM-based toolchains, including:
+This repository contains build scripts and auxiliary material for building LLVM-based toolchains for embedded,
+including:
 
 - clang + llvm
-- eld linker
+- eld
 - lld
-- libc++abi
-- libc++
-- compiler-rt for Linux Arm/AArch64
-- compiler-rt for bare-metal Arm/AArch64
+- compiler-rt
+- picolibc
+- musl
 - musl-embedded
+- libc++/libunwind/libc++abi
+
+For Arm and AArch64 embedded environments, picolibc or musl-embedded may be used as the libc.
+For RISC-V, only picolibc may be used.
+
+Libraries intended for use in Linux environments may also be built as part of CPULLVM, though these
+are primarily intended for testing and validation. For Arm and AArch64, musl-embedded is used
+as the libc for Linux. For RISC-V, musl is used.
 
 ## Targets Built
-- Arm
-- AArch64
+CPULLVM supports generating code for Arm, AArch64, RISC-V, and x86 targets only. It does **not** generate code for other targets supported by the upstream LLVM compiler.
 
 ## Enabled Projects
 - llvm
 - clang
 - polly
 - lld
-- mlir
 - eld
 
-## Goal
-The CPULLVM Compiler generates code for Arm and AArch64 targets only. It does **not** generate code for other targets supported by the upstream LLVM compiler.
-
 ## Components
-The CPULLVM toolchain for Embedded relies on the following upstream components:
+CPULLVM relies on the following upstream components:
 
-- [CPULLVM](https://github.com/qualcomm/cpullvm-toolchain)
+- [LLVM](https://github.com/llvm/llvm-project)
+- [picolibc](https://github.com/picolibc/picolibc)
+- [musl](https://musl.libc.org/)
 - [musl-embedded](https://github.com/qualcomm/musl-embedded)
-- [eld linker](https://github.com/qualcomm/eld)
+- [eld](https://github.com/qualcomm/eld)
 
 ## Host Platforms
-CPULLVM Toolchain for Embedded is built and tested on
-- Linux Ubuntu 22.04 LTS
+CPULLVM is built and tested on
+- Linux Ubuntu 22.04 LTS on x86_64 and AArch64
+- Windows Server 2025 on x86_64
+- Windows 11 Desktop on Arm64
 
 ## Getting started
 
@@ -67,17 +74,6 @@ CPULLVM Toolchain for Embedded is built and tested on
    
     sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
     sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
-
-   #### Install libc++ and libc++abi
-   These provide C++ standard library support for Clang.
-      
-    sudo apt-get install libc++-19-dev libc++abi-19-dev
-
-   #### Install cross-compilers for Arm/AArch64
-   Required for building Arm and AArch64 targets.
-      
-    sudo apt-get install gcc-arm-linux-gnueabi
-    sudo apt-get install gcc-aarch64-linux-gnu
 
 ### Steps to build the CPULLVM compiler toolchain
 


### PR DESCRIPTION
Changes generally fall into a few categories:
- As we added new projects (picolibc, musl) and new targets (RISC-V), our
  READMEs weren't updated to reflect this. Do so
- "CPULLVM Toolchain for Embedded" is generally dropped--it was used
  inconsistently and we have some support for Linux.
- "bare-metal" is generally dropped in favor of "embedded" as it is more
  appropriate for what we're doing.
- Outdated dependency references were removed.
- Remove wording that suggests that CPULLVM is "optimized" for Linux
  development and clarify that we *do* ship Linux libraries, but these are
  primarily intended for testing/validation.

Larger reworks of our READMEs will come soon, this is just a quick first
pass.