### PR TITLE
[cpullvm] Include our docs folder in the installation

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -794,6 +794,12 @@ install(
     COMPONENT llvm-toolchain-docs
 )
 
+install(
+    DIRECTORY docs
+    DESTINATION .
+    COMPONENT llvm-toolchain-docs
+)
+
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
     string(APPEND LIBC_LICENSE_FILES " - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc\n")
 endif()


### PR DESCRIPTION
We include our README, etc. which reference these files. So, just include them in the installation as well in case they're helpful to refer to.

Note that this is what Arm's toolchain does/did--I think I originally omitted this since we had no 'docs/' folder at the time and forgot to re-include it once we created one.