### PR TITLE
[cpullvm] Remove explicit references to documentation filenames

### DIFF
--- a/qualcomm-software/README.md
+++ b/qualcomm-software/README.md
@@ -49,8 +49,8 @@ CPULLVM is built and tested on
 
 Binary releases of CPULLVM are available [here](https://github.com/qualcomm/cpullvm-toolchain/releases).
 
-For tips on getting started with using CPULLVM, please see [user.md](./docs/user.md).
+For tips on getting started with using CPULLVM, please see the [user guide](./docs/user.md).
 
-For instructions on building from source, please see [building.md](./docs/building.md).
+For instructions on building from source, please see the documentation on [building from source](./docs/building.md).
 
-If you are interested in contributing to CPULLVM, please see [CONTRIBUTING.md](/CONTRIBUTING.md).
+If you are interested in contributing to CPULLVM, please see [our contributing guide](/CONTRIBUTING.md).

--- a/qualcomm-software/docs/building.md
+++ b/qualcomm-software/docs/building.md
@@ -54,7 +54,7 @@ python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/p
 ```
 
 Other projects (eld, picolibc, etc.) are checked out and patched automatically. If you prefer, you can check
-out and patch the repos manually and use those, see [developing.md](./developing.md).
+out and patch the repos manually and use those, see [our developer documentation](./developing.md).
 
 ## Building
 
@@ -113,4 +113,4 @@ ninja package-llvm-toolchain
 
 CPULLVM can be configured and built in a variety of ways, including changing the default libc to use for embedded,
 building Linux libraries, and building only a subset of library variants. These (and other) options are
-documented in part in [developing.md](./developing.md).
+documented in part in [our developer documentation](./developing.md).

--- a/qualcomm-software/docs/developing.md
+++ b/qualcomm-software/docs/developing.md
@@ -114,7 +114,7 @@ individual library variant, respectively, without having to rebuild the toolchai
 an existing set of LLVM tools). 
 
 ## Testing the toolchain
-Running `ninja check-all-llvm-toolchain` as described in [building.md](building.md) will test the entire
+Running `ninja check-all-llvm-toolchain` as described in [our build documentation](building.md) will test the entire
 toolchain (LLVM tests like `check-clang`, eld tests, any enabled library tests). But, it is also possible
 to test these components separately. A non-exhaustive list of `check-` targets CPULLVM provides:
 * `check-clang`, `check-llvm`, and the other usual LLVM `check-` targets are all still valid


### PR DESCRIPTION
We expressed a preference towards this, so remove the references to the actual file names.