### PR TITLE
[cpullvm] Specify exact Windows image we're using

### DIFF
--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -54,7 +54,7 @@ jobs:
             test_script: test.ps1
             install_script: install_dependencies.ps1
             target_os: Windows-x86_64
-            runner: windows-latest
+            runner: windows-2025
 
           - build_script: build.ps1
             test_script: test.ps1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,7 +86,7 @@ jobs:
             test_script: test.ps1
             install_script: install_dependencies.ps1
             target_os: Windows-x86_64
-            runner: windows-latest
+            runner: windows-2025
 
           - build_script: build_copy_runtimes.ps1
             test_script: test.ps1


### PR DESCRIPTION
Align with guidance from [1] and what we do with the rest of our images in specifying the specific version we're using rather than 'latest'.

Hopefully this should prevent any surprises.

[1] https://llvm.org/docs/CIBestPractices.html