### PR TITLE
[cpullvm][Github] Schedule Zephyr tests

### DIFF
--- a/.github/workflows/zephyr-twister-tests.yml
+++ b/.github/workflows/zephyr-twister-tests.yml
@@ -5,6 +5,8 @@ name: Zephyr Twister Tests
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1' # Sunday 21:00 PST (Monday 05:00 UTC)
   pull_request:
     paths:
       - '.github/workflows/zephyr-twister-tests.yml'


### PR DESCRIPTION
Run them weekly just to have some idea of whether anything breaks--we aren't tracking them closely enough for daily to be all that helpful.

Also scheduling them so that the toolchain is hopefully pretty close to our Sunday nightly build.