### PR TITLE
[cpullvm] Set CC/CXX in the environment for Windows builds

### DIFF
--- a/qualcomm-software/docs/building.md
+++ b/qualcomm-software/docs/building.md
@@ -68,34 +68,30 @@ currently-enabled embedded variants.
 > [build scripts](/qualcomm-software/scripts) for examples on how our toolchains are built and packaged
 > on different hosts.
 
-### Linux
-The commands in the sections below assume you are in the `cpullvm-toolchain/qualcomm-software` directory.
+### Configuring and building the toolchain
 
-The toolchain can be built directly with CMake.
+The commands in the sections below assume you are in the `cpullvm-toolchain/qualcomm-software` directory.
 
 All dependencies are assumed to be present in your `PATH`.
 
+First, populate the `CC` and `CXX` environment variables to tell CMake which toolchain to use:
+
+Linux:
 ```
-# Alternatively, CMAKE_C_COMPILER/CMAKE_CXX_COMPILER may be set directly
 export CC=clang
 export CXX=clang++
+```
+Windows:
+```
+$env:CC = 'clang-cl'
+$env:CXX = 'clang-cl'
+```
+
+Then, the toolchain can be configured directly with CMake and built:
+```
 mkdir build
 cd build
 cmake .. -GNinja -DFETCHCONTENT_QUIET=OFF
-ninja llvm-toolchain
-```
-
-### Windows
-The commands in the sections below assume you are in the `cpullvm-toolchain/qualcomm-software` directory.
-
-The toolchain can be built directly with CMake.
-
-All dependencies are assumed to be present in your `PATH`.
-
-```
-mkdir build
-cd build
-cmake .. -GNinja -DFETCHCONTENT_QUIET=OFF -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
 ninja llvm-toolchain
 ```
 

--- a/qualcomm-software/scripts/build.ps1
+++ b/qualcomm-software/scripts/build.ps1
@@ -20,6 +20,9 @@ Set-VS-Env
 $repoRoot = git -C $PSScriptRoot rev-parse --show-toplevel
 $buildDir = (Join-Path $repoRoot build)
 
+$env:CC = 'clang-cl'
+$env:CXX = 'clang-cl'
+
 mkdir $buildDir
 cd $buildDir
 
@@ -27,8 +30,6 @@ cd $buildDir
 cmake ..\qualcomm-software `
   -GNinja `
   -DFETCHCONTENT_QUIET=OFF `
-  -DENABLE_QEMU_TESTING=OFF `
-  -DCMAKE_C_COMPILER=clang-cl `
-  -DCMAKE_CXX_COMPILER=clang-cl
+  -DENABLE_QEMU_TESTING=OFF
 
 ninja package-llvm-toolchain

--- a/qualcomm-software/scripts/build_copy_runtimes.ps1
+++ b/qualcomm-software/scripts/build_copy_runtimes.ps1
@@ -21,6 +21,9 @@ Set-VS-Env
 $repoRoot = git -C $PSScriptRoot rev-parse --show-toplevel
 $buildDir = (Join-Path $repoRoot build)
 
+$env:CC = 'clang-cl'
+$env:CXX = 'clang-cl'
+
 mkdir $buildDir -Force
 cd $buildDir
 
@@ -30,8 +33,6 @@ cmake ..\qualcomm-software `
   -GNinja `
   -DFETCHCONTENT_QUIET=OFF `
   -DPREBUILT_TARGET_LIBRARIES=ON `
-  -DENABLE_LINUX_LIBRARIES=ON `
-  -DCMAKE_C_COMPILER=clang-cl `
-  -DCMAKE_CXX_COMPILER=clang-cl
+  -DENABLE_LINUX_LIBRARIES=ON
 
 ninja package-llvm-toolchain


### PR DESCRIPTION
There's a few different aims here:
* Setting CMAKE_C_COMPILER, etc. directly can be a bit confusing when looking through our logs. That value is not propagated when we add multilib and the runtimes as external CMake projects so these projects report MSVC as CMAKE_C[XX]_COMPILER. We don't *use* MSVC in these subprojects (we manually pass in/use the just-built LLVM toolchain) so there shouldn't be any functional change here, but it should hopefully avoid confusion if/when people look through logs.

  So, I think it is best we avoid recommending this if we can.
* This also aligns our Windows builds closer to what we recommend for Linux.

With this change, I think we can also consolidate our build instructions a bit to make them (hopefully) more clear/concise.