### PR TITLE
Test riscv64 SCS baremetal runtime variants

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -122,6 +122,12 @@
             "libraries_supported": "picolibc"
         },
         {
+            "variant": "riscv64imac_lp64_scs_nopic",
+            "json": "riscv64imac_lp64_scs_nopic.json",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "riscv64gc_lp64_nopic",
             "json": "riscv64gc_lp64_nopic.json",
             "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic",
@@ -144,6 +150,12 @@
             "json": "riscv64gc_zba_zbb_lp64d_nopic.json",
             "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic",
             "libraries_supported": "picolibc"
-        }
+        },
+        {
+            "variant": "riscv64gc_lp64_scs_nopic",
+            "json": "riscv64gc_lp64_scs_nopic.json",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic",
+            "libraries_supported": "picolibc"
+         }
     ]
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_scs_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_scs_nopic.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "riscv64",
+            "VARIANT": "riscv64gc_lp64_scs_nopic",
+            "COMPILE_FLAGS": "-march=rv64gc -mabi=lp64 -mcmodel=medany -fsanitize=shadow-call-stack -fstack-protector-strong",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "rv64",
+            "QEMU_PARAMS": "-bios none",
+            "FLASH_ADDRESS": "0x80000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x80400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_scs_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_scs_nopic.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "riscv64",
+            "VARIANT": "riscv64imac_lp64_scs_nopic",
+            "COMPILE_FLAGS": "-march=rv64imac -mabi=lp64 -mcmodel=medany -fsanitize=shadow-call-stack -fstack-protector-strong",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "rv64",
+            "QEMU_PARAMS": "-bios none",
+            "FLASH_ADDRESS": "0x80000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x80400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/patches/llvm-project/0002-Multilib-Expose-shadow-call-stack-as-multilib-flags-.patch
+++ b/qualcomm-software/patches/llvm-project/0002-Multilib-Expose-shadow-call-stack-as-multilib-flags-.patch
@@ -1,0 +1,68 @@
+From f973e4dd9b67f5d38a8b0a314d68d2e49da94039 Mon Sep 17 00:00:00 2001
+From: Pengxuan Zheng <pzheng@qti.qualcomm.com>
+Date: Fri, 20 Feb 2026 15:57:21 -0800
+Subject: [PATCH] [Multilib] Expose shadow call stack as multilib flags for
+ RISC-V
+
+This allows multilib selection based on shadow call stack for RISC-V.
+---
+ clang/lib/Driver/ToolChain.cpp                  | 11 +++++++++--
+ clang/test/Driver/print-multi-selection-flags.c |  6 ++++++
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChain.cpp b/clang/lib/Driver/ToolChain.cpp
+index 77a2c73f0d44..a71bf906d3d2 100644
+--- a/clang/lib/Driver/ToolChain.cpp
++++ b/clang/lib/Driver/ToolChain.cpp
+@@ -325,7 +325,8 @@ static void getARMMultilibFlags(const Driver &D, const llvm::Triple &Triple,
+ 
+ static void getRISCVMultilibFlags(const Driver &D, const llvm::Triple &Triple,
+                                   const llvm::opt::ArgList &Args,
+-                                  Multilib::flags_list &Result) {
++                                  Multilib::flags_list &Result,
++                                  bool hasShadowCallStack) {
+   std::string Arch = riscv::getRISCVArch(Args, Triple);
+   // Canonicalize arch for easier matching
+   auto ISAInfo = llvm::RISCVISAInfo::parseArchString(
+@@ -334,6 +335,11 @@ static void getRISCVMultilibFlags(const Driver &D, const llvm::Triple &Triple,
+     Result.push_back("-march=" + (*ISAInfo)->toString());
+ 
+   Result.push_back(("-mabi=" + riscv::getRISCVABI(Args, Triple)).str());
++
++  if (hasShadowCallStack)
++    Result.push_back("-fsanitize=shadow-call-stack");
++  else
++    Result.push_back("-fno-sanitize=shadow-call-stack");
+ }
+ 
+ Multilib::flags_list
+@@ -370,7 +376,8 @@ ToolChain::getMultilibFlags(const llvm::opt::ArgList &Args) const {
+     break;
+   case llvm::Triple::riscv32:
+   case llvm::Triple::riscv64:
+-    getRISCVMultilibFlags(D, Triple, Args, Result);
++    getRISCVMultilibFlags(D, Triple, Args, Result,
++                          getSanitizerArgs(Args).hasShadowCallStack());
+     break;
+   default:
+     break;
+diff --git a/clang/test/Driver/print-multi-selection-flags.c b/clang/test/Driver/print-multi-selection-flags.c
+index b1a0a29ec418..eba00e3278f1 100644
+--- a/clang/test/Driver/print-multi-selection-flags.c
++++ b/clang/test/Driver/print-multi-selection-flags.c
+@@ -86,6 +86,12 @@
+ // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=aarch64-none-elf -mbig-endian | FileCheck --check-prefix=CHECK-BIG-ENDIAN %s
+ // CHECK-BIG-ENDIAN: -mbig-endian
+ 
++// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf -fsanitize=shadow-call-stack | FileCheck --check-prefix=CHECK-SHADOW-CALL-STACK %s
++// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf -fno-sanitize=shadow-call-stack | FileCheck --check-prefix=CHECK-NO-SHADOW-CALL-STACK %s
++// RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv64-none-elf | FileCheck --check-prefix=CHECK-NO-SHADOW-CALL-STACK %s
++// CHECK-SHADOW-CALL-STACK: -fsanitize=shadow-call-stack
++// CHECK-NO-SHADOW-CALL-STACK: -fno-sanitize=shadow-call-stack
++
+ // RUN: %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml -print-multi-flags-experimental --target=riscv32-none-elf -march=rv32g | FileCheck --check-prefix=CHECK-RV32 %s
+ // CHECK-RV32: --target=riscv32-unknown-none-elf
+ // CHECK-RV32: -mabi=ilp32d
+-- 
+2.34.1
+

--- a/qualcomm-software/test/multilib/riscv64.test
+++ b/qualcomm-software/test/multilib/riscv64.test
@@ -21,6 +21,14 @@
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
+# CHECK-IMAC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_scs_nopic{{$}}
+# CHECK-IMAC-LP64-SCS-FNO-PIC-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
+# CHECK-GC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_scs_nopic{{$}}
+# CHECK-GC-LP64-SCS-FNO-PIC-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND


### PR DESCRIPTION
A custom multilib flag "scs" was added. Testing for picolibc is disabled due to lack of runtime support.