### PR TITLE
[cpullvm] Install libedit-dev for LLDB

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,7 +69,7 @@ jobs:
         include:
           - build_script: build_copy_runtimes.sh
             test_script: test.sh
-            install_script: ''
+            install_script: install_dependencies.sh
             target_os: Linux-AArch64
             runner: ubuntu-22.04-arm
 

--- a/qualcomm-software/scripts/install_dependencies.sh
+++ b/qualcomm-software/scripts/install_dependencies.sh
@@ -3,7 +3,7 @@
 
 sudo apt-get update
 # Used by lldb
-sudo apt-get install swig
+sudo apt-get install swig libedit-dev
 
 # Install meson. eld support was added in v1.9.0, so we need at least that.
 pip install meson==1.10.0


### PR DESCRIPTION
Install this optional dependency [1] for LLDB.

It looks like all the other ones are present in our AArch64 Github runners,
except Lua which we also disabled downstream anyway. (And we have Python
for lldb explicitly disabled right now.)

Apparently we also didn't run the install_dependencies.sh in our nightly. I
think that makes sense in that we're copying the runtimes so didn't need
meson. This should have been added with originally, but I missed it and
apparently we already had swig available.

[1] https://lldb.llvm.org/resources/build.html#optional-dependencies