### PR TITLE
workflows/issue-release-workflow: Add an environment in order to limi…

### DIFF
--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -1,0 +1,70 @@
+# This contains the workflow definitions that allow users to test backports
+# to the release branch using comments on issues.
+#
+# /cherry-pick <commit> <...>
+#
+# This comment will attempt to cherry-pick the given commits to the latest
+# release branch (release/Y.x) and if successful, push the result to a branch
+# on github.
+#
+# /branch <owner>/<repo>/<branch>
+#
+# This comment will create a pull request from <branch> to the latest release
+# branch.
+
+name: Issue Release Workflow
+
+permissions:
+  contents: read
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+  issues:
+    types:
+      - opened
+
+env:
+  COMMENT_BODY: ${{ github.event.action == 'opened' && github.event.issue.body || github.event.comment.body  }}
+
+jobs:
+  backport-commits:
+    name: Backport Commits
+    runs-on: ubuntu-24.04
+    environment: main-branch-only
+    permissions:
+      issues: write
+      pull-requests: write
+    if: >-
+      (github.repository == 'llvm/llvm-project') &&
+      !startswith(github.event.comment.body, '<!--IGNORE-->') &&
+      contains(github.event.action == 'opened' && github.event.issue.body || github.event.comment.body, '/cherry-pick')
+    steps:
+      - name: Fetch LLVM sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: llvm/llvm-project
+          # GitHub stores the token used for checkout and uses it for pushes
+          # too, but we want to use a different token for pushing, so we need
+          # to disable persist-credentials here.
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup Environment
+        run: |
+          pip install --require-hashes -r ./llvm/utils/git/requirements.txt
+          ./llvm/utils/git/github-automation.py --token ${{ github.token }} setup-llvmbot-git
+
+      - name: Backport Commits
+        run: |
+          printf "%s" "$COMMENT_BODY" |
+          ./llvm/utils/git/github-automation.py \
+          --repo "$GITHUB_REPOSITORY" \
+          --token "${{ secrets.RELEASE_WORKFLOW_PR_CREATE }}" \
+          release-workflow \
+          --branch-repo-token ${{ secrets.RELEASE_WORKFLOW_PUSH_SECRET }} \
+          --issue-number ${{ github.event.issue.number }} \
+          --requested-by ${{ (github.event.action == 'opened' && github.event.issue.user.login) || github.event.comment.user.login }} \
+          auto

--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -54,7 +54,10 @@ jobs:
       - name: Setup Environment
         run: |
           pip install --require-hashes -r ./llvm/utils/git/requirements.txt
-          ./llvm/utils/git/github-automation.py --token ${{ github.token }} setup-llvmbot-git
+
+          # Set committer identity for commits created by this workflow
+          git config user.name  "cpullvmbot"
+          git config user.email "cpullvmbot@qti.qualcomm.com"
 
       - name: Backport Commits
         run: |

--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -4,7 +4,7 @@
 # /cherry-pick <commit> <...>
 #
 # This comment will attempt to cherry-pick the given commits to the latest
-# release branch (release/Y.x) and if successful, push the result to a branch
+# release branch (release/qualcomm-software/Y.x) and if successful, push the result to a branch
 # on github.
 #
 # /branch <owner>/<repo>/<branch>
@@ -33,19 +33,18 @@ jobs:
   backport-commits:
     name: Backport Commits
     runs-on: ubuntu-24.04
-    environment: main-branch-only
     permissions:
       issues: write
       pull-requests: write
     if: >-
-      (github.repository == 'llvm/llvm-project') &&
+      (github.repository == 'qualcomm/cpullvm-toolchain') &&
       !startswith(github.event.comment.body, '<!--IGNORE-->') &&
       contains(github.event.action == 'opened' && github.event.issue.body || github.event.comment.body, '/cherry-pick')
     steps:
-      - name: Fetch LLVM sources
+      - name: Fetch cpullvm sources
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          repository: llvm/llvm-project
+          repository: qualcomm/cpullvm-toolchain
           # GitHub stores the token used for checkout and uses it for pushes
           # too, but we want to use a different token for pushing, so we need
           # to disable persist-credentials here.


### PR DESCRIPTION
…t secret access (#179585)

I've created a new environment called `main-branch-only` which is meant to be used for running the GitHub Actions based automations for the project. By using an environment, we can move some of the secrets we use from the repository configuration and into the environment configuration, which means they will only be accessible for jobs that run on the branch we specify, which in this case is the main branch.

This will prevent people from using user branches as a way to gain access to secret values (which they can do now very easily by creating a workflow that dumps the secrets). Even though someone could still do this by pushing to main, user branches are hard to monitor and they can be easily deleted after dumping the secrets leaving no trace.

If someone where to do this on the main branch it would be much more visible and impossible to cover up.

I would like to apply this to more workflows, but I'm starting here so I can test it and make sure it works the way I expect.

(cherry picked from commit 4e21141bae0dac9eadd28fe230ffe213cd156af6)