### PR TITLE
[cpullvm] Build some aarch64 configs using initial exec TLS model

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
@@ -19,7 +19,8 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "TLS_MODEL": "initial-exec"
         },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp.json
@@ -19,7 +19,8 @@
             "ENABLE_CXX_LIBS": "OFF",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "TLS_MODEL": "initial-exec"
         },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "OFF",

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -85,6 +85,15 @@ set(ENABLE_LIBC_TESTS ${ENABLE_LIBC_TESTS_def} CACHE BOOL "Enable libc tests (pi
 set(ENABLE_COMPILER_RT_TESTS ${ENABLE_COMPILER_RT_TESTS_def} CACHE BOOL "Enable compiler-rt tests.")
 set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tests.")
 set(DISABLE_THREADS ${DISABLE_THREADS_def} CACHE BOOL "Disable threads/atomic/TLS (picolibc only).")
+set(SUPPORTED_TLS_MODELS local-exec initial-exec local-dynamic global-dynamic)
+if(NOT DEFINED TLS_MODEL_def)
+    set(TLS_MODEL_def local-exec)
+elseif(NOT TLS_MODEL_def IN_LIST SUPPORTED_TLS_MODELS)
+    string(REPLACE ";" ", " SUPPORTED_TLS_MODELS_STR "${SUPPORTED_TLS_MODELS}")
+    message(FATAL_ERROR "Unsupported TLS_MODEL value. Supported values are ${SUPPORTED_TLS_MODELS_STR}")
+endif()
+set(TLS_MODEL ${TLS_MODEL_def} CACHE STRING "TLS model to use. Currently only used by picolibc, other projects use the project/toolchain defaults.")
+set_property(CACHE TLS_MODEL PROPERTY STRINGS ${SUPPORTED_TLS_MODELS})
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
 
 # Set up a few arbitrary pass-through flags for musl-embedded. This probably
@@ -494,6 +503,7 @@ if(C_LIBRARY STREQUAL picolibc)
             --buildtype=${LIBRARY_MESON_BUILD_TYPE}
             -Dsingle-thread=${single_thread}
             -Dthread-local-storage=${thread_local_storage}
+            -Dtls-model=${TLS_MODEL}
             -Datomic-ungetc=${atomic_ungetc}
             <SOURCE_DIR>
         BUILD_COMMAND ${MESON_EXECUTABLE} compile


### PR DESCRIPTION
local-exec is the default TLS model in picolibc when thread-local-storage is configured. However, we have a few cases where local-exec cannot be used, so change the configs used in those cases to be initial-exec.

This adds a new `TLS_MODEL` variable to control this.

There's a few things to note here:
1. This is intentionally done without multilib support for now as we don't want to be shipping separate per-TLS-model configs right now.
2. Ideally we'd use a consistent TLS model across most/all aarch64 configs (or all configs in general) but a) we're missing some TLS model optimizations in the linker (initial-exec to local-exec when the pre-requisites are met, etc.) and b) we've recently had some correctness issues pop up when testing initial-exec configs. So limit this to only the configs where we know we need this.
3. The TLS_MODEL option is only handled by picolibc. Other projects (compiler-rt, libc++) don't force this in a way that causes issues (or, generally don't seem to use TLS for the things we're building). So, leave those projects alone for now and address only picolibc. This should be easy to extend if we find out those projects need this set as well.