### PR TITLE
[Github] Update runners to Ubuntu 24

### DIFF
--- a/.github/workflows/check_modified_files.yml
+++ b/.github/workflows/check_modified_files.yml
@@ -20,7 +20,7 @@ jobs:
   check-modified-files:
     # Don't run on forks
     if: github.repository == 'qualcomm/cpullvm-toolchain'
-    runs-on: self-hosted
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout source

--- a/.github/workflows/zephyr-twister-tests.yml
+++ b/.github/workflows/zephyr-twister-tests.yml
@@ -18,7 +18,7 @@ jobs:
   build-Linux-x86-toolchain:
     if: github.repository == 'qualcomm/cpullvm-toolchain'
     name: Build toolchain
-    runs-on: self-hosted
+    runs-on: cpullvm-ubuntu24-x86_64
     steps:
       - name: Checkout source
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
zephyr-twister-tests.yml is doing a full toolchain build so we should have that match what is done in our nightlies, etc. So, switch that to using our self hosted Ubuntu 24 runners.

check_modified_files.yml isn't doing a build or anything very complicated so should be fairly OS-agnostic, but update this for parity with our other workflows. Use github's runners since it is a very simple check.