### PR TITLE
[cpullvm] Upload nightly builds before testing

### DIFF
--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -86,10 +86,6 @@ jobs:
       - name: Build
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
-      - name: Test
-        if: matrix.test_script != ''
-        run: ./qualcomm-software/scripts/${{ matrix.test_script }}
-
       - name: Upload built packages
         uses: actions/upload-artifact@v4
         if: success()
@@ -99,3 +95,7 @@ jobs:
             build*/cpullvm-*.tar.xz
             build*/cpullvm-*.zip
           retention-days: 7
+
+      - name: Test
+        if: matrix.test_script != ''
+        run: ./qualcomm-software/scripts/${{ matrix.test_script }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,9 +45,6 @@ jobs:
       - name: Build
         run: ./qualcomm-software/scripts/build.sh
 
-      - name: Test
-        run: ./qualcomm-software/scripts/test.sh
-
       - name: Upload built packages
         uses: actions/upload-artifact@v4
         if: success()
@@ -56,6 +53,9 @@ jobs:
           path: build*/cpullvm-*.tar.xz
           if-no-files-found: error
           retention-days: 7
+
+      - name: Test
+        run: ./qualcomm-software/scripts/test.sh
 
   build-and-test:
     if: github.repository == 'qualcomm/cpullvm-toolchain'
@@ -123,10 +123,6 @@ jobs:
       - name: Build
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
-      - name: Test
-        if: matrix.test_script != ''
-        run: ./qualcomm-software/scripts/${{ matrix.test_script }}
-
       - name: Upload built packages
         uses: actions/upload-artifact@v4
         if: success()
@@ -137,3 +133,7 @@ jobs:
             build*/cpullvm-*.zip
             !build/cpullvm-*-Linux-x86_64.tar.xz
           retention-days: 7
+
+      - name: Test
+        if: matrix.test_script != ''
+        run: ./qualcomm-software/scripts/${{ matrix.test_script }}


### PR DESCRIPTION
It can still be helpful to have these toolchains, even if ex: a lit test is failing. So upload before testing.

Note that doesn't address the dependencies of the non-Linux x86 builds on the Linux x86 test step. That requires a bit more finagling, so we'll handle it later.