### PR TITLE
[cpullvm][Github] Use Zephyr's ci-base Docker image

### DIFF
--- a/.github/workflows/zephyr-twister-tests.yml
+++ b/.github/workflows/zephyr-twister-tests.yml
@@ -50,7 +50,7 @@ jobs:
     # our (limited in number) self-hosted runners for hours at a time.
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:main
+      image: ghcr.io/zephyrproject-rtos/ci-base:main
       # Work around a mismatch between UIDs, see https://github.com/actions/checkout/issues/956
       options: '--user 0'
 
@@ -92,6 +92,11 @@ jobs:
         run: |
           west init -l .
           west update
+
+      # Source hosttools (including qemu) from the Zephyr SDK.
+      - name: Install Zephyr SDK hosttools
+        run: |
+          west sdk install --no-gnu-toolchains --install-base /opt/toolchains
 
       - name: Run Twister tests
         shell: bash


### PR DESCRIPTION
We're currently seeing errors in our Zephyr builders when setting up the
docker containers that seem to boil down to running out of storage ("failed
to register layer: ... no space left on device" [1][2]).

I *think* this is a consequence of using Github's free runners--they only
have 14 GB of storage [3] and the uncompressed image size of Zephyr's ci
image is around 19 GB. That said, I'm not sure why we're seeing this error
inconsistently if that is the case.

But, to try and resolve this, transition to Zephyr's ci-base image instead.
That one doesn't include the Zephyr SDK (and is only ~8 GB) but is otherwise
the same. We don't actually care about the toolchain bits of the SDK so that
is fine, but we do want the hosttools (qemu, etc.). So make sure we manually
add that.

[1] https://github.com/qualcomm/cpullvm-toolchain/actions/runs/24049165765
[2] https://github.com/qualcomm/cpullvm-toolchain/actions/runs/24109581240
[3] https://docs.github.com/en/actions/reference/runners/github-hosted-runners