### PR TITLE
[WIP] Remove clang-runtimes dir

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -71,7 +71,7 @@ option(
     "Target libraries are prebuilt so no need to build them"
 )
 set(TARGET_LIBRARIES_DIR
-    "lib/clang-runtimes" CACHE STRING
+    "lib" CACHE STRING
     "Directory containing the target libraries."
 )
 set(LLVM_TOOLCHAIN_MULTILIB_JSON
@@ -571,7 +571,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         # If we're building a non-default libc with the intention of
         # installing it as an overlay on the main package archive, then
         # all of its includes, libraries and multilib.yaml go in a
-        # subdirectory of lib/clang-runtimes. Configuration files in the
+        # subdirectory of lib. Configuration files in the
         # bin directory will make it easy to reset the sysroot to point at
         # that subdir.
         set(library_subdir "/${LLVM_TOOLCHAIN_C_LIBRARY}")

--- a/qualcomm-software/cmake/copy_target_libraries.py
+++ b/qualcomm-software/cmake/copy_target_libraries.py
@@ -60,7 +60,7 @@ def main():
     lib_dir = os.path.join(args.build_dir, "llvm", "lib")
     os.makedirs(lib_dir, exist_ok=True)
 
-    destination = os.path.join(lib_dir, "clang-runtimes")
+    destination = os.path.join(lib_dir)
 
     if os.path.isdir(destination):
         shutil.rmtree(destination)
@@ -84,7 +84,7 @@ def main():
         # position. The rest of the files in the distribution folder
         # will be deleted automatically when the tmp object goes out of
         # scope.
-        move_folder(os.path.join(tmp, "*", "lib", "clang-runtimes"), lib_dir)
+        move_folder(os.path.join(tmp, "*", "lib"), lib_dir)
 
         if args.include_linux_libraries:
             # Move the entire resource directory

--- a/qualcomm-software/musl-embedded.cfg
+++ b/qualcomm-software/musl-embedded.cfg
@@ -1,1 +1,1 @@
---sysroot <CFGDIR>/../lib/clang-runtimes/musl-embedded
+--sysroot <CFGDIR>/../lib/musl-embedded

--- a/qualcomm-software/test/lit.site.cfg.py.in
+++ b/qualcomm-software/test/lit.site.cfg.py.in
@@ -11,7 +11,7 @@ config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@LLVM_DEFAULT_TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
-config.substitutions.append(("%llvm_embedded_libs_dir", "@LLVM_BINARY_DIR@/lib/clang-runtimes"))
+config.substitutions.append(("%llvm_embedded_libs_dir", "@LLVM_BINARY_DIR@/lib"))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
Related RFC: https://discourse.llvm.org/t/rfc-remove-the-use-of-clang-runtimes-subfolder-in-the-baremetal-driver/90504

This change removes `clang-runtimes` from relevant paths.