### PR TITLE
[cpullvm] Note that QEMU system mode is used

### DIFF
--- a/qualcomm-software/docs/building.md
+++ b/qualcomm-software/docs/building.md
@@ -22,9 +22,9 @@ CPULLVM requires the following software to be installed:
 Library testing requires:
 * [QEMU](https://www.qemu.org/download/)
 
-Testing with QEMU is enabled by default, but can be disabled using the 
-`-DENABLE_QEMU_TESTING=OFF` CMake option if testing is not required or QEMU is
-not installed.
+Testing with QEMU (using QEMU's [system emulation](https://www.qemu.org/docs/master/system/introduction.html))
+is enabled by default, but can be disabled using the `-DENABLE_QEMU_TESTING=OFF` CMake
+option if testing is not required or QEMU is not installed.
 
 A relatively recent version of QEMU is required to support the latest RISC-V extensions.
 CPULLVM currently builds and tests with QEMU v10.1.3.


### PR DESCRIPTION
Errors are explicit that we're looking for `qemu-system-<arch>` if it isn't present when building, but this is a somewhat consistent point of confusion. Add a note that we're using system emulation that we can point to.