### PR TITLE
[cpullvm][Github] Add pull_request trigger for our nightlies when they are modified

### DIFF
--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -18,6 +18,9 @@ name: Native Runtime Nightly Build and Test
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/native-runtime-nightly.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,9 @@ name: Nightly Build and Test
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/nightly.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
This saves us from having to manually add/remove the "pull_request" when updating these, aligns with what is recommeneded in [1], and should hopefully give people some indication of how they can enable nightlies on their own branches/PRs for testing purposes.

These take a long time to run (4+ hours) but for changes to these files, we'd expect them to be run generally anyway.

[1] https://llvm.org/docs/CIBestPractices.html