### PR TITLE
[cpullvm] Add additional variants for testing Zephyr

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -56,6 +56,12 @@
             "flags": "--target=thumbv7m-unknown-none-eabi -mfpu=none"
         },
         {
+            "variant": "armv7m_soft_nofp_nopic",
+            "json": "armv7m_soft_nofp_nopic.json",
+            "flags": "--target=thumbv7m-unknown-none-eabi -mfpu=none -fno-pic",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "riscv32imc_ilp32_nothreads_nopic",
             "json": "riscv32imc_ilp32_nothreads_nopic.json",
             "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic",
@@ -121,7 +127,7 @@
             "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imac_zcb_zcmp_zba_zbb -mabi=ilp32 -fno-pic",
             "libraries_supported": "picolibc"
         },
-	{
+        {
             "variant": "riscv32imafc_ilp32f",
             "json": "riscv32imafc_ilp32f.json",
             "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imafc -mabi=ilp32f",
@@ -137,6 +143,12 @@
             "variant": "riscv32imafc_zcb_zcmp_zba_zbb_ilp32f",
             "json": "riscv32imafc_zcb_zcmp_zba_zbb_ilp32f.json",
             "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imafc_zcb_zcmp_zba_zbb -mabi=ilp32f",
+            "libraries_supported": "picolibc"
+        },
+        {
+            "variant": "riscv32gc_ilp32d",
+            "json": "riscv32gc_ilp32d.json",
+            "flags": "--target=riscv32-unknown-unknown-elf -march=rv32gc -mabi=ilp32d",
             "libraries_supported": "picolibc"
         },
         {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
@@ -1,0 +1,25 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv7m",
+            "VARIANT": "armv7m_soft_nofp_nopic",
+            "COMPILE_FLAGS": "-mfloat-abi=soft -march=armv7m -mfpu=none -mno-unaligned-access",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "mps2-an385",
+            "QEMU_CPU": "cortex-m3",
+            "FLASH_ADDRESS": "0x00000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x20000000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "riscv32",
+            "VARIANT": "riscv32gc_ilp32d",
+            "COMPILE_FLAGS": "-march=rv32gc -mabi=ilp32d -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "rv32",
+            "QEMU_PARAMS": "-bios none",
+            "FLASH_ADDRESS": "0x80000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x80400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -119,7 +119,7 @@ def main():
             description="If the installed default multilib does not have a library available for -mcpu=cortex-r52, this test will fail.",
         ),
         XFail(
-            name="picolibc_rv64gc",
+            name="picolibc rv32/64gc",
             testnames=[
                 "math_errhandling.test",
                 "test-fma.test",
@@ -127,6 +127,7 @@ def main():
             result=NewResult.XFAILED,
             project="picolibc",
             variants=[
+                "riscv32gc_ilp32d",
                 "riscv64gc_lp64d_nopic",
                 "riscv64gc_zba_zbb_lp64d_nopic",
                 "riscv64gc_lp64_nopic",


### PR DESCRIPTION
Two variants added:
* rv32gc ilp32d - Zephyr uses this extension/abi combo for quite
  a few hardfloat tests and we didn't have a compatible variant previously.
* armv7m nopic - Our existing variant is built with -fPIC and, for tests on
  qemu_cortex_m3 at least, Zephyr has linker script snippets that /DISCARD/
  the .got. eld currently can't relax referencing the .got, leading to
  errors when building. So for now provide a nopic variant for testing. Note
  also that, since this is for Zephyr only, we don't build this for
  musl-embedded. This config should also be removed once this
  optimization/relaxation is implemented in eld.