### PR TITLE
[cpullvm][Github] Add check for changes outside allowed files

### DIFF
--- a/.github/workflows/check_modified_files.yml
+++ b/.github/workflows/check_modified_files.yml
@@ -1,0 +1,35 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Check whether a PR makes changes only in files that we are allowed
+# to modify.
+
+name: Check Modified Files
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-modified-files:
+    # Don't run on forks
+    if: github.repository == 'qualcomm/cpullvm-toolchain'
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 2
+      
+      - name: Check modified files
+        run: |
+          mkdir -p build
+          git diff --name-only HEAD~ HEAD > build/files_changed.txt
+          python3 qualcomm-software/ci/check_modified_files.py --modified-files build/files_changed.txt

--- a/qualcomm-software/ci/check_modified_files.py
+++ b/qualcomm-software/ci/check_modified_files.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+A script to check that a list of modified files only includes those that we are allowed
+to modify. This is intended to help enforce our policy of making changes only within
+a few specific places (.github, qualcomm-software, and some documentation files).
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+CPULLVM_ALLOWED_PATHSPEC_FILE = Path(__file__).parent / "cpullvm_modified_files"
+
+
+# Test if a path is in the ignore list.
+def is_path_ignored(test_path: str, ignored_paths: list[str]) -> bool:
+    for ignored_path in ignored_paths:
+        # The ignore list contains paths or directories.
+        # Anything in an ignored subdirectory should also be ignored.
+        if os.path.commonpath([ignored_path, test_path]) == ignored_path:
+            logger.debug(f"{test_path} ignored by line {ignored_path}")
+            return True
+    return False
+
+
+# Test if a pull request contains a change outside of the allowed list of
+# files we may modify.
+def has_changes_outside_allowed_list(modified_files: str) -> bool:
+    excluded_files = []
+    included_files = []
+    with open(CPULLVM_ALLOWED_PATHSPEC_FILE, "r") as f:
+        ignored_paths = f.read().splitlines()
+    with open(modified_files, "r") as f:
+        file_list = f.read().splitlines()
+    for changed_file in file_list:
+        if is_path_ignored(changed_file, ignored_paths):
+            excluded_files.append(changed_file)
+        else:
+            included_files.append(changed_file)
+    if len(excluded_files) > 0:
+        excluded_list = "\n".join(excluded_files)
+        logger.info(f"File modifications in the allowed list:\n{excluded_list}")
+    if len(included_files) > 0:
+        included_list = "\n".join(included_files)
+        logger.info(f"File modifications outside the allowed list:\n{included_list}")
+    else:
+        logger.info("No modifications to files outside the allowed list found.")
+    return len(included_files) > 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--modified-files",
+        required=True,
+        help="File containing the list of files modified"
+    )
+    args = parser.parse_args()
+
+    if has_changes_outside_allowed_list(args.modified_files):
+        logger.info("Check failed, modified files contain changes outside of the allowed locations.")
+        sys.exit(1)
+    else:
+        logger.info("Check passed, modified files contain no changes outside of the allowed locations.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/qualcomm-software/ci/cpullvm_modified_files
+++ b/qualcomm-software/ci/cpullvm_modified_files
@@ -1,0 +1,4 @@
+.github
+qualcomm-software
+CONTRIBUTING.md
+README.md


### PR DESCRIPTION
Generally, we're only allowed to make changes in a handful of locations
(.github, qualcomm-software, and a few documentation files). Add a new workflow
to enforce this.

Note that this is heavily based on ATfE's `check_downstream_changes.py` and we
use the same approach (and some of the same code!) in defining a pathspec file
that notes where we are allowed to make changes. This should be helpful once
we start syncing changes and it came up as being a useful thing when adding
our CHANGELOG in the past.