### PR TITLE
[cpullvm] Enable libcxxabi tests

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
@@ -19,7 +19,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "ON",
             "TLS_MODEL": "initial-exec"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
@@ -19,7 +19,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp.json
@@ -19,7 +19,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
@@ -19,7 +19,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/armv8_soft_neon.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv8_soft_neon.json
@@ -19,7 +19,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         },
         "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "ON",
             "DISABLE_THREADS": "ON"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_ilp32_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_ilp32f.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zba_zbb_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zba_zbb_ilp32f.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imc_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imc_ilp32_nothreads_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "ON",
             "DISABLE_THREADS": "ON"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "ON",
             "DISABLE_THREADS": "ON"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF"
+            "ENABLE_LIBCXX_TESTS": "ON"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
@@ -20,7 +20,7 @@
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
             "ENABLE_COMPILER_RT_TESTS": "ON",
-            "ENABLE_LIBCXX_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "ON",
             "DISABLE_THREADS": "ON"
         }
     }

--- a/qualcomm-software/embedded-runtimes/test-support/llvm-libc++abi-picolibc.cfg.in
+++ b/qualcomm-software/embedded-runtimes/test-support/llvm-libc++abi-picolibc.cfg.in
@@ -19,8 +19,10 @@ config.substitutions.append(('%{link_flags}',
     ' -nostdlib++ -L %{lib}'
     ' -lc++ -lc++abi'
     ' -nostdlib -L %{libc-lib}'
+    ' -Wl,--start-group'
     ' -lc -lm -lclang_rt.builtins'
     ' %{libc-extra-link-flags}'
+    ' -Wl,--end-group'
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %{temp} -- '

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -187,6 +187,23 @@ def main():
                 "since compiler-rt's atomic.c requires lock-free hardware CAS to compile.",
         ),
         XFail(
+            name="Insufficient RAM",
+            testnames=[
+                "dynamic_cast14.pass.cpp",
+            ],
+            result=NewResult.XFAILED,
+            project="libcxx",
+            variants=[
+                "armv7m_hard_fpv5_d16_nopic",
+                "armv7m_soft_nofp",
+                "armv7m_soft_nofp_nopic",
+            ],
+            description="dynamic_cast14.pass.cpp (cxxabi test) fails due to"
+                "insufficient memory. It requires at-least 10MB RAM. Increasing the"
+                "RAM_SIZE from current 8MB to 10MB in"
+                "armv7m_hard_fpv5_d16_nopic.json leads to QTOOL-141735",
+        ),
+        XFail(
             name="emulated crash signals",
             testnames=[
                 "aarch64/emupac.c",

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -187,9 +187,7 @@ def main():
                 "armv7m_soft_nofp_nopic",
             ],
             description="dynamic_cast14.pass.cpp (cxxabi test) fails due to"
-                "insufficient memory. It requires at-least 10MB RAM. Increasing the"
-                "RAM_SIZE from current 8MB to 10MB in"
-                "these variants leads to QTOOL-141735",
+                "insufficient memory. It requires at-least 10MB RAM."
         ),
         XFail(
             name="emulated crash signals",

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -201,7 +201,7 @@ def main():
             description="dynamic_cast14.pass.cpp (cxxabi test) fails due to"
                 "insufficient memory. It requires at-least 10MB RAM. Increasing the"
                 "RAM_SIZE from current 8MB to 10MB in"
-                "armv7m_hard_fpv5_d16_nopic.json leads to QTOOL-141735",
+                "these variants leads to QTOOL-141735",
         ),
         XFail(
             name="emulated crash signals",

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -152,6 +152,41 @@ def main():
             description="Disable the tests for now while the issue is being fixed upstream (https://github.com/picolibc/picolibc/pull/1072).",
         ),
         XFail(
+            name="picolibc_rv32im_xqci",
+            testnames=[
+                "test-except.test"
+            ],
+            result=NewResult.EXCLUDE,
+            project="picolibc",
+            variants=[
+                "riscv32im_xqci_ilp32_nothreads_nopic"
+            ],
+            description="This test times out for some reason and we will most probably need a fix in QEMU. Disable until we have one.",
+        ),
+        XFail(
+            name="no hardware atomics cxxabi",
+            testnames=[
+                "test_exception_storage.pass.cpp",
+            ],
+            result=NewResult.XFAILED,
+            project="libcxx",
+            variants=[
+                "riscv32im_xqci_ilp32_nothreads_nopic",
+                "riscv32imc_ilp32_nothreads_nopic",
+                "riscv32imc_ilp32_scs_nothreads_nopic",
+                "riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic",
+                "riscv64imc_lp64_nothreads_nopic",
+                "riscv64imc_lp64_scs_nothreads_nopic",
+            ],
+            description="These variants are built without the RISC-V A (atomic) extension "
+                "so no hardware atomic instructions are available. "
+                "test_exception_storage.pass.cpp links against libc++, which pulls in "
+                "ios_base::xalloc() from ios.cpp. That function unconditionally uses "
+                "std::atomic<int>, which lowers to a __atomic_fetch_add_4 call on targets "
+                "without hardware atomics. This symbol has no provider on these targets "
+                "since compiler-rt's atomic.c requires lock-free hardware CAS to compile.",
+        ),
+        XFail(
             name="emulated crash signals",
             testnames=[
                 "aarch64/emupac.c",

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -152,18 +152,6 @@ def main():
             description="Disable the tests for now while the issue is being fixed upstream (https://github.com/picolibc/picolibc/pull/1072).",
         ),
         XFail(
-            name="picolibc_rv32im_xqci",
-            testnames=[
-                "test-except.test"
-            ],
-            result=NewResult.EXCLUDE,
-            project="picolibc",
-            variants=[
-                "riscv32im_xqci_ilp32_nothreads_nopic"
-            ],
-            description="This test times out for some reason and we will most probably need a fix in QEMU. Disable until we have one.",
-        ),
-        XFail(
             name="no hardware atomics cxxabi",
             testnames=[
                 "test_exception_storage.pass.cpp",

--- a/qualcomm-software/scripts/test.sh
+++ b/qualcomm-software/scripts/test.sh
@@ -23,3 +23,4 @@ REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 cd "${REPO_ROOT}"/build
 ninja check-all
 ninja check-llvm-toolchain
+ninja check-cxxabi


### PR DESCRIPTION
Enable ENABLE_LIBCXX_TESTS for all embedded picolibc variants that have CXX libs and libc tests already enabled (ENABLE_CXX_LIBS=ON, ENABLE_LIBC_TESTS=ON). This covers ARM, AArch64 and RISC-V variants and allows running the libcxxabi test suite against them via QEMU semihosting
