### PR TITLE
[cpullvm] Update developing.md with info on multilib flags, QEMU extensions

### DIFF
--- a/qualcomm-software/docs/developing.md
+++ b/qualcomm-software/docs/developing.md
@@ -41,10 +41,23 @@ To build additional embedded library variants, add the variant-specific JSON fil
 
 Corresponding multilib tests should be added in [test/multilib](../test/multilib/) as well.
 
+#### Specifying multilib and compile flags for variants
 Note that the flags listed the multilib.json entry are used differently than those in the variant-specific JSON
-file. Those in the multilib.json entry are used for multilib selection *only* (and may not be valid compiler flags,
-as in the case of the `armvX` flags). The flags listed in the variant-specific JSON file are used when actually
-building the runtimes.
+file. Those in the multilib.json entry are used for multilib selection *only*--the flags listed in the
+variant-specific JSON file are used when actually building the runtimes.
+
+There's a few important things to note about the multilib selection flags (those in multilib.json):
+* The flags don't necessarily need to be valid compiler flags. One notable example of this is the `armvX`
+  feature flags used in some AArch64 variants. These should be the exception though.
+* Multilib flag matching generally happens on the normalized user input. So, normalized forms of triples
+  (`aarch64-unknown-none-elf` instead of `aarch64-none-elf`) and arch strings (`armv8.5-a` instead of
+  `armv8.5a`) should be used. The notable exception here is RISC-V arch strings--our CMake normalizes
+  the input `-march` strings automatically so non-normalized forms may be used.
+
+#### Enabling additional extensions for RISC-V in QEMU
+Some of our variants enable extensions that are not enabled by default in QEMU. For now, these can be
+enabled by passing the appropriate extensions through the `QEMU_CPU` variable in the variant-specific
+JSON file (ex: `"QEMU_CPU": "rv32,i=true,m=true<extra extensions>"`).
 
 ### Adding new Linux variants
 

--- a/qualcomm-software/docs/developing.md
+++ b/qualcomm-software/docs/developing.md
@@ -57,7 +57,10 @@ There's a few important things to note about the multilib selection flags (those
 #### Enabling additional extensions for RISC-V in QEMU
 Some of our variants enable extensions that are not enabled by default in QEMU. For now, these can be
 enabled by passing the appropriate extensions through the `QEMU_CPU` variable in the variant-specific
-JSON file (ex: `"QEMU_CPU": "rv32,i=true,m=true<extra extensions>"`).
+JSON file (ex: `"QEMU_CPU": "rv32,i=true,m=false<extra extensions>"`).
+
+Note that may also have to explicitly disable extensions which QEMU enables by default if it conflicts with
+what you're enabling.
 
 ### Adding new Linux variants
 

--- a/qualcomm-software/docs/developing.md
+++ b/qualcomm-software/docs/developing.md
@@ -59,7 +59,7 @@ Some of our variants enable extensions that are not enabled by default in QEMU. 
 enabled by passing the appropriate extensions through the `QEMU_CPU` variable in the variant-specific
 JSON file (ex: `"QEMU_CPU": "rv32,i=true,m=false<extra extensions>"`).
 
-Note that may also have to explicitly disable extensions which QEMU enables by default if it conflicts with
+Note that you may also have to disable extensions which QEMU enables by default if it conflicts with
 what you're enabling.
 
 ### Adding new Linux variants


### PR DESCRIPTION
Provide some minimal documentation for two things we've had come up a few times now:
1. Add a hint on what is and isn't expected to be normalized when adding multilib flags for new embedded variants.
2. Mention how to enable extra extensions in QEMU. We'll have examples of this in the codebase soon, but the failures don't make it particularly obvious what is going on. Hopefully a reference here will at least put it on people's radar and give some hint about what to look for to fix it.