### PR TITLE
[cpullvm] Suppress --print-enabled-extensions stderr output

### DIFF
--- a/qualcomm-software/cmake/get_canonical_riscv_march.cmake
+++ b/qualcomm-software/cmake/get_canonical_riscv_march.cmake
@@ -15,6 +15,7 @@ function(get_canonical_riscv_march compiler_path build_args march_out)
         ${command_args}
         RESULT_VARIABLE return_val
         OUTPUT_VARIABLE extension_output
+        ERROR_VARIABLE extension_output
     )
     if(NOT return_val EQUAL 0)
         message(FATAL_ERROR "Unable to execute `--print-enabled-extensions` to retreive canonical `-march` string")


### PR DESCRIPTION
--print-enabled-extensions prints clang's version information (which goes to
stderr) then the enabled extension information.

Previously, we were only piping stdout to a variable, so the stderr output
would make it to the terminal. This isn't necessarily a problem, but does get
noisy when it happens for each RISC-V variant (and includes warnings about
unknown `-fmultilib-flag` flags, etc.).

Just eat the stderr output as well.