### PR TITLE
Add riscv64 SCS baremetal runtime variants

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -122,6 +122,12 @@
             "libraries_supported": "picolibc"
         },
         {
+            "variant": "riscv64imac_lp64_scs_nopic",
+            "json": "riscv64imac_lp64_scs_nopic.json",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "riscv64gc_lp64_nopic",
             "json": "riscv64gc_lp64_nopic.json",
             "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic",
@@ -144,6 +150,12 @@
             "json": "riscv64gc_zba_zbb_lp64d_nopic.json",
             "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic",
             "libraries_supported": "picolibc"
-        }
+        },
+        {
+            "variant": "riscv64gc_lp64_scs_nopic",
+            "json": "riscv64gc_lp64_scs_nopic.json",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic",
+            "libraries_supported": "picolibc"
+         }
     ]
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_scs_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_scs_nopic.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "riscv64",
+            "VARIANT": "riscv64gc_lp64_scs_nopic",
+            "COMPILE_FLAGS": "-march=rv64gc -mabi=lp64 -mcmodel=medany -fsanitize=shadow-call-stack -fstack-protector-strong",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "rv64",
+            "QEMU_PARAMS": "-bios none",
+            "FLASH_ADDRESS": "0x80000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x80400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_scs_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_scs_nopic.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "riscv64",
+            "VARIANT": "riscv64imac_lp64_scs_nopic",
+            "COMPILE_FLAGS": "-march=rv64imac -mabi=lp64 -mcmodel=medany -fsanitize=shadow-call-stack -fstack-protector-strong",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "rv64",
+            "QEMU_PARAMS": "-bios none",
+            "FLASH_ADDRESS": "0x80000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x80400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/test/multilib/riscv64.test
+++ b/qualcomm-software/test/multilib/riscv64.test
@@ -21,6 +21,14 @@
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
+# CHECK-IMAC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_scs_nopic{{$}}
+# CHECK-IMAC-LP64-SCS-FNO-PIC-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
+# CHECK-GC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_scs_nopic{{$}}
+# CHECK-GC-LP64-SCS-FNO-PIC-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND


### PR DESCRIPTION
Testing for picolibc is disabled due to lack of runtime support.