### PR TITLE
[cpullvm][Github] Upload the toolchain in precheckins

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -59,6 +59,15 @@ jobs:
       - name: Build toolchain
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
+      - name: Upload built packages
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}
+          path: |
+            build*/cpullvm-*.tar.xz
+          retention-days: 1
+
       - name: Test
         if: matrix.test_script != ''
         run: ./qualcomm-software/scripts/${{ matrix.test_script }}


### PR DESCRIPTION
Retain it for only 24 hours to hopefully prevent issues with consuming too much storage.

Also upload it before testing--even if unit tests fail, it might be helpful to have access to the toolchain if it was built successfully.