### PR TITLE
Update some aarch64 baremetal variants to use initial-exec TLS model

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -1,8 +1,8 @@
 {
     "libs": [
         {
-            "variant": "aarch64a",
-            "json": "aarch64a.json",
+            "variant": "aarch64a_tlsie",
+            "json": "aarch64a_tlsie.json",
             "flags": "--target=aarch64-unknown-none-elf"
         },
         {
@@ -16,13 +16,13 @@
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+bti"
         },
         {
-            "variant": "aarch64a_pacret_bkey_bti",
-            "json": "aarch64a_pacret_bkey_bti.json",
+            "variant": "aarch64a_pacret_bkey_bti_tlsie",
+            "json": "aarch64a_pacret_bkey_bti_tlsie.json",
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti"
         },
         {
-            "variant": "aarch64a_soft_nofp",
-            "json": "aarch64a_soft_nofp.json",
+            "variant": "aarch64a_soft_nofp_tlsie",
+            "json": "aarch64a_soft_nofp_tlsie.json",
             "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft"
         },
         {

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_tlsie.json
@@ -2,8 +2,8 @@
     "args": {
         "common": {
             "TARGET_ARCH": "aarch64a",
-            "VARIANT": "aarch64a_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fPIC",
+            "VARIANT": "aarch64a_pacret_bkey_bti_tlsie",
+            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
@@ -16,17 +16,17 @@
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {
-            "ENABLE_CXX_LIBS": "OFF",
-            "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
-        },
-        "musl-embedded": {
-            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS": "--quic-aarch64-nofp",
+            "TLS_MODEL": "initial-exec"
+        },
+        "musl-embedded": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
             "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
@@ -2,8 +2,8 @@
     "args": {
         "common": {
             "TARGET_ARCH": "aarch64a",
-            "VARIANT": "aarch64a",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "VARIANT": "aarch64a_soft_nofp_tlsie",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
@@ -16,16 +16,18 @@
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {
-            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_CXX_LIBS": "OFF",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "TLS_MODEL": "initial-exec"
         },
         "musl-embedded": {
-            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_CXX_LIBS": "OFF",
             "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
+            "EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS": "--quic-aarch64-nofp",
             "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
@@ -2,8 +2,8 @@
     "args": {
         "common": {
             "TARGET_ARCH": "aarch64a",
-            "VARIANT": "aarch64a_pacret_bkey_bti",
-            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fPIC",
+            "VARIANT": "aarch64a_tlsie",
+            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
@@ -17,9 +17,10 @@
         },
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "TLS_MODEL": "initial-exec"
         },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -85,6 +85,15 @@ set(ENABLE_LIBC_TESTS ${ENABLE_LIBC_TESTS_def} CACHE BOOL "Enable libc tests (pi
 set(ENABLE_COMPILER_RT_TESTS ${ENABLE_COMPILER_RT_TESTS_def} CACHE BOOL "Enable compiler-rt tests.")
 set(ENABLE_LIBCXX_TESTS ${ENABLE_LIBCXX_TESTS_def} CACHE BOOL "Enable libcxx tests.")
 set(DISABLE_THREADS ${DISABLE_THREADS_def} CACHE BOOL "Disable threads/atomic/TLS (picolibc only).")
+set(SUPPORTED_TLS_MODELS local-exec initial-exec local-dynamic global-dynamic)
+if(NOT DEFINED TLS_MODEL_def)
+    set(TLS_MODEL_def local-exec)
+elseif(NOT TLS_MODEL_def IN_LIST SUPPORTED_TLS_MODELS)
+    string(REPLACE ";" ", " SUPPORTED_TLS_MODELS_STR "${SUPPORTED_TLS_MODELS}")
+    message(FATAL_ERROR "Unsupported TLS_MODEL value. Supported values are ${SUPPORTED_TLS_MODELS_STR}")
+endif()
+set(TLS_MODEL ${TLS_MODEL_def} CACHE STRING "TLS model to use. Currently only used by picolibc, other projects use the project/toolchain defaults.")
+set_property(CACHE TLS_MODEL PROPERTY STRINGS ${SUPPORTED_TLS_MODELS})
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
 
 # Set up a few arbitrary pass-through flags for musl-embedded. This probably
@@ -494,6 +503,7 @@ if(C_LIBRARY STREQUAL picolibc)
             --buildtype=${LIBRARY_MESON_BUILD_TYPE}
             -Dsingle-thread=${single_thread}
             -Dthread-local-storage=${thread_local_storage}
+            -Dtls-model=${TLS_MODEL}
             -Datomic-ungetc=${atomic_ungetc}
             <SOURCE_DIR>
         BUILD_COMMAND ${MESON_EXECUTABLE} compile

--- a/qualcomm-software/test/multilib/aarch64.test
+++ b/qualcomm-software/test/multilib/aarch64.test
@@ -5,7 +5,7 @@
 
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
-# CHECK-AARCH64: aarch64-none-elf/aarch64a{{$}}
+# CHECK-AARCH64: aarch64-none-elf/aarch64a_tlsie{{$}}
 # CHECK-AARCH64-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
@@ -20,13 +20,13 @@
 
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
-# CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti{{$}}
+# CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti_tlsie{{$}}
 # CHECK-PACRET-BKEY-BTI-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
-# CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp{{$}}
+# CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp_tlsie{{$}}
 # CHECK-NOFP-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI


### PR DESCRIPTION
This patch borrowed the `TLS_MODEL` variable Jonathon implemented in https://github.com/qualcomm/cpullvm-toolchain/pull/228.