### PR TITLE
[cpullvm][Github] Update actions for Node deprecation

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
@@ -61,7 +61,7 @@ jobs:
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Upload built packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: success()
         with:
           name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -73,7 +73,7 @@ jobs:
           git config --global core.longpaths true
 
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           # We build in the repository and rely on clean to cleanup possible
           # old build products if the runner doesn't do it itself.
@@ -90,7 +90,7 @@ jobs:
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Upload built packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: success()
         with:
           name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           # We build in the repository and rely on clean to cleanup possible
           # old build products if the runner doesn't do it itself.
@@ -49,7 +49,7 @@ jobs:
         run: ./qualcomm-software/scripts/build.sh
 
       - name: Upload built packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: success()
         with:
           name: cpullvm-packages-build.sh-Linux-x86
@@ -105,14 +105,14 @@ jobs:
           git config --global core.longpaths true
 
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           # We build in the repository and rely on clean to cleanup possible
           # old build products if the runner doesn't do it itself.
           clean: true
 
       - name: Download Linux-x86 package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: cpullvm-packages-build.sh-Linux-x86
 
@@ -127,7 +127,7 @@ jobs:
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Upload built packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: success()
         with:
           name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}


### PR DESCRIPTION
Our builds are getting warnings as some of the actions that we're using are using deprecated versions of Node.js. See ex: [1]. So, update the relevant actions.

upload/download were left at v6/v7, respectively, as these releases should solve the Node.js issue, and the newer releases are *very* new. So let's wait a bit before updating to those.

While here, I'm also flipping over to using specific SHAs to be consistent with LLVM per [2].

[1] https://github.com/qualcomm/cpullvm-toolchain/actions/runs/22929283277
[2] https://llvm.org/docs/CIBestPractices.html