### PR TITLE
[cpullvm][Multilib] Don't require matching against -fno-exceptions

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -3,100 +3,100 @@
         {
             "variant": "aarch64a",
             "json": "aarch64a.json",
-            "flags": "--target=aarch64-unknown-none-elf -fno-exceptions"
+            "flags": "--target=aarch64-unknown-none-elf"
         },
         {
             "variant": "aarch64a_pacret",
             "json": "aarch64a_pacret.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -mbranch-protection=pac-ret+leaf -fno-exceptions"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -mbranch-protection=pac-ret+leaf"
         },
         {
             "variant": "aarch64a_pacret_bti",
             "json": "aarch64a_pacret_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+bti -fno-exceptions"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+bti"
         },
         {
             "variant": "aarch64a_pacret_bkey_bti",
             "json": "aarch64a_pacret_bkey_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti -fno-exceptions"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti"
         },
         {
             "variant": "aarch64a_soft_nofp",
             "json": "aarch64a_soft_nofp.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -fno-exceptions"
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft"
         },
         {
             "variant": "aarch64a_soft_nofp_pacret_bti",
             "json": "aarch64a_soft_nofp_pacret_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft"
         },
         {
             "variant": "aarch64a_soft_nofp_pacret_bkey_bti",
             "json": "aarch64a_soft_nofp_pacret_bkey_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft -fno-exceptions"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft"
         },
         {
             "variant": "armv7a_soft_neon",
             "json": "armv7a_soft_neon.json",
-            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=neon -fno-exceptions"
+            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=neon"
         },
         {
             "variant": "armv7a_soft_nofp",
             "json": "armv7a_soft_nofp.json",
-            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=none -fno-exceptions"
+            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=none"
         },
         {
             "variant": "riscv32imac_ilp32",
             "json": "riscv32imac_ilp32.json",
-            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac -mabi=ilp32 -fno-exceptions",
+            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac -mabi=ilp32",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "riscv32imac_ilp32_nopic",
             "json": "riscv32imac_ilp32_nopic.json",
-            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fno-exceptions",
+            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "riscv32imac_zba_zbb_ilp32",
             "json": "riscv32imac_zba_zbb_ilp32.json",
-            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-exceptions",
+            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "riscv32imac_zba_zbb_ilp32_nopic",
             "json": "riscv32imac_zba_zbb_ilp32_nopic.json",
-            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic -fno-exceptions",
+            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "riscv64imac_lp64_nopic",
             "json": "riscv64imac_lp64_nopic.json",
-            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic -fno-exceptions",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "riscv64gc_lp64_nopic",
             "json": "riscv64gc_lp64_nopic.json",
-            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic -fno-exceptions",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "riscv64gc_zba_zbb_lp64_nopic",
             "json": "riscv64gc_zba_zbb_lp64_nopic.json",
-            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic -fno-exceptions",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "riscv64gc_lp64d_nopic",
             "json": "riscv64gc_lp64d_nopic.json",
-            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic -fno-exceptions",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "riscv64gc_zba_zbb_lp64d_nopic",
             "json": "riscv64gc_zba_zbb_lp64d_nopic.json",
-            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic -fno-exceptions",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic",
             "libraries_supported": "picolibc"
         }
     ]

--- a/qualcomm-software/test/multilib/aarch64.test
+++ b/qualcomm-software/test/multilib/aarch64.test
@@ -3,40 +3,40 @@
 # Should also revisit whether there are relevant tests we can reuse even without
 # the original multilib.
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -fno-exceptions | FileCheck %s --check-prefix=CHECK-AARCH64
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -fno-exceptions | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
 # CHECK-AARCH64: aarch64-none-elf/aarch64a{{$}}
 # CHECK-AARCH64-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf -fno-exceptions | FileCheck %s --check-prefix=CHECK-PACRET
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf -fno-exceptions | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
 # CHECK-PACRET: aarch64-none-elf/aarch64a_pacret{{$}}
 # CHECK-PACRET-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti -fno-exceptions | FileCheck %s --check-prefix=CHECK-PACRET-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti -fno-exceptions | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
 # CHECK-PACRET-BTI: aarch64-none-elf/aarch64a_pacret_bti{{$}}
 # CHECK-PACRET-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fno-exceptions | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fno-exceptions | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
 # CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti{{$}}
 # CHECK-PACRET-BKEY-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp{{$}}
 # CHECK-NOFP-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
 # CHECK-NOFP-PACRET-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti{{$}}
 # CHECK-NOFP-PACRET-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft -fno-exceptions | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # CHECK-NOFP-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bkey_bti{{$}}
 # CHECK-NOFP-PACRET-BKEY-BTI-EMPTY:

--- a/qualcomm-software/test/multilib/armv7.test
+++ b/qualcomm-software/test/multilib/armv7.test
@@ -1,7 +1,7 @@
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -fno-exceptions | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
 # CHECK-ARMV7: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none -fno-exceptions | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
 # CHECK-ARMV7-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-NOFP-EMPTY:

--- a/qualcomm-software/test/multilib/riscv32.test
+++ b/qualcomm-software/test/multilib/riscv32.test
@@ -1,24 +1,24 @@
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
 # CHECK-IMAC-PIC: riscv32-unknown-elf/riscv32imac_ilp32{{$}}
 # CHECK-IMAC-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
 # CHECK-IMAC-ZBA-ZBB: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32{{$}}
 # CHECK-IMAC-ZBA-ZBB-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
 # CHECK-IMAC-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/riscv64.test
+++ b/qualcomm-software/test/multilib/riscv64.test
@@ -1,27 +1,27 @@
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
 # CHECK-GC-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64d_nopic{{$}}
 # CHECK-GC-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64d_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
 # CHECK-GC-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_nopic{{$}}
 # CHECK-GC-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic -fno-exceptions | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic -fno-exceptions 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic -fno-exceptions  2>&1| FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags


### PR DESCRIPTION
Currently, all of our configs have exception support disabled and people are required to pass -fno-exceptions to match any multilib. This becomes a bit unwieldy as this is required even for ex: C-only projects. We also don't particularly want to ship -fexceptions variants currently as a fallback or differ from community in terms of -fexceptions defaults.

So for now, just don't require matching -fno-exceptions to get a library without exception support.

This is a bit iffy in the sense that if we *do* need an -fexceptions variant, we'll have to rethink how we handle this situation. But, we've discussed this and decided to live with that possibility.