### PR TITLE
Enable python for LLDB.

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -175,6 +175,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     lldb-dap
     lldb-instr
     lldb-mcp
+    lldb-python-scripts
     lldb-server
     llvm-addr2line
     llvm-ar
@@ -250,17 +251,11 @@ set(LLVM_BUILD_RUNTIME OFF CACHE BOOL "")
 set(LIBCLANG_BUILD_STATIC ON CACHE BOOL "")
 set(LLVM_POLLY_LINK_INTO_TOOLS ON CACHE BOOL "")
 set(CLANG_DEFAULT_LINKER lld CACHE STRING "")
-# FIXME: We have a few issues integrating lldb:
-#   1. We add LLVM sources via `add_subdirectory` which lldb does not like--it
-#      expects to be the top level project. Currently we see issues with
-#      incorrect symlinks and incorrect paths in `lldb -P` stemming from this.
-#   2. We set the default target triple of the toolchain to a triple that
-#      doesn't necessarily match the host. lldb tries running binaries built
-#      for the default target on the host, which fails.
-# We have workarounds for #2, but #1 is still an open issue. For now, disable
-# python support and turn off testing while we sort out the best way to handle
-# these issues.
-set(LLDB_ENABLE_PYTHON OFF CACHE BOOL "")
+set(LLDB_ENABLE_PYTHON ON CACHE BOOL "")
+# LLDB tests don't work on x86 because clang defaults to AArch64 target triple.
+# See https://github.com/llvm/llvm-project/issues/203090 .  Using a clang
+# wrapper works around a few of the failures; we don't have any good workaround
+# for the rest.
 set(LLDB_INCLUDE_TESTS OFF CACHE BOOL "")
 
 # Default to a release build


### PR DESCRIPTION
Tests are not enabled due to failures (see comment in code).

(Depends on 6e7c4fd79d769bf860045af798a1ee7eefc88305 from upstream.)