### PR TITLE
[cpullvm] Enable copying Linux libraries from existing distribution files

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -134,8 +134,8 @@ option(
     "Include additional library variants for use on Linux targets"
     OFF
 )
-if(ENABLE_LINUX_LIBRARIES AND WIN32)
-    message(FATAL_ERROR "ENABLE_LINUX_LIBRARIES is not permitted on Windows")
+if((ENABLE_LINUX_LIBRARIES AND WIN32) AND NOT PREBUILT_TARGET_LIBRARIES)
+    message(FATAL_ERROR "Building Linux libraries from source is not supported on Windows")
 endif()
 option(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL
     "Make cpack build an overlay package that can be unpacked over the main toolchain to install a secondary set of libraries based on musl-embedded."

--- a/qualcomm-software/cmake/copy_target_libraries.py
+++ b/qualcomm-software/cmake/copy_target_libraries.py
@@ -15,6 +15,20 @@ import tarfile
 import tempfile
 
 
+def move_folder(src_glob, dest):
+    """
+    Move the folder given by `src_glob` to `dest`. `src_glob` is treated
+    as a glob, but is assumed to point to only one folder.
+    """
+
+    for src_dir in glob.glob(src_glob):
+        break
+    else:
+        raise RuntimeError("Extracted distribution directory not found")
+
+    shutil.move(src_dir, dest)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -27,6 +41,11 @@ def main():
         "--build-dir",
         required=True,
         help="The build root directory to copy into",
+    )
+    parser.add_argument(
+        "--include-linux-libraries",
+        action="store_true",
+        help="Whether to copy Linux libraries in addition to embedded libraries",
     )
     args = parser.parse_args()
 
@@ -46,6 +65,14 @@ def main():
     if os.path.isdir(destination):
         shutil.rmtree(destination)
 
+    if args.include_linux_libraries:
+        # The "linux-libraries" build folder is our own construct, so assume
+        # there is nothing we need to preserve.
+        linux_lib_dir = os.path.join(args.build_dir, "llvm", "linux-libraries")
+        if os.path.isdir(linux_lib_dir):
+            shutil.rmtree(linux_lib_dir)
+        os.makedirs(linux_lib_dir)
+
     with tempfile.TemporaryDirectory(
         dir=args.build_dir,
     ) as tmp:
@@ -53,20 +80,27 @@ def main():
         with tarfile.open(distribution_file) as tf:
             tf.extractall(tmp)
 
-        # Find the clang-runtimes directory in the extracted package
-        # directory.
-        for clang_runtimes in glob.glob(
-            os.path.join(tmp, "*", "lib", "clang-runtimes")
-        ):
-            break
-        else:
-            raise RuntimeError("Extracted distribution directory not found")
-
-        # Move the directory containing the target libraries into
+        # Move directories containing the target libraries into
         # position. The rest of the files in the distribution folder
         # will be deleted automatically when the tmp object goes out of
         # scope.
-        shutil.move(clang_runtimes, lib_dir)
+        move_folder(os.path.join(tmp, "*", "lib", "clang-runtimes"), lib_dir)
+
+        if args.include_linux_libraries:
+            # Move the entire resource directory
+            move_folder(
+                os.path.join(tmp, "*", "lib", "clang", "*"),
+                os.path.join(linux_lib_dir, "resource-dir")
+            )
+            # Move the libc/libc++ directories one-by-one
+            linux_lib_folders = [
+                "aarch64-unknown-linux-musl",
+                "arm-unknown-linux-musleabi",
+                "riscv32-unknown-linux-musl",
+                "riscv64-unknown-linux-musl",
+            ]
+            for folder in linux_lib_folders:
+                move_folder(os.path.join(tmp, "*", folder), linux_lib_dir)
 
 
 if __name__ == "__main__":

--- a/qualcomm-software/scripts/build_copy_runtimes.ps1
+++ b/qualcomm-software/scripts/build_copy_runtimes.ps1
@@ -24,12 +24,13 @@ $buildDir = (Join-Path $repoRoot build)
 mkdir $buildDir -Force
 cd $buildDir
 
-python3 ..\qualcomm-software\cmake\copy_target_libraries.py --distribution-file=cpullvm-*.tar.xz --build-dir=$buildDir
+python3 ..\qualcomm-software\cmake\copy_target_libraries.py --include-linux-libraries --distribution-file=cpullvm-*.tar.xz --build-dir=$buildDir
 
 cmake ..\qualcomm-software `
   -GNinja `
   -DFETCHCONTENT_QUIET=OFF `
   -DPREBUILT_TARGET_LIBRARIES=ON `
+  -DENABLE_LINUX_LIBRARIES=ON `
   -DCMAKE_C_COMPILER=clang-cl `
   -DCMAKE_CXX_COMPILER=clang-cl
 

--- a/qualcomm-software/scripts/build_copy_runtimes.sh
+++ b/qualcomm-software/scripts/build_copy_runtimes.sh
@@ -25,12 +25,13 @@ export CXX=clang++
 mkdir -p "${REPO_ROOT}"/build
 cd "${REPO_ROOT}"/build
 
-python3 ../qualcomm-software/cmake/copy_target_libraries.py --distribution-file=cpullvm-*.tar.xz --build-dir=$PWD
+python3 ../qualcomm-software/cmake/copy_target_libraries.py --include-linux-libraries --distribution-file=cpullvm-*.tar.xz --build-dir=$PWD
 
 cmake ../qualcomm-software \
  -GNinja \
  -DFETCHCONTENT_QUIET=OFF \
  -DPREBUILT_TARGET_LIBRARIES=ON \
+ -DENABLE_LINUX_LIBRARIES=ON \
  ${EXTRA_CMAKE_ARGS}
 
 ninja package-llvm-toolchain


### PR DESCRIPTION
This adds an off-by-default flag `--include-linux-libraries` to copy_target_libraries.py to accomplish this.

Turn this new flag on in our nightlies that copy runtimes too.