### PR TITLE
[cpullvm] Freeze musl-embedded to a sha for the release

### DIFF
--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -17,8 +17,8 @@
     },
     "musl-embedded": {
       "url": "https://github.com/qualcomm/musl-embedded",
-      "tagType": "branch",
-      "tag": "main"
+      "tagType": "commithash",
+      "tag": "09177f66d7f893f0470f5610035897338bae6228"
     },
     "eld": {
       "url": "https://github.com/qualcomm/eld",


### PR DESCRIPTION
We don't expect any more musl-embedded changes and we don't have specific release branches for musl-embedded. So, freeze it on a specific commit so we don't pick up additional changes unexpectedly.