### PR TITLE
[cpullvm] Add more explicit references to options for running tests

### DIFF
--- a/qualcomm-software/docs/building.md
+++ b/qualcomm-software/docs/building.md
@@ -105,6 +105,8 @@ To run all LLVM, eld, and library tests together, the below command may be used:
 ```
 ninja check-all-llvm-toolchain
 ```
+Tests can also be run in smaller subsets, please refer to our [developer documentation](./developing.md#testing-the-toolchain)
+for more information.
 
 ### Installing the toolchain
 

--- a/qualcomm-software/docs/developing.md
+++ b/qualcomm-software/docs/developing.md
@@ -120,5 +120,10 @@ to test these components separately. A non-exhaustive list of `check-` targets C
 * `check-clang`, `check-llvm`, and the other usual LLVM `check-` targets are all still valid
 * `check-eld` works as usual
 * `check-llvm-toolchain-lit` runs only the built-in [multilib tests](../test/multilib/)
-* `check-<component>` targets (where component is ex: picolibc) will run any enabled tests for that component across all variants
+* `check-<component>` targets will run any enabled tests for that component across all variants
 * `check-<component>-<variant>` targets will run the given component tests for the specified variant
+
+Example (non-exhaustive) components that can be used in the commands above:
+* `compiler-rt`
+* `picolibc` (or the name of the C library selected if different)
+* `cxx`/`cxxabi`/`unwind`


### PR DESCRIPTION
To hopefully make it a bit more explicit how to run subsets of tests:
1. In building.md, add a reference to our developer documentation that has additional details.
2. In developing.md, add explicit examples of the types of components that can be used.