### PR TITLE
[cpullvm] Disable RTTI support

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a.json
@@ -5,7 +5,7 @@
             "VARIANT": "aarch64a",
             "COMPILE_FLAGS": "-march=armv8-a -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "cortex-a57",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret.json
@@ -5,7 +5,7 @@
             "VARIANT": "aarch64a_pacret",
             "COMPILE_FLAGS": "-march=armv8.3a -mbranch-protection=pac-ret+leaf -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "cortex-a57",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
@@ -5,7 +5,7 @@
             "VARIANT": "aarch64a_pacret_bkey_bti",
             "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "cortex-a57",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bti.json
@@ -5,7 +5,7 @@
             "VARIANT": "aarch64a_pacret_bti",
             "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+bti -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "cortex-a57",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp.json
@@ -5,7 +5,7 @@
             "VARIANT": "aarch64a_soft_nofp",
             "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "cortex-a57",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bkey_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bkey_bti.json
@@ -5,7 +5,7 @@
             "VARIANT": "aarch64a_soft_nofp_pacret_bkey_bti",
             "COMPILE_FLAGS": "-march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "cortex-a57",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
@@ -5,7 +5,7 @@
             "VARIANT": "aarch64a_soft_nofp_pacret_bti",
             "COMPILE_FLAGS": "-march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "cortex-a57",

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
@@ -5,7 +5,7 @@
             "VARIANT": "armv7a_soft_neon",
             "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7a -mthumb -mfpu=neon -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "none",
             "QEMU_CPU": "cortex-a7",

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
@@ -5,7 +5,7 @@
             "VARIANT": "armv7a_soft_nofp",
             "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7a -mthumb -mfpu=none -mhwdiv=none -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "none",
             "QEMU_CPU": "cortex-a7",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
@@ -5,7 +5,7 @@
             "VARIANT": "riscv32imac_ilp32",
             "COMPILE_FLAGS": "-march=rv32imac -mabi=ilp32",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "rv32",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
@@ -5,7 +5,7 @@
             "VARIANT": "riscv32imac_ilp32_nopic",
             "COMPILE_FLAGS": "-march=rv32imac -mabi=ilp32",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "rv32",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
@@ -5,7 +5,7 @@
             "VARIANT": "riscv32imac_zba_zbb_ilp32",
             "COMPILE_FLAGS": "-march=rv32imac_zba_zbb -mabi=ilp32 -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "rv32",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
@@ -5,7 +5,7 @@
             "VARIANT": "riscv32imac_zba_zbb_ilp32_nopic",
             "COMPILE_FLAGS": "-march=rv32imac_zba_zbb -mabi=ilp32",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "rv32",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
@@ -5,7 +5,7 @@
             "VARIANT": "riscv64gc_lp64_nopic",
             "COMPILE_FLAGS": "-march=rv64gc -mabi=lp64 -mcmodel=medany",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "rv64",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
@@ -5,7 +5,7 @@
             "VARIANT": "riscv64gc_lp64d_nopic",
             "COMPILE_FLAGS": "-march=rv64gc -mabi=lp64d -mcmodel=medany",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "rv64",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
@@ -5,7 +5,7 @@
             "VARIANT": "riscv64gc_zba_zbb_lp64_nopic",
             "COMPILE_FLAGS": "-march=rv64gc_zba_zbb -mabi=lp64 -mcmodel=medany",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "rv64",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
@@ -5,7 +5,7 @@
             "VARIANT": "riscv64gc_zba_zbb_lp64d_nopic",
             "COMPILE_FLAGS": "-march=rv64gc_zba_zbb -mabi=lp64d -mcmodel=medany",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "rv64",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
@@ -5,7 +5,7 @@
             "VARIANT": "riscv64imac_lp64",
             "COMPILE_FLAGS": "-march=rv64imac -mabi=lp64 -mcmodel=medany",
             "ENABLE_EXCEPTIONS": "OFF",
-            "ENABLE_RTTI": "ON",
+            "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "rv64",


### PR DESCRIPTION
All of our embedded variants are built without exception support so RTTI support is of limited utility in theory, and we don't know of anyone actually using it in practice.

So, lets disable it.