### PR TITLE
machine/riscv: Refactor machine specific memcpy/memmove overriding me…

### DIFF
--- a/qualcomm-software/patches/picolibc/0004-machine-riscv-Refactor-machine-specific-memcpy-memmo.patch
+++ b/qualcomm-software/patches/picolibc/0004-machine-riscv-Refactor-machine-specific-memcpy-memmo.patch
@@ -1,0 +1,502 @@
+From 99c3ca6634d60e6a7db0c930b0beb2d162175209 Mon Sep 17 00:00:00 2001
+From: Venkata Ramanaiah Nalamothu <vnalamot@qti.qualcomm.com>
+Date: Mon, 16 Mar 2026 00:48:03 -0700
+Subject: [PATCH] machine/riscv: Refactor machine specific memcpy/memmove
+ overriding mechanism
+
+For RISC-V, it is possible to have several optimized implementations
+of library routines depending on which hardware extensions are enabled
+and the current mechanism to choose the appropriate implementation
+will quickly become messy when dealing with many implementations.
+
+With the refactor, the idea is, for e.g., 'newlib/libc/machine/riscv/memcpy.c'
+will override the generic 'newlib/libc/string/memcpy.c' through the
+'srcs_machine' scheme and conditions in 'newlib/libc/machine/riscv/memcpy.c'
+will decide which implementation gets compiled and used for a given scenario.
+
+Put all the related changes into one header, e.g. 'rv_string.h' for all
+'string.h' related API specializations, to avoid the potential header
+file clutter as we specialize more and more APIs from several headers.
+This mechanism is simple and scalable.
+
+The existing 'rv_string.h' is renamed to 'rv_strcpy.h'.
+
+This patch is a squashed commit of all the changes from upstream PRs:
+    https://github.com/picolibc/picolibc/pull/1090
+    https://github.com/picolibc/picolibc/pull/1092
+    https://github.com/picolibc/picolibc/pull/1098
+---
+ newlib/libc/machine/riscv/CMakeLists.txt      |   2 +-
+ newlib/libc/machine/riscv/memcpy-asm.S        |   6 +-
+ newlib/libc/machine/riscv/memcpy.c            |   9 +-
+ newlib/libc/machine/riscv/memmove.S           |   6 +-
+ .../riscv/{memmove-stub.c => memmove.c}       |   4 +-
+ newlib/libc/machine/riscv/meson.build         |   2 +-
+ newlib/libc/machine/riscv/rv_strcpy.h         | 139 +++++++++++++++++
+ newlib/libc/machine/riscv/rv_string.h         | 143 +++---------------
+ newlib/libc/machine/riscv/stpcpy.c            |   2 +-
+ newlib/libc/machine/riscv/strcpy.c            |   2 +-
+ newlib/libc/machine/riscv/strlen.c            |   2 +-
+ 11 files changed, 176 insertions(+), 141 deletions(-)
+ rename newlib/libc/machine/riscv/{memmove-stub.c => memmove.c} (85%)
+ create mode 100644 newlib/libc/machine/riscv/rv_strcpy.h
+
+diff --git a/newlib/libc/machine/riscv/CMakeLists.txt b/newlib/libc/machine/riscv/CMakeLists.txt
+index 91a4b7a73..1ccfaad01 100644
+--- a/newlib/libc/machine/riscv/CMakeLists.txt
++++ b/newlib/libc/machine/riscv/CMakeLists.txt
+@@ -40,7 +40,7 @@ picolibc_sources_flags("-fno-builtin"
+   memcpy-asm.S
+   memcpy.c
+   memmove.S
+-  memmove-stub.c
++  memmove.c
+   memset.S
+   setjmp.S
+   stpcpy.c
+diff --git a/newlib/libc/machine/riscv/memcpy-asm.S b/newlib/libc/machine/riscv/memcpy-asm.S
+index 71758b415..61699849f 100644
+--- a/newlib/libc/machine/riscv/memcpy-asm.S
++++ b/newlib/libc/machine/riscv/memcpy-asm.S
+@@ -9,9 +9,9 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
+ 
+-#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++#ifdef _MACHINE_RISCV_MEMCPY_ASM_
+ .section .text.memcpy
+ .global memcpy
+ .type	memcpy, @function
+@@ -31,4 +31,4 @@ memcpy:
+   ret
+ 
+   .size	memcpy, .-memcpy
+-#endif
++#endif /* _MACHINE_RISCV_MEMCPY_ASM_ */
+diff --git a/newlib/libc/machine/riscv/memcpy.c b/newlib/libc/machine/riscv/memcpy.c
+index fe31bec59..5d15115fb 100644
+--- a/newlib/libc/machine/riscv/memcpy.c
++++ b/newlib/libc/machine/riscv/memcpy.c
+@@ -9,12 +9,9 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
+-
+-#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+-//memcpy defined in memcpy-asm.S
+-#else
++#include "rv_string.h"
+ 
++#ifdef _MACHINE_RISCV_MEMCPY_C_
+ #include <string.h>
+ #include <stdint.h>
+ #include "../../string/local.h"
+@@ -96,4 +93,4 @@ small:
+     goto small;
+   return aa;
+ }
+-#endif
++#endif /* _MACHINE_RISCV_MEMCPY_C_ */
+diff --git a/newlib/libc/machine/riscv/memmove.S b/newlib/libc/machine/riscv/memmove.S
+index 04334c36d..679dba66f 100644
+--- a/newlib/libc/machine/riscv/memmove.S
++++ b/newlib/libc/machine/riscv/memmove.S
+@@ -9,9 +9,9 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
+ 
+-#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++#ifdef _MACHINE_RISCV_MEMMOVE_ASM_
+ .section .text.memmove
+ .global memmove
+ .type	memmove, @function
+@@ -39,4 +39,4 @@ memmove:
+   ret
+ 
+   .size	memmove, .-memmove
+-#endif
++#endif /* _MACHINE_RISCV_MEMMOVE_ASM_ */
+diff --git a/newlib/libc/machine/riscv/memmove-stub.c b/newlib/libc/machine/riscv/memmove.c
+similarity index 85%
+rename from newlib/libc/machine/riscv/memmove-stub.c
+rename to newlib/libc/machine/riscv/memmove.c
+index 60b3239e9..0a8c601de 100644
+--- a/newlib/libc/machine/riscv/memmove-stub.c
++++ b/newlib/libc/machine/riscv/memmove.c
+@@ -9,8 +9,8 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
+ 
+-#if !defined(__PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
++#ifdef _MACHINE_RISCV_MEMMOVE_GENERIC_
+ #include "../../string/memmove.c"
+ #endif
+diff --git a/newlib/libc/machine/riscv/meson.build b/newlib/libc/machine/riscv/meson.build
+index 050e4cbd9..bf5a279d6 100644
+--- a/newlib/libc/machine/riscv/meson.build
++++ b/newlib/libc/machine/riscv/meson.build
+@@ -37,7 +37,7 @@ srcs_machine = [
+   'memcpy-asm.S',
+   'memcpy.c',
+   'memmove.S',
+-  'memmove-stub.c',
++  'memmove.c',
+   'memset.S',
+   'setjmp.S',
+   'stpcpy.c',
+diff --git a/newlib/libc/machine/riscv/rv_strcpy.h b/newlib/libc/machine/riscv/rv_strcpy.h
+new file mode 100644
+index 000000000..6b4a645be
+--- /dev/null
++++ b/newlib/libc/machine/riscv/rv_strcpy.h
+@@ -0,0 +1,139 @@
++/* Copyright (c) 2017  SiFive Inc. All rights reserved.
++
++   This copyrighted material is made available to anyone wishing to use,
++   modify, copy, or redistribute it subject to the terms and conditions
++   of the FreeBSD License.   This program is distributed in the hope that
++   it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
++   including the implied warranties of MERCHANTABILITY or FITNESS FOR
++   A PARTICULAR PURPOSE.  A copy of this license is available at
++   http://www.opensource.org/licenses.
++*/
++
++#ifndef _RV_STRCPY_H
++#define _RV_STRCPY_H
++
++#include <stdbool.h>
++#include <string.h>
++#include "xlenint.h"
++
++#if __riscv_zbb
++  // Determine which intrinsics to use based on XLEN and endianness
++  #if __riscv_xlen == 64
++    #if __has_builtin(__builtin_riscv_orc_b_64)
++      #define __LIBC_RISCV_ZBB_ORC_B(x)       __builtin_riscv_orc_b_64 (x)
++    #endif
++
++    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
++      #if __has_builtin(__builtin_riscv_ctz_64)
++        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_ctz_64(x)
++      #endif
++    #else
++      #if __has_builtin(__builtin_riscv_clz_64)
++        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_clz_64(x)
++      #endif
++    #endif
++  #else
++    #if __has_builtin(__builtin_riscv_orc_b_32)
++      #define __LIBC_RISCV_ZBB_ORC_B(x)       __builtin_riscv_orc_b_32(x)
++    #endif
++
++    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
++      #if __has_builtin(__builtin_riscv_ctz_32)
++        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_ctz_32(x)
++      #endif
++    #else
++      #if __has_builtin(__builtin_riscv_clz_32)
++        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_clz_32(x)
++      #endif
++    #endif
++  #endif
++#endif
++
++
++static __inline uintxlen_t __libc_detect_null(uintxlen_t w)
++{
++#ifdef __LIBC_RISCV_ZBB_ORC_B
++  /*
++    If there are any zeros in each byte of the register, all bits will
++    be unset for that byte value, otherwise, all bits will be set.
++    If the value is -1, all bits are set, meaning no null byte was found.
++  */
++  return __LIBC_RISCV_ZBB_ORC_B(w) != (uintxlen_t) -1;
++#else
++  uintxlen_t mask = 0x7f7f7f7f;
++  #if __riscv_xlen == 64
++    mask = ((mask << 16) << 16) | mask;
++  #endif
++  return ~(((w & mask) + mask) | w | mask);
++#endif
++}
++
++
++static __inline
++#if __riscv_misaligned_slow || __riscv_misaligned_fast
++__disable_sanitizer
++#endif
++char *__libc_strcpy(char *dst, const char *src, bool ret_start)
++{
++  char *dst0 = dst;
++
++#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
++#if !(__riscv_misaligned_slow || __riscv_misaligned_fast)
++  int misaligned = ((uintxlen_t)dst | (uintxlen_t)src) & (sizeof (uintxlen_t) - 1);
++  if (__builtin_expect(!misaligned, 1))
++#endif
++    {
++      uintxlen_t *pdst = (uintxlen_t *)dst;
++      const uintxlen_t *psrc = (const uintxlen_t *)src;
++
++      while (!__libc_detect_null(*psrc))
++        *pdst++ = *psrc++;
++
++      dst = (char *)pdst;
++      src = (const char *)psrc;
++
++      if (ret_start)
++        {
++          if (!(*dst++ = src[0])) return dst0;
++          if (!(*dst++ = src[1])) return dst0;
++          if (!(*dst++ = src[2])) return dst0;
++          if (!(*dst++ = src[3])) return dst0;
++          #if __riscv_xlen == 64
++            if (!(*dst++ = src[4])) return dst0;
++            if (!(*dst++ = src[5])) return dst0;
++            if (!(*dst++ = src[6])) return dst0;
++          #endif
++        }
++      else
++        {
++          if (!(*dst++ = src[0])) return dst - 1;
++          if (!(*dst++ = src[1])) return dst - 1;
++          if (!(*dst++ = src[2])) return dst - 1;
++          if (!(*dst++ = src[3])) return dst - 1;
++          #if __riscv_xlen == 64
++            if (!(*dst++ = src[4])) return dst - 1;
++            if (!(*dst++ = src[5])) return dst - 1;
++            if (!(*dst++ = src[6])) return dst - 1;
++            dst0 = dst;
++          #endif
++        }
++
++      *dst = 0;
++      return dst0;
++    }
++#endif /* not PREFER_SIZE_OVER_SPEED */
++
++  char ch;
++  do
++    {
++      ch = *src;
++      src++;
++      dst++;
++      *(dst - 1) = ch;
++    } while (ch);
++
++  return ret_start ? dst0 : dst - 1;
++}
++
++
++#endif /* _RV_STRCPY_H */
+diff --git a/newlib/libc/machine/riscv/rv_string.h b/newlib/libc/machine/riscv/rv_string.h
+index da5798493..4f40ab690 100644
+--- a/newlib/libc/machine/riscv/rv_string.h
++++ b/newlib/libc/machine/riscv/rv_string.h
+@@ -7,133 +7,32 @@
+    including the implied warranties of MERCHANTABILITY or FITNESS FOR
+    A PARTICULAR PURPOSE.  A copy of this license is available at
+    http://www.opensource.org/licenses.
+-*/
+-
+-#ifndef _RV_STRING_H
+-#define _RV_STRING_H
+ 
+-#include <stdbool.h>
+-#include <string.h>
+-#include "xlenint.h"
+-
+-#if __riscv_zbb
+-  // Determine which intrinsics to use based on XLEN and endianness
+-  #if __riscv_xlen == 64
+-    #if __has_builtin(__builtin_riscv_orc_b_64)
+-      #define __LIBC_RISCV_ZBB_ORC_B(x)       __builtin_riscv_orc_b_64 (x)
+-    #endif
++   Changes from Qualcomm Technologies, Inc. are provided under the following
++   license:
++   Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++   SPDX-License-Identifier: BSD-3-Clause-Clear
++*/
+ 
+-    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+-      #if __has_builtin(__builtin_riscv_ctz_64)
+-        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_ctz_64(x)
+-      #endif
+-    #else
+-      #if __has_builtin(__builtin_riscv_clz_64)
+-        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_clz_64(x)
+-      #endif
+-    #endif
+-  #else
+-    #if __has_builtin(__builtin_riscv_orc_b_32)
+-      #define __LIBC_RISCV_ZBB_ORC_B(x)       __builtin_riscv_orc_b_32(x)
+-    #endif
++#ifndef _RV_STRING_H_
++#define _RV_STRING_H_
+ 
+-    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+-      #if __has_builtin(__builtin_riscv_ctz_32)
+-        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_ctz_32(x)
+-      #endif
+-    #else
+-      #if __has_builtin(__builtin_riscv_clz_32)
+-        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_clz_32(x)
+-      #endif
+-    #endif
+-  #endif
+-#endif
++/* This file defines macros to choose a specific custom implementation for
++ * 'string.h' APIs. The specialization is segretated per API to allow for
++ * different and/or complex scenarios for each API. */
+ 
++#include <picolibc.h>
+ 
+-static __inline uintxlen_t __libc_detect_null(uintxlen_t w)
+-{
+-#ifdef __LIBC_RISCV_ZBB_ORC_B
+-  /*
+-    If there are any zeros in each byte of the register, all bits will
+-    be unset for that byte value, otherwise, all bits will be set.
+-    If the value is -1, all bits are set, meaning no null byte was found.
+-  */
+-  return __LIBC_RISCV_ZBB_ORC_B(w) != (uintxlen_t) -1;
++#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++# define _MACHINE_RISCV_MEMCPY_ASM_
+ #else
+-  uintxlen_t mask = 0x7f7f7f7f;
+-  #if __riscv_xlen == 64
+-    mask = ((mask << 16) << 16) | mask;
+-  #endif
+-  return ~(((w & mask) + mask) | w | mask);
+-#endif
+-}
+-
+-
+-static __inline
+-#if __riscv_misaligned_slow || __riscv_misaligned_fast
+-__disable_sanitizer
+-#endif
+-char *__libc_strcpy(char *dst, const char *src, bool ret_start)
+-{
+-  char *dst0 = dst;
+-
+-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+-#if !(__riscv_misaligned_slow || __riscv_misaligned_fast)
+-  int misaligned = ((uintxlen_t)dst | (uintxlen_t)src) & (sizeof (uintxlen_t) - 1);
+-  if (__builtin_expect(!misaligned, 1))
+-#endif
+-    {
+-      uintxlen_t *pdst = (uintxlen_t *)dst;
+-      const uintxlen_t *psrc = (const uintxlen_t *)src;
+-
+-      while (!__libc_detect_null(*psrc))
+-        *pdst++ = *psrc++;
+-
+-      dst = (char *)pdst;
+-      src = (const char *)psrc;
+-
+-      if (ret_start)
+-        {
+-          if (!(*dst++ = src[0])) return dst0;
+-          if (!(*dst++ = src[1])) return dst0;
+-          if (!(*dst++ = src[2])) return dst0;
+-          if (!(*dst++ = src[3])) return dst0;
+-          #if __riscv_xlen == 64
+-            if (!(*dst++ = src[4])) return dst0;
+-            if (!(*dst++ = src[5])) return dst0;
+-            if (!(*dst++ = src[6])) return dst0;
+-          #endif
+-        }
+-      else
+-        {
+-          if (!(*dst++ = src[0])) return dst - 1;
+-          if (!(*dst++ = src[1])) return dst - 1;
+-          if (!(*dst++ = src[2])) return dst - 1;
+-          if (!(*dst++ = src[3])) return dst - 1;
+-          #if __riscv_xlen == 64
+-            if (!(*dst++ = src[4])) return dst - 1;
+-            if (!(*dst++ = src[5])) return dst - 1;
+-            if (!(*dst++ = src[6])) return dst - 1;
+-            dst0 = dst;
+-          #endif
+-        }
+-
+-      *dst = 0;
+-      return dst0;
+-    }
+-#endif /* not PREFER_SIZE_OVER_SPEED */
+-
+-  char ch;
+-  do
+-    {
+-      ch = *src;
+-      src++;
+-      dst++;
+-      *(dst - 1) = ch;
+-    } while (ch);
+-
+-  return ret_start ? dst0 : dst - 1;
+-}
++# define _MACHINE_RISCV_MEMCPY_C_
++# endif
+ 
++#if !defined(__PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
++# define _MACHINE_RISCV_MEMMOVE_GENERIC_
++#else
++# define _MACHINE_RISCV_MEMMOVE_ASM_
++# endif
+ 
+-#endif /* _RV_STRING_H */
++#endif /* _RV_STRING_H_ */
+diff --git a/newlib/libc/machine/riscv/stpcpy.c b/newlib/libc/machine/riscv/stpcpy.c
+index 47fbf8499..eb9a67f21 100644
+--- a/newlib/libc/machine/riscv/stpcpy.c
++++ b/newlib/libc/machine/riscv/stpcpy.c
+@@ -11,7 +11,7 @@
+ 
+ #define _DEFAULT_SOURCE
+ #include <stdbool.h>
+-#include "rv_string.h"
++#include "rv_strcpy.h"
+ 
+ #undef stpcpy
+ 
+diff --git a/newlib/libc/machine/riscv/strcpy.c b/newlib/libc/machine/riscv/strcpy.c
+index 653985f91..ad4658f55 100644
+--- a/newlib/libc/machine/riscv/strcpy.c
++++ b/newlib/libc/machine/riscv/strcpy.c
+@@ -10,7 +10,7 @@
+ */
+ 
+ #include <stdbool.h>
+-#include "rv_string.h"
++#include "rv_strcpy.h"
+ 
+ #undef strcpy
+ 
+diff --git a/newlib/libc/machine/riscv/strlen.c b/newlib/libc/machine/riscv/strlen.c
+index 064157515..e93e492ff 100644
+--- a/newlib/libc/machine/riscv/strlen.c
++++ b/newlib/libc/machine/riscv/strlen.c
+@@ -13,7 +13,7 @@
+ 
+ #include <string.h>
+ #include <stdint.h>
+-#include "rv_string.h"
++#include "rv_strcpy.h"
+ 
+ size_t strlen(const char *str)
+ {
+-- 
+2.34.1
+


### PR DESCRIPTION
…chanism

For RISC-V, it is possible to have several optimized implementations of library routines depending on which hardware extensions are enabled and the current mechanism to choose the appropriate implementation will quickly become messy when dealing with many implementations.

With the refactor, the idea is, for e.g., 'newlib/libc/machine/riscv/memcpy.c' will override the generic 'newlib/libc/string/memcpy.c' through the 'srcs_machine' scheme and conditions in 'newlib/libc/machine/riscv/memcpy.c' will decide which implementation gets compiled and used for a given scenario.

Put all the related changes into one header, e.g. 'rv_string.h' for all 'string.h' related API specializations, to avoid the potential header file clutter as we specialize more and more APIs from several headers. This mechanism is simple and scalable.

The existing 'rv_string.h' is renamed to 'rv_strcpy.h'.

This patch file is a squashed commit of all the changes from upstream PRs:
    https://github.com/picolibc/picolibc/pull/1090
    https://github.com/picolibc/picolibc/pull/1092
    https://github.com/picolibc/picolibc/pull/1098

These changes are available in Picolibc v1.8.11 and this patch file can be deleted when we upgrade picolibc to v1.8.11.