### PR TITLE
[cpullvm] Install an 'empty' multilib.yaml at the base of every embedded variant

### DIFF
--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -216,10 +216,7 @@ if(ENABLE_LIBC_TESTS OR ENABLE_COMPILER_RT_TESTS OR ENABLE_LIBCXX_TESTS)
     list(JOIN lit_test_executor " " lit_test_executor)
 endif()
 
-# Adding "-isystem ${TEMP_LIB_DIR}/include" to work around a sysroot issue for
-# RISC-V baremetal. We may not need this workaround in the future if the issue
-# is fixed upstream.
-set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS} --sysroot ${TEMP_LIB_DIR} -isystem ${TEMP_LIB_DIR}/include")
+set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS} --sysroot ${TEMP_LIB_DIR}")
 # Compiling the libraries benefits from some extra optimization
 # flags, and requires a sysroot.
 set(lib_compile_flags "${compile_arch_flags} -ffunction-sections -fdata-sections")
@@ -241,6 +238,16 @@ elseif(LIBRARY_BUILD_TYPE STREQUAL releasewithdebuginfo)
     set(LIBRARY_CMAKE_BUILD_TYPE RelWithDebInfo)
     set(LIBRARY_MESON_BUILD_TYPE debugoptimized)
 endif()
+
+# Copy the empty multilib file. The intent here is only to suppress the
+# hardcoded multilibs that are present in the Baremetal toolchain object. This
+# allows us to use `--sysroot` consistently across all variants while building
+# and users to use `--sysroot` to point to any of our library variants.
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/empty-multilib.yaml
+    ${TEMP_LIB_DIR}/multilib.yaml
+    COPYONLY
+)
 
 ###############################################################################
 # compiler-rt

--- a/qualcomm-software/embedded-runtimes/empty-multilib.yaml
+++ b/qualcomm-software/embedded-runtimes/empty-multilib.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This file is a minimal multilib configuration that should match any flags and
+# point into "base" directory used for multilib (currently, the sysroot).
+
+MultilibVersion: '1.0'
+Variants:
+- Dir: .
+  Flags: []

--- a/qualcomm-software/test/lit.site.cfg.py.in
+++ b/qualcomm-software/test/lit.site.cfg.py.in
@@ -11,6 +11,7 @@ config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@LLVM_DEFAULT_TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
+config.substitutions.append(("%llvm_embedded_libs_dir", "@LLVM_BINARY_DIR@/lib/clang-runtimes"))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/qualcomm-software/test/multilib/sysroot.test
+++ b/qualcomm-software/test/multilib/sysroot.test
@@ -1,0 +1,19 @@
+## This file includes tests that ensure we are able to point `--sysroot` at our
+## library variants. This isn't a given as there are hardcoded multilibs in the
+## baremetal toolchain object that can cause issues with this. Test that our
+## empty multilib scheme is working as expected in resolving this.
+
+## Do basic checks to confirm whether the empty multilib scheme is still needed.
+# rm -rf %t && mkdir -p %t/fake_sysroot
+# RUN: %clang --sysroot=%t/fake_sysroot --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-RV32-HARDCODED
+# CHECK-RV32-HARDCODED: rv32im{{/|\\}}ilp32
+# RUN: %clang --sysroot=%t/fake_sysroot --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-RV64-HARDCODED
+# CHECK-RV64-HARDCODED: rv64imafdc{{/|\\}}lp64d
+
+## Check that pointing to our variants (with the empty multilib) works as expected.
+# RUN: %clang --sysroot=%llvm_embedded_libs_dir/riscv32-unknown-elf/riscv32imac_ilp32 --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-RV32-SYSROOT
+# CHECK-RV32-SYSROOT: riscv32-unknown-elf{{/|\\}}riscv32imac_ilp32
+# CHECK-RV32-SYSROOT-NOT: rv32im{{/|\\}}ilp32
+# RUN: %clang --sysroot=%llvm_embedded_libs_dir/riscv32-unknown-elf/riscv32imac_ilp32 --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-RV64-SYSROOT
+# CHECK-RV64-SYSROOT: riscv32-unknown-elf{{/|\\}}riscv32imac_ilp32
+# CHECK-RV64-SYSROOT-NOT: rv64imafdc{{/|\\}}lp64d


### PR DESCRIPTION
Currently, the clang's Baremetal toolchain object has a few hardcoded RISC-V multilib variants that are used if there is no multilib.yaml that clang can find.

Importantly, our library layouts do not match the layout the hardcoded multilibs expect, so when we *do* match one, options like `--sysroot` pointing to our variants break.

This creates issues for us in two scenarios:
1. While building out the sysroot for each variant, we use `--sysroot` to source the just-built headers and libraries.
2. We want to provide users the ability to use `--sysroot` to point to any of our library variants.

Installing a minimal multilib.yaml that matches any flags and points into the same folder as what multilib uses as the "base" directory (for Baremetal, this is the sysroot currently) seems like the easiest way to handle this without changes to upstream.

The other thing to note here is that we write this file out at configure time rather than build time. I waffled on this a bit, but it is a) similar to how we handle some other dependencies (meson's cross files, the "real" multilib.yaml) and b) is very simple to implement without worrying about our build dependencies. So, just live writing it out at configure time.