### PR TITLE
[Runner] Move AArch64 nightly workflows to Ubuntu 24.04 ARM

### DIFF
--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -44,13 +44,13 @@ jobs:
             test_script: test.sh
             install_script: install_dependencies.sh
             target_os: Linux-AArch64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
 
           - build_script: build_musl-embedded_overlay.sh
             test_script: ''
             install_script: ''
             target_os: Linux-AArch64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
 
           - build_script: build.ps1
             test_script: test.ps1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,7 +76,7 @@ jobs:
             test_script: test.sh
             install_script: install_dependencies.sh
             target_os: Linux-AArch64
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
 
           - build_script: build_musl-embedded_overlay.sh
             test_script: ''


### PR DESCRIPTION
Updates native-runtime-nightly and nightly workflows to run on ubuntu-24.04-arm instead of ubuntu-22.04-arm.