### PR TITLE
[cpullvm] Add armv7m -mfpu=fpv5-d16 hard float variant

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -62,6 +62,12 @@
             "libraries_supported": "picolibc"
         },
         {
+            "variant": "armv7m_hard_fpv5_d16_nopic",
+            "json": "armv7m_hard_fpv5_d16_nopic.json",
+            "flags": "--target=thumbv7m-unknown-none-eabihf -mfpu=fpv5-d16 -munaligned-access -fno-pic",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "riscv32imc_ilp32_nothreads_nopic",
             "json": "riscv32imc_ilp32_nothreads_nopic.json",
             "flags": "--target=riscv32-unknown-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic",

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
@@ -1,0 +1,25 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "armv7m",
+            "VARIANT": "armv7m_hard_fpv5_d16_nopic",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7m -mfpu=fpv5-d16",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "mps2-an500",
+            "QEMU_CPU": "cortex-m7",
+            "FLASH_ADDRESS": "0x00000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x20000000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/test/multilib/armv7m.test
+++ b/qualcomm-software/test/multilib/armv7m.test
@@ -5,3 +5,12 @@
 # RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
 # CHECK-SOFT-NOFP-NOPIC: arm-none-eabi/armv7m_soft_nofp_nopic{{$}}
 # CHECK-SOFT-NOFP-NOPIC-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# CHECK-HARD-FPV5-D16-NOPIC: arm-none-eabi/armv7m_hard_fpv5_d16_nopic{{$}}
+# CHECK-HARD-FPV5-D16-NOPIC-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fPIC 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# NOT-FOUND: warning: no multilib found matching flags


### PR DESCRIPTION
The intention here is to offer a variant for Cortex M7 users with fpv5-d16 enabled.

There's a few misc. things to note here:
- The normalized triple clang uses when `-mcpu=cortex-m7` is used is actually along the lines of `thumbv7em*` rather than the `thumb7m` we use here. Our `multilib.yaml.in` has mappings for these which we inherited from ATfE. So, align with what their configs seem to do and stick with thumbv7m.
- Picolibc is the only libc we want to support for this variant--a musl-embedded variant is intentionally omitted as we're moving away from musl-embedded.
- This variant is built without PIC support. The relevant user isn't using PIC and we've had issues with PIC + eld + Zephyr in the past for 32bit Arm targets (see https://github.com/qualcomm/cpullvm-toolchain/pull/309) so let's default towards nopic.
- We build our other armv7m configurations with `-mno-unaligned-access` (and we don't have both aligned and unaligned variants like ATfE). But, the relevant user build here is resolving to `-munaligned-access` so I'm not going to force `-mno-unaligned-access` in the library build unless we have a particular need.