### PR TITLE
Change variant name for riscv64imac_lp64_nopic

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "riscv64",
-            "VARIANT": "riscv64imac_lp64",
+            "VARIANT": "riscv64imac_lp64_nopic",
             "COMPILE_FLAGS": "-march=rv64imac -mabi=lp64 -mcmodel=medany",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "ON",


### PR DESCRIPTION
This seems to be the only exception. So change it to align with other variants.