### PR TITLE
release/qualcomm-software/22.x: [cpullvm] Re-add llvm-config to distribution components (#251)

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -181,6 +181,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     llvm-as
     llvm-cat
     llvm-cfi-verify
+    llvm-config
     llvm-cov
     llvm-cvtres
     llvm-cxxdump


### PR DESCRIPTION
Backport 199985a

Requested by: @jonathonpenix