### PR TITLE
[patch_repo] allow script to detect if patches have been applied already

### DIFF
--- a/qualcomm-software/cmake/patch_repo.py
+++ b/qualcomm-software/cmake/patch_repo.py
@@ -25,7 +25,7 @@ def main():
         "--method",
         choices=["am", "apply"],
         default="apply",
-        help="Git command to use. git am will add each patch as a commit, whereas git apply will leave patched changes staged.",
+        help="Git command to use. git am will add each patch as a commit, whereas git apply will leave patched changes staged and skip patches that are already applied.",
     )
     parser.add_argument(
         "--reset",
@@ -114,7 +114,9 @@ def main():
                 if args.three_way:
                     apply_check_args.append("--3way")
                 apply_check_args.append(str(current_patch))
-                p_check = subprocess.run(apply_check_args)
+                p_check = subprocess.run(
+                    apply_check_args, capture_output=True, text=True
+                )
 
                 if p_check.returncode == 0:
                     # Patch will apply.
@@ -129,7 +131,23 @@ def main():
                     p = subprocess.run(apply_args, check=True)
                     applied_patches.append(current_patch)
                 else:
-                    # Patch won't apply.
+                    # Patch does not apply cleanly. Check if it is already applied
+                    # by attempting a reverse check.
+                    reverse_check_args = git_cmd + [
+                        "apply",
+                        "--ignore-whitespace",
+                        "--reverse",
+                        "--check",
+                        str(current_patch),
+                    ]
+                    p_rev = subprocess.run(
+                        reverse_check_args, capture_output=True, text=True
+                    )
+                    if p_rev.returncode == 0:
+                        print(f"Skipping {current_patch.name} (already applied).")
+                        continue
+
+                    # Patch is not already applied and cannot be applied cleanly.
                     print(f"Unable to apply {current_patch.name}")
                     if args.restore_on_fail:
                         # Remove any patches that have already been applied.

--- a/qualcomm-software/docs/building.md
+++ b/qualcomm-software/docs/building.md
@@ -50,7 +50,7 @@ Generally, these patches are automatically applied, except for llvm-project whic
 patched manually. The below command assumes you are in the `cpullvm-toolchain` directory:
 
 ```
-python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
+python3 qualcomm-software/cmake/patch_repo.py qualcomm-software/patches/llvm-project
 ```
 
 Other projects (eld, picolibc, etc.) are checked out and patched automatically. If you prefer, you can check

--- a/qualcomm-software/docs/building.md
+++ b/qualcomm-software/docs/building.md
@@ -50,7 +50,7 @@ Generally, these patches are automatically applied, except for llvm-project whic
 patched manually. The below command assumes you are in the `cpullvm-toolchain` directory:
 
 ```
-python3 qualcomm-software/cmake/patch_repo.py qualcomm-software/patches/llvm-project
+python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
 ```
 
 Other projects (eld, picolibc, etc.) are checked out and patched automatically. If you prefer, you can check

--- a/qualcomm-software/docs/developing.md
+++ b/qualcomm-software/docs/developing.md
@@ -75,13 +75,12 @@ and libc++/libc++abi/libunwind libraries for the variant.
 ### Re-running CMake
 Unless you have manually checked out and patched CPULLVM's various dependencies (see "Manually checking out
 and patching dependencies" below), CPULLVM's CMake will automatically checkout and patch the dependencies'
-Git repositories. Note that it will *always* try to patch these repos, even if the patches have already been
-applied. So, if you rerun CMake (either by manually invoking it or by modifying a file in some way that CMake
-automatically reruns when rebuilding), you'll likely encounter errors.
+Git repositories. The patching script uses `git am` and will skip patches that have already been applied,
+so re-running CMake is safe in the common case.
 
-To work around this, after the first time you invoke CMake, you can include `-DFETCHCONTENT_FULLY_DISCONNECTED=ON`
-in your CMake command to tell it to stop updating and patching. Worst case, you can also manually remove the
-cloned repostories (located in `<build>/_deps`).
+If you encounter issues with re-running CMake (for example, after a failed or partial patch application),
+you can include `-DFETCHCONTENT_FULLY_DISCONNECTED=ON` in your CMake command to tell it to stop updating
+and patching. Worst case, you can also manually remove the cloned repositories (located in `<build>/_deps`).
 
 ### Manually checking out and patching dependencies
 It is also possible to manually checkout CPULLVM's dependencies. If you do so, you must ensure the

--- a/qualcomm-software/docs/developing.md
+++ b/qualcomm-software/docs/developing.md
@@ -75,7 +75,7 @@ and libc++/libc++abi/libunwind libraries for the variant.
 ### Re-running CMake
 Unless you have manually checked out and patched CPULLVM's various dependencies (see "Manually checking out
 and patching dependencies" below), CPULLVM's CMake will automatically checkout and patch the dependencies'
-Git repositories. The patching script uses `git am` and will skip patches that have already been applied,
+Git repositories. The patching script will skip patches that have already been applied,
 so re-running CMake is safe in the common case.
 
 If you encounter issues with re-running CMake (for example, after a failed or partial patch application),


### PR DESCRIPTION
In the current implementation, re-running builds fails as git apply fails to apply patches to _deps/* due to the patches already being applied. This patch fixes that by detecting if patches have been applied using git apply --reverse checks.