### PR TITLE
[ATfE] Add automerge script and workflows

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,11 +10,9 @@ on:
   workflow_dispatch:
 jobs:
   Run-Automerge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
-      contents: write
       pull-requests: write
-      issues: write
     if: github.repository == 'qualcomm/cpullvm-toolchain'
     strategy:
       matrix:
@@ -22,32 +20,26 @@ jobs:
           - from_branch: main
             to_branch: qualcomm-software
     steps:
-      - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v1
+      - name: Configure Access Token
+        uses: actions/create-github-app-token@f45685208fd9b88321d74015b5996fc8c3e43d18 # v1.0.0
         id: generate-token
         with:
-          app-id: ${{ secrets.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-      - name: Authenticate GitHub CLI
-        run: |
-          gh auth logout --hostname github.com || true
-          echo "${{ steps.generate-token.outputs.token }}" | gh auth login --with-token
-          gh auth setup-git
-      - name: Checkout target branch
-        uses: actions/checkout@v4
+          app_id: ${{ secrets.SYNC_APP_ID }}
+          private_key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ matrix.branches.to_branch }}
-          fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - name: Configure Git Identity
         run: |
-          git config --local user.name "cpullvmbot"
-          git config --local user.email "cpullvmbot@qti.qualcomm.com"
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Fetch Branches
         run: |
           git remote set-branches --add origin ${{ matrix.branches.from_branch }}
           git fetch origin ${{ matrix.branches.from_branch }}:${{ matrix.branches.from_branch }}
-          git pull --ff-only origin ${{ matrix.branches.to_branch }}
+          git pull --unshallow --ff-only origin ${{ matrix.branches.to_branch }}
       - name: Run automerge
         run: python3 qualcomm-software/ci/automerge.py --project-name ${{ github.repository }} --from-branch ${{ matrix.branches.from_branch }} --to-branch ${{ matrix.branches.to_branch }} --verbose
         env:

--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   Fetch-Upstream:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'qualcomm/cpullvm-toolchain'
     strategy:
       matrix:
@@ -17,13 +17,13 @@ jobs:
       UPSTREAM_REMOTE: https://github.com/llvm/llvm-project.git
     steps:
       - name: Configure Access Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@f45685208fd9b88321d74015b5996fc8c3e43d18 # v1.0.0
         id: generate-token
         with:
-          app-id: ${{ secrets.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.SYNC_APP_ID }}
+          private_key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ matrix.branch }}
           token: ${{ steps.generate-token.outputs.token }}
@@ -33,7 +33,7 @@ jobs:
         run: git pull --ff-only upstream ${{ matrix.branch }}
       - name: Configure Git Identity
         run: |
-          git config --local user.name "cpullvmbot"
-          git config --local user.email "cpullvmbot@qti.qualcomm.com"
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Push Changes
         run: git push origin ${{ matrix.branch }}

--- a/qualcomm-software/ci/automerge.py
+++ b/qualcomm-software/ci/automerge.py
@@ -11,7 +11,6 @@ import logging
 import shlex
 import subprocess
 import sys
-from typing import Optional, List, Iterable, Dict
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -22,6 +21,7 @@ MERGE_CONFLICT_LABEL = "automerge_conflict"
 AUTOMERGE_BRANCH = "automerge"
 REMOTE_NAME = "origin"
 MERGE_IGNORE_PATHSPEC_FILE = Path(__file__).parent / "cpullvm_modified_files"
+
 
 class MergeConflictError(Exception):
     """
@@ -92,6 +92,7 @@ def prefix_current_commit_message(git_repo: Git) -> None:
     commit_msg = f"Automerge: {log_output}"
     git_repo.run_cmd(["commit", "--amend", "--message=" + commit_msg])
 
+
 def merge_commit(
     git_repo: Git,
     to_branch: str,
@@ -112,7 +113,6 @@ def merge_commit(
     # that by not checking the exist status and validating that a merge is in
     # progress after `git merge` runs.
     git_repo.run_cmd(["merge", commit_hash, "--no-commit", "--no-ff"], check=False)
-  
     if not is_merge_in_progress(git_repo):
         raise RuntimeError("Unexpected error occurred when running git merge")
     restore_changes_to_ignored_files(git_repo, ignored_paths)
@@ -149,7 +149,7 @@ def create_pull_request(git_repo: Git, to_branch: str) -> None:
             AUTOMERGE_BRANCH,
             "--base",
             to_branch,
-            "--body", "Automerge hit a merge conflict. Please check the CI logs for details.",
+            "--fill",
             "--title",
             pr_title,
             "--label",
@@ -177,7 +177,6 @@ def get_merge_commit_list(git_repo: Git, from_branch: str, to_branch: str) -> li
     logger.info(
         "Calculating list of commits to be merged from %s to %s", from_branch, to_branch
     )
-    
     merge_base_output = git_repo.run_cmd(["merge-base", from_branch, to_branch])
     merge_base_commit = merge_base_output.strip()
     log_output = git_repo.run_cmd(
@@ -190,8 +189,6 @@ def get_merge_commit_list(git_repo: Git, from_branch: str, to_branch: str) -> li
     commit_list = commit_list.split("\n")
     commit_list.reverse()
     logger.info("Found %d commits to be merged", len(commit_list))
-    logger.info("First commit getting synced : %s", commit_list[0])
-    logger.info("Last  commit getting synced : %s", commit_list[-1])
     return commit_list
 
 
@@ -251,6 +248,7 @@ def main():
         action="store_true",
         help="Print verbose log messages during automerge run",
     )
+
     args = arg_parser.parse_args()
 
     if args.verbose:
@@ -272,7 +270,8 @@ def main():
             ignored_paths = ignored_paths_file.read().splitlines()
 
         merge_commits = get_merge_commit_list(
-            git_repo, args.from_branch, args.to_branch)
+            git_repo, args.from_branch, args.to_branch
+        )
         for commit_hash in merge_commits:
             merge_commit(
                 git_repo,


### PR DESCRIPTION
This introduces a script to automatically perform the merge of incoming changes from upstream LLVM which live in the `main` branch into the downstream `qualcomm-software` branch. It also includes a GitHub Workflow to execute it after every sync from upstream.

This a cherrypick of arm/arm-toolchain@8b29e5e

Change-Id: I6f8abc1445e7ed37d4569f4bb1f44a8eb5a08157