### PR TITLE
release/qualcomm-software/22.x: [cpullvm] Have THIRD-PARTY-LICENSES.txt reflect the projects enabled (#240)

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -793,7 +793,16 @@ install(
     COMPONENT llvm-toolchain-docs
 )
 
-configure_file(cmake/THIRD-PARTY-LICENSES.txt.in THIRD-PARTY-LICENSES.txt)
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
+    string(APPEND LIBC_LICENSE_FILES " - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc\n")
+endif()
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded OR ENABLE_LINUX_LIBRARIES)
+    string(APPEND LIBC_LICENSE_FILES " - musl-embedded: third-party-licenses/musl-embedded-COPYRIGHT.txt\n")
+    if(ENABLE_LINUX_LIBRARIES)
+        string(APPEND LIBC_LICENSE_FILES " - musl: third-party-licenses/musl-COPYRIGHT.txt\n")
+    endif()
+endif()
+configure_file(cmake/THIRD-PARTY-LICENSES.txt.in THIRD-PARTY-LICENSES.txt @ONLY)
 
 if(NOT LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL)
     set(third_party_license_summary_install_dir .)

--- a/qualcomm-software/cmake/THIRD-PARTY-LICENSES.txt.in
+++ b/qualcomm-software/cmake/THIRD-PARTY-LICENSES.txt.in
@@ -7,10 +7,7 @@ additional or alternate licenses:
  - libc++: third-party-licenses/LIBCXX-LICENSE.txt
  - libc++abi: third-party-licenses/LIBCXXABI-LICENSE.txt
  - libunwind: third-party-licenses/LIBUNWIND-LICENSE.txt
- - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc
  - eld: third-party-licenses/eld-LICENSE.txt
- - musl-embedded: third-party-licenses/musl-embedded-COPYRIGHT.txt
- - musl: third-party-licenses/musl-COPYRIGHT.txt
  - Arm Toolchain for Embedded: third-party-licenses/ATfE-LICENSE.txt
-
-Picolibc licenses refer to its source files. Sources are identified in VERSION.txt.
+@LIBC_LICENSE_FILES@
+Project licenses may refer to its source files. Sources are identified in VERSION.txt.


### PR DESCRIPTION
Backport 4ace457

Requested by: @jonathonpenix