### PR TITLE
Add riscv64imc baremetal runtime variants

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -116,6 +116,18 @@
             "libraries_supported": "picolibc"
         },
         {
+            "variant": "riscv64imc_lp64_nothreads_nopic",
+            "json": "riscv64imc_lp64_nothreads_nopic.json",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic",
+            "libraries_supported": "picolibc"
+        },
+        {
+            "variant": "riscv64imc_lp64_scs_nothreads_nopic",
+            "json": "riscv64imc_lp64_scs_nothreads_nopic.json",
+            "flags": "--target=riscv64-unknown-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "riscv64imac_lp64_nopic",
             "json": "riscv64imac_lp64_nopic.json",
             "flags": "--target=riscv64-unknown-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
@@ -1,0 +1,27 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "riscv64",
+            "VARIANT": "riscv64imc_lp64_nothreads_nopic",
+            "COMPILE_FLAGS": "-march=rv64imc -mabi=lp64 -mcmodel=medany",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "rv64",
+            "QEMU_PARAMS": "-bios none",
+            "FLASH_ADDRESS": "0x80000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x80400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "DISABLE_THREADS": "ON"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_scs_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_scs_nothreads_nopic.json
@@ -1,0 +1,27 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "riscv64",
+            "VARIANT": "riscv64imc_lp64_scs_nothreads_nopic",
+            "COMPILE_FLAGS": "-march=rv64imc -mabi=lp64 -mcmodel=medany -fsanitize=shadow-call-stack -fstack-protector-strong",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "rv64",
+            "QEMU_PARAMS": "-bios none",
+            "FLASH_ADDRESS": "0x80000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x80400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "DISABLE_THREADS": "ON"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/multilib.yaml.in
+++ b/qualcomm-software/embedded-multilib/multilib.yaml.in
@@ -38,6 +38,14 @@ Groups:
 - Name: stdlibs
   Type: Exclusive
 
+# Custom flag declarations.
+Flags:
+- Name: threads
+  Values:
+  - Name: no-threads
+  - Name: threads
+  Default: threads
+
 # The list of library variants is substituted in by CMakeLists.txt, so
 # that it can respect the LLVM_TOOLCHAIN_LIBRARY_VARIANTS setting and
 # only include the set of libraries actually included in this build.

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -84,6 +84,7 @@ set(ENABLE_CXX_LIBS ${ENABLE_CXX_LIBS_def} CACHE BOOL "Build CXX libs")
 set(ENABLE_LIBC_TESTS ${ENABLE_LIBC_TESTS_def} CACHE BOOL "Enable libc tests (picolibc only).")
 set(ENABLE_COMPILER_RT_TESTS ${ENABLE_COMPILER_RT_TESTS_def} CACHE BOOL "Enable compiler-rt tests.")
 set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tests.")
+set(DISABLE_THREADS ${DISABLE_THREADS_def} CACHE BOOL "Disable threads/atomic/TLS (picolibc only).")
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
 
 # Set up a few arbitrary pass-through flags for musl-embedded. This probably
@@ -447,6 +448,15 @@ if(C_LIBRARY STREQUAL picolibc)
 
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/meson-cross-build.txt.in ${CMAKE_CURRENT_BINARY_DIR}/meson-cross-build.txt @ONLY)
 
+    set(single_thread "false")
+    set(thread_local_storage "picolibc")
+    set(atomic_ungetc "true")
+    if(DISABLE_THREADS)
+      set(single_thread "true")
+      set(thread_local_storage "false")
+      set(atomic_ungetc "false")
+    endif()
+
     ExternalProject_Add(
         picolibc
         STAMP_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/stamp
@@ -474,6 +484,9 @@ if(C_LIBRARY STREQUAL picolibc)
             --prefix <INSTALL_DIR>
             --cross-file ${CMAKE_CURRENT_BINARY_DIR}/meson-cross-build.txt
             --buildtype=${LIBRARY_MESON_BUILD_TYPE}
+            -Dsingle-thread=${single_thread}
+            -Dthread-local-storage=${thread_local_storage}
+            -Datomic-ungetc=${atomic_ungetc}
             <SOURCE_DIR>
         BUILD_COMMAND ${MESON_EXECUTABLE} compile
         INSTALL_COMMAND ${MESON_EXECUTABLE} install ${MESON_INSTALL_QUIET}

--- a/qualcomm-software/test/multilib/riscv64.test
+++ b/qualcomm-software/test/multilib/riscv64.test
@@ -5,6 +5,14 @@
 # CHECK-IMAC-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-NO-THREADS-FNO-PIC
+# CHECK-IMC-LP64-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_nothreads_nopic{{$}}
+# CHECK-IMC-LP64-NO-THREADS-FNO-PIC-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC
+# CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_scs_nothreads_nopic{{$}}
+# CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
 # CHECK-GC-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64d_nopic{{$}}
 # CHECK-GC-LP64D-FNO-PIC-EMPTY:


### PR DESCRIPTION
riscv64imc_lp64_nothreads_nopic
riscv64imc_lp64_scs_nothreads_nopic

A new variable, `DISABLE_THREADS`, is introduced to control atomic/TLS/threads enablement. We set `DISABLE_THREADS` to `ON` for these two variants to disable atomic/TLS/threads. Besides, picolibc testing for
riscv64imc_lp64_scs_nothreads_nopic is disabled due to lack of shadow call stack runtime support.