### PR TITLE
Add aarch64a_standalone baremetal runtime variant

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -6,6 +6,12 @@
             "flags": "--target=aarch64-unknown-none-elf"
         },
         {
+            "variant": "aarch64a_standalone",
+            "json": "aarch64a_standalone.json",
+            "flags": "--target=aarch64-unknown-none-elf -fmultilib-flag=standalone",
+            "libraries_supported": "musl-embedded"
+        },
+        {
             "variant": "aarch64a_pacret",
             "json": "aarch64a_pacret.json",
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -mbranch-protection=pac-ret+leaf"

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_standalone.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_standalone.json
@@ -1,0 +1,27 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_standalone",
+            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "FLASH_ADDRESS": "0x40000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x40400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "musl-embedded": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS": "--quic-libc-standalone",
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align -D__QUIC_ENABLE_FLT_FOR_PRINT"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/multilib.yaml.in
+++ b/qualcomm-software/embedded-multilib/multilib.yaml.in
@@ -45,6 +45,11 @@ Flags:
   - Name: no-threads
   - Name: threads
   Default: threads
+- Name: musl-subvariant
+  Values:
+  - Name: standalone
+  - Name: no-subvariant
+  Default: no-subvariant
 
 # The list of library variants is substituted in by CMakeLists.txt, so
 # that it can respect the LLVM_TOOLCHAIN_LIBRARY_VARIANTS setting and


### PR DESCRIPTION
This is to support the libc-standalone.a variant from musl-embedded.