### PR TITLE
[cpullvm] Use full testnames for clang xfails

### DIFF
--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -100,8 +100,8 @@ def main():
         XFail(
             name="no frwpi",
             testnames=[
-                "Driver/ropi-rwpi.c",
-                "Preprocessor/arm-pic-predefines.c",
+                "Clang :: Driver/ropi-rwpi.c",
+                "Clang :: Preprocessor/arm-pic-predefines.c",
             ],
             result=NewResult.XFAILED,
             conditional=check_frwpi_error,
@@ -111,7 +111,7 @@ def main():
         XFail(
             name="no r52",
             testnames=[
-                "Driver/arm-fpu-selection.s",
+                "Clang :: Driver/arm-fpu-selection.s",
             ],
             result=NewResult.XFAILED,
             conditional=check_r52_warning,


### PR DESCRIPTION
When handling xfails, lit understands/checks against two things:
* The file name (something like 'Driver/ropi-rwpi.c')
* The full test name (something like 'Clang :: Driver/ropi-rwpi.c')

We've generally used the first, but this causes problems as this form changes based on the host platform. For example, on Windows, lit would see a file name of ex: ('Driver\ropi-rwpi.c'). But, we always write our xfails in the "Linux-y" way, so our xfails don't work.

To fix this, use the full testnames as these seem to keep the same form regardless of the host platform.