### PR TITLE
[cpullvm][Github] Don't run precheckins based on modifying .md files

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -14,6 +14,7 @@ on:
     types: [opened, synchronize, reopened]
     paths-ignore:
       - '.github/workflows/qcom-preflight-checks.yml'
+      - '**/*.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
There isn't really a point to running our precheckins when updating .md files like our README, docs, etc.

So add these files to the list of paths to ignore in our precheckin builds.