### PR TITLE
[cpullvm] - Prepare for LIBCXX tests enablement ARM. 

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_hard_vfpv3.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_hard_vfpv3.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -235,12 +235,15 @@ if(ENABLE_LIBC_TESTS OR ENABLE_COMPILER_RT_TESTS OR ENABLE_LIBCXX_TESTS)
 endif()
 
 set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS} --sysroot ${TEMP_LIB_DIR}")
+if(NOT C_LIBRARY STREQUAL musl-embedded)
+    # Apply the same TLS model to test compilation as is used for library builds.
+    # Without this, -fPIC variants default to general-dynamic TLS which emits
+    # __tls_get_addr calls that are not available on bare-metal.
+    string(APPEND compile_arch_flags " -ftls-model=${TLS_MODEL}")
+endif()
 # Compiling the libraries benefits from some extra optimization
 # flags, and requires a sysroot.
 set(lib_compile_flags "${compile_arch_flags} -ffunction-sections -fdata-sections")
-if(NOT C_LIBRARY STREQUAL musl-embedded)
-    string(APPEND lib_compile_flags " -ftls-model=${TLS_MODEL}")
-endif()
 
 # Generic target names for the C library.
 # Declare these now, since compiler-rt requires the 'install' dependency.

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -190,6 +190,153 @@ def main():
                 "insufficient memory. It requires at-least 10MB RAM."
         ),
         XFail(
+            name="flat-container-oom-armv7m",
+            testnames=[
+                "std/containers/container.adaptors/flat.map/flat.map.capacity/size.pass.cpp",
+                "std/containers/container.adaptors/flat.set/flat.set.capacity/size.pass.cpp",
+            ],
+            result=NewResult.XFAILED,
+            project="libcxx",
+            variants=[
+                "armv7m_soft_nofp",
+                "armv7m_soft_nofp_nopic",
+                "armv7m_hard_fpv5_d16_nopic",
+            ],
+            description="flat.map/size and flat.set/size insert 1,000,000 elements at "
+                        "runtime, exceeding the 8MB RAM on armv7m bare-metal QEMU targets. "
+                        "armv7a/armv8 have 16MB RAM and pass. The test aborts with exit 1.",
+        ),
+        XFail(
+            name="sort-heap-complexity-armv7m",
+            testnames=[
+                "std/algorithms/alg.sorting/alg.heap.operations/sort.heap/complexity.pass.cpp",
+                "std/algorithms/alg.sorting/alg.heap.operations/sort.heap/ranges_sort_heap.pass.cpp",
+            ],
+            result=NewResult.XFAILED,
+            project="libcxx",
+            variants=[
+                "armv7m_soft_nofp",
+                "armv7m_soft_nofp_nopic",
+                "armv7m_hard_fpv5_d16_nopic",
+            ],
+            description="sort.heap complexity tests use std::random_device which falls "
+                        "back to a fixed seed on armv7m bare-metal, causing the complexity "
+                        "assertion to fail. armv7a/armv8 pass. Exits with code 1.",
+        ),
+        XFail(
+            name="simd-unary-compiler-crash-armv7a",
+            testnames=[
+                "std/experimental/simd/simd.class/simd_unary.pass.cpp",
+            ],
+            result=NewResult.EXCLUDE,
+            project="libcxx",
+            variants=[
+                "armv7a_soft_neon",
+                "armv8_soft_neon",
+            ],
+            description="simd_unary.pass.cpp triggers a clang assertion failure "
+                        "(ScalarizeVecOp_VSETCC: expected v1i1 type) in "
+                        "LegalizeVectorTypes.cpp when compiling std::experimental::simd "
+                         "on ARMv7-A/ARMv8 with NEON. Compiler bug; exclude until fixed.",
+        ),
+        XFail(
+            name="long-double-picolibc-aarch64",
+            testnames=[
+                "std/strings/string.conversions/stold.pass.cpp",
+                "std/strings/string.conversions/to_string.pass.cpp",
+                "std/localization/locale.categories/category.monetary/locale.money.get/locale.money.get.members/get_long_double_overlong.pass.cpp",
+                "std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.hex.pass.cpp",
+                "std/localization/locale.categories/category.numeric/locale.nm.put/facet.num.put.members/put_long_double.pass.cpp",
+                "std/input.output/iostream.format/output.streams/ostream.formatted/ostream.inserters.arithmetic/long_double.pass.cpp",
+            ],
+            result=NewResult.XFAILED,
+            project="libcxx",
+            variants=[
+                "aarch64a_tlsie",
+            ],
+            description="Long double is 128-bit on AArch64 and conversion between 128-bit "
+                        "types and strings is broken in picolibc. ARM 32-bit is unaffected "
+                        "(64-bit long double).",
+        ),
+        XFail(
+            name="aeabi-unwind-cpp-pr0-missing-arm",
+            testnames=[
+                "std/language.support/support.coroutines/end.to.end/",
+                "std/language.support/support.coroutines/coroutine.handle/coroutine.handle.noop/",
+                "std/language.support/support.coroutines/coroutine.handle/coroutine.handle.prom/",
+                "extensions/libcxx/odr_signature.exceptions.sh.cpp",
+            ],
+            result=NewResult.EXCLUDE,
+            project="libcxx",
+            variants=[
+                "armv8_soft_neon",
+                "armv7a_soft_neon",
+                "armv7a_soft_nofp",
+                "armv7a_hard_vfpv3",
+                "armv7m_soft_nofp",
+                "armv7m_soft_nofp_nopic",
+                "armv7m_hard_fpv5_d16_nopic",
+            ],
+            description="Tests that emit .ARM.exidx unwind tables referencing "
+                        "__aeabi_unwind_cpp_pr0, which is absent in the bare-metal "
+                        "semihosting runtime. Affects coroutine tests (which emit unwind "
+                        "tables even with -fno-exceptions) and odr_signature.exceptions "
+                        "(which mixes -fexceptions and -fno-exceptions TUs).",
+        ),
+        XFail(
+            name="at_exit",
+            testnames=[
+                "std/language.support/support.start.term/quick_exit.pass.cpp",
+            ],
+            result=NewResult.XFAILED,
+            project="libcxx",
+            description="at_quick_exit symbol is not found in the picolibc semihosting runtime.",
+        ),
+        XFail(
+            name="uchar-cuchar-xpass-picolibc",
+            testnames=[
+                "std/depr/depr.c.headers/uchar_h.compile.pass.cpp",
+                "std/strings/c.strings/cuchar.compile.pass.cpp",
+            ],
+            result=NewResult.PASSED,
+            project="libcxx",
+            description="uchar_h and cuchar compile tests are XFAIL upstream for picolibc "
+                        "(mbrtoc16 not defined), but picolibc does define mbrtoc16/c16rtomb "
+                        "so they pass on all our bare-metal variants. Suppress XPASS.",
+        ),
+        XFail(
+            name="cas-non-power-of-2-no-generic-atomic",
+            testnames=[
+                "std/atomics/atomics.types.generic/cas_non_power_of_2.pass.cpp",
+            ],
+            result=NewResult.EXCLUDE,
+            project="libcxx",
+            variants=[
+                "armv8_soft_neon",
+                "armv7a_soft_neon",
+                "armv7a_soft_nofp",
+                "armv7a_hard_vfpv3",
+                "armv7m_soft_nofp",
+                "armv7m_soft_nofp_nopic",
+                "armv7m_hard_fpv5_d16_nopic",
+            ],
+            description="cas_non_power_of_2.pass.cpp tests atomic operations on structs of "
+                        "sizes 3, 5, and 6 bytes, which require the generic (unsized) libcalls "
+                        "__atomic_load / __atomic_compare_exchange.  These lock-based fallbacks "
+                        "are not provided by libclang_rt.builtins.a on our bare-metal ARM targets.",
+        ),
+        XFail(
+            name="no-c8rtomb-verify-picolibc",
+            testnames=[
+                "std/strings/c.strings/no_c8rtomb_mbrtoc8.verify.cpp",
+            ],
+            result=NewResult.EXCLUDE,
+            project="libcxx",
+            description="Picolibc provides c8rtomb/mbrtoc8, so the verify test's expected "
+                        "errors ('no member named c8rtomb') do not fire. Exclude since the "
+                        "test premise does not apply to picolibc targets.",
+        ),
+        XFail(
             name="emulated crash signals",
             testnames=[
                 "aarch64/emupac.c",

--- a/qualcomm-software/scripts/test_libcxx.sh
+++ b/qualcomm-software/scripts/test_libcxx.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to run the libc++ tests for the Qualcomm embedded toolchain.
+#
+# These tests are kept separate from test.sh because ninja check-cxx takes
+# significantly longer to run than the rest of the test suite.  Run this
+# script in addition to test.sh when libc++ test coverage is required.
+#
+# The script assumes a successful build of the toolchain exists in the 'build'
+# directory inside the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+
+cd "${REPO_ROOT}"/build
+ninja  check-cxx-aarch64a_tlsie 
+ninja  check-cxx-armv7a_hard_vfpv3
+ninja  check-cxx-armv7a_soft_neon 
+ninja  check-cxx-armv7a_soft_nofp 
+ninja  check-cxx-armv7m_hard_fpv5_d16_nopic 
+ninja  check-cxx-armv7m_soft_nofp 
+ninja  check-cxx-armv7m_soft_nofp_nopic 
+ninja  check-cxx-armv8_soft_neon


### PR DESCRIPTION
Manage fixes and split testing script to run check-cxx separately to reduce the testing time for libcxx tests. 