### PR TITLE
[cpullvm] Make note about deprecating musl into a warning

### DIFF
--- a/qualcomm-software/docs/user.md
+++ b/qualcomm-software/docs/user.md
@@ -7,9 +7,10 @@ To install it, untar the overlay file at the root of the CPULLVM toolchain insta
 
 To invoke the toolchain using musl-embedded as the C library, use the `--config=musl-embedded.cfg` compiler option.
 
-NOTE:
-musl Linux variants are used for CPULLVM test infrastructure.
-musl-embedded will be deprecated in CPULLVM 23.1.0. Please switch to picolibc.
+> [!WARNING]
+> musl Linux variants are used for CPULLVM test infrastructure.
+> 
+> musl-embedded will be deprecated in CPULLVM 23.1.0. Please switch to picolibc.
 
 ## Using ELD
 CPULLVM supports and recommends the [ELD linker](https://github.com/qualcomm/eld) for building embedded images.


### PR DESCRIPTION
Apparantly this is a thing supported by Github. Upgrade the note to a warning to make this a bit more noticeable.