### PR TITLE
[cpullvm] Re-add llvm-config to distribution components

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -181,6 +181,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     llvm-as
     llvm-cat
     llvm-cfi-verify
+    llvm-config
     llvm-cov
     llvm-cvtres
     llvm-cxxdump


### PR DESCRIPTION
Apparently we use this internally. So re-add this for now and we can sort out whether we *should* be using it later.