### PR TITLE
release/qualcomm-software/22.x: [cpullvm] Add note about C++ support in the user readme (#256)

### DIFF
--- a/qualcomm-software/docs/user.md
+++ b/qualcomm-software/docs/user.md
@@ -14,3 +14,13 @@ musl-embedded will be deprecated in CPULLVM 23.1.0. Please switch to picolibc.
 ## Using ELD
 CPULLVM supports and recommends the [ELD linker](https://github.com/qualcomm/eld) for building embedded images.
 To do this, add the `-fuse-ld=eld` flag to the compiler driver invocation.
+
+## C++ Support
+libc++ and libc++abi runtimes libraries are provided for many embedded variants. Features that are currently not
+supported include:
+
+* Multithreading
+* Exceptions
+* RTTI
+
+If variants with exceptions and RTTI enabled are required, please file an issue.


### PR DESCRIPTION
Backport 98cb58f

Requested by: @jonathonpenix