### PR TITLE
Add compiler-rt build for Windows targets.

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -134,9 +134,18 @@ option(
     "Include additional library variants for use on Linux targets"
     OFF
 )
+option(
+    ENABLE_WINDOWS_LIBRARIES
+    "Include additional library variants for use on Windows targets"
+    "${CMAKE_HOST_WIN32}"
+)
 if((ENABLE_LINUX_LIBRARIES AND WIN32) AND NOT PREBUILT_TARGET_LIBRARIES)
     message(FATAL_ERROR "Building Linux libraries from source is not supported on Windows")
 endif()
+if(ENABLE_WINDOWS_LIBRARIES AND NOT CMAKE_HOST_WIN32)
+    message(FATAL_ERROR "Building Windows libraries from source is not supported on Linux")
+endif()
+
 option(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL
     "Make cpack build an overlay package that can be unpacked over the main toolchain to install a secondary set of libraries based on musl-embedded."
     ${overlay_install_default})
@@ -651,6 +660,38 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
     endif()
 endif()
 
+if(ENABLE_WINDOWS_LIBRARIES)
+    set(windows_library_prefix ${CMAKE_BINARY_DIR}/windows-library-builds)
+    ExternalProject_Add(
+        windows-libraries
+        STAMP_DIR ${windows_library_prefix}/stamp
+        BINARY_DIR ${windows_library_prefix}/build
+        TMP_DIR ${windows_library_prefix}/tmp
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/scripts
+        INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/llvm/windows-libraries
+        DEPENDS ${lib_tool_dependencies}
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND
+            powershell -ExecutionPolicy Bypass -File "<SOURCE_DIR>/build_windows_runtimes.ps1"
+                -ToolsPath ${CMAKE_CURRENT_BINARY_DIR}/llvm/bin
+                -BaseBuildDir <BINARY_DIR>
+                -BaseInstallDir <INSTALL_DIR>
+                -LLVMSrcDir ${llvmproject_src_dir}
+        INSTALL_COMMAND ""
+        USES_TERMINAL_CONFIGURE TRUE
+        USES_TERMINAL_BUILD TRUE
+        USES_TERMINAL_INSTALL TRUE
+        STEP_TARGETS build install
+        LOG_BUILD TRUE
+        BUILD_ALWAYS TRUE
+    )
+
+    add_dependencies(
+        llvm-toolchain-runtimes
+        windows-libraries-install
+    )
+endif()
+
 FILE(WRITE "${CMAKE_BINARY_DIR}/llvm/${TARGET_CFI_DIR}/cfi_ignorelist.txt" "")
 install(
     FILES
@@ -676,6 +717,15 @@ if(ENABLE_LINUX_LIBRARIES)
     # compiler-rt
     install(
         DIRECTORY ${LLVM_BINARY_DIR}/linux-libraries/resource-dir/.
+        DESTINATION lib/clang/${LLVM_VERSION_MAJOR}
+        COMPONENT llvm-toolchain-libs
+    )
+endif()
+
+if(ENABLE_WINDOWS_LIBRARIES)
+    # compiler-rt
+    install(
+        DIRECTORY ${LLVM_BINARY_DIR}/windows-libraries/.
         DESTINATION lib/clang/${LLVM_VERSION_MAJOR}
         COMPONENT llvm-toolchain-libs
     )

--- a/qualcomm-software/scripts/build_windows_runtimes.ps1
+++ b/qualcomm-software/scripts/build_windows_runtimes.ps1
@@ -1,0 +1,99 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+param(
+    [Parameter(Mandatory,
+    HelpMessage="Path to directory to find Clang/LLVM tools")]
+    [string]$ToolsPath,
+    [Parameter(Mandatory,
+    HelpMessage="Directory for the build")]
+    [string]$BaseBuildDir,
+    [Parameter(Mandatory,
+    HelpMessage="Directory for the install")]
+    [string]$BaseInstallDir,
+    [Parameter(Mandatory,
+    HelpMessage="Directory of the LLVM sources")]
+    [string]$LLVMSrcDir
+)
+
+Write-Host "Options: -ToolsPath $ToolsPath -BaseBuildDir $BaseBuildDir -BaseInstallDir $BaseInstallDir -LLVMSrcDir $LLVMSrcDir"
+
+$env:Path = $ToolsPath + ";" + $env:Path
+
+$Variants= @("x86_64", "aarch64")
+$VariantTargets = @{
+    x86_64 = "x86_64-windows-msvc"
+    aarch64 = "aarch64-windows-msvc"
+}
+
+# We link against Visual Studio libraries; make sure we can find them.
+
+$vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+$vcVarsTargets = $null
+# We need to invoke vcvarsall.bat differently depending on the host.
+if ($hostArch -eq 'ARM64') {
+  $vcVarsTargets = @{
+    x86_64 = "arm64_x64"
+    aarch64 = "arm64"
+  }
+} else {
+  $vcVarsTargets = @{
+    x86_64 = "x64"
+    aarch64 = "x64_arm64"
+  }
+}
+
+# Find an appropriate VS install.
+$VS_INSTALL = & $vswhere -latest -products * `
+  -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+  -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 `
+  -property installationPath
+
+if (-not $VS_INSTALL) {
+  throw "*** ERROR: Visual Studio installation missing components (need both x86 and arm64 compilers)"
+}
+
+$VCVARSALL = Join-PATH $VS_INSTALL "VC\Auxiliary\Build\vcvarsall.bat"
+if (-not (Test-Path $VCVARSALL)) {
+  throw "*** ERROR: vcvarsall.bat not found."
+}
+
+foreach ($Variant in $Variants) {
+  Write-Host "Variant $Variant"
+  $VariantBaseBuildDir="$BaseBuildDir\$Variant"
+  mkdir $VariantBaseBuildDir -ErrorAction SilentlyContinue
+
+  # Switch environment to the current variant.
+  $vcvarsTarget = $vcvarsTargets[$Variant]
+  cmd /c "call `"$VCVARSALL`" $vcvarsTarget && set" | ForEach-Object {
+    if ($_ -match '^(.*?)=(.*)$') {
+      [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2], 'Process')
+    }
+  }
+
+  $VariantTarget = $VariantTargets[$Variant]
+  $CompilerRtBuildDir="$VariantBaseBuildDir/compiler-rt"
+  cmake -G Ninja `
+      -DCMAKE_INSTALL_PREFIX="$BaseInstallDir" `
+      -DCMAKE_BUILD_TYPE="Release" `
+      -DCMAKE_C_COMPILER="clang-cl" `
+      -DCMAKE_CXX_COMPILER="clang-cl" `
+      -DCMAKE_SYSTEM_NAME="Windows" `
+      -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON `
+      -DCMAKE_ASM_COMPILER_TARGET="$VariantTarget" `
+      -DCMAKE_C_COMPILER_TARGET="$VariantTarget" `
+      -DCMAKE_CXX_COMPILER_TARGET="$VariantTarget" `
+      -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON `
+      -DCOMPILER_RT_BUILD_BUILTINS=ON `
+      -DCOMPILER_RT_BUILD_LIBFUZZER=OFF `
+      -DCOMPILER_RT_SANITIZERS_TO_BUILD="" `
+      -DCOMPILER_RT_BUILD_ORC=OFF `
+      -DCOMPILER_RT_BUILD_XRAY=OFF `
+      -DLLVM_ENABLE_RUNTIMES=compiler-rt `
+      -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" `
+      -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" `
+      -DCMAKE_MODULE_LINKER_FLAGS="-fuse-ld=lld" `
+      -B "$CompilerRtBuildDir" `
+      -S "$LLVMSrcDir/runtimes"
+  ninja -C "$CompilerRtBuildDir" install
+}


### PR DESCRIPTION
compiler-rt isn't usually necessary on Windows, but there are some libraries with more obscure uses: the builtins library has SME support routines, the profile library is useful for PGO and coverage, the ubsan library is useful for enabling ubsan.

Builds both x64 and arm64 libraries... not sure we really need the x64 versions, but the build steps are basically the same.

(Only works on Windows host for obvious reasons.)