### PR TITLE
[Multilib] Add more arm32/aarch64 variants

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -52,6 +52,11 @@
             "libraries_supported": "picolibc"
         },
         {
+            "variant": "armv7a_soft_nofp",
+            "json": "armv7a_soft_nofp.json",
+            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=none -fno-exceptions"
+        },
+        {
             "variant": "riscv32imac_ilp32_nopic",
             "json": "riscv32imac_ilp32_nopic.json",
             "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic",


### PR DESCRIPTION
Adding ARMv7a no-fp variant and AArch64[-nofp] PACRET[-BKEY][-BTI] Variants

(cherry picked from commit 11f55f10c263d5203d242a3d34c455d23ea27413)