### PR TITLE
Add -fPIC to compile flags for riscv32imac_ilp32 baremetal variant

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "riscv32",
             "VARIANT": "riscv32imac_ilp32",
-            "COMPILE_FLAGS": "-march=rv32imac -mabi=ilp32",
+            "COMPILE_FLAGS": "-march=rv32imac -mabi=ilp32 -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "ON",
             "TEST_EXECUTOR": "qemu",


### PR DESCRIPTION
The -fPIC flag was missed when adding the riscv32imac_ilp32 baremetal variant.