### PR TITLE
[cpullvm] Add missing basic multilib tests, update armv8 multilib triple

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -38,7 +38,7 @@
         {
             "variant": "armv8_soft_neon",
             "json": "armv8_soft_neon.json",
-            "flags": "--target=thumbv8-unknown-none-eabi -mfpu=neon-fp-armv8"
+            "flags": "--target=thumbv8a-unknown-none-eabi -mfpu=neon-fp-armv8"
         },
         {
             "variant": "armv7a_soft_neon",

--- a/qualcomm-software/test/multilib/armv7m.test
+++ b/qualcomm-software/test/multilib/armv7m.test
@@ -1,0 +1,7 @@
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# CHECK-SOFT-NOFP: arm-none-eabi/armv7m_soft_nofp{{$}}
+# CHECK-SOFT-NOFP-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
+# CHECK-SOFT-NOFP-NOPIC: arm-none-eabi/armv7m_soft_nofp_nopic{{$}}
+# CHECK-SOFT-NOFP-NOPIC-EMPTY:

--- a/qualcomm-software/test/multilib/armv8.test
+++ b/qualcomm-software/test/multilib/armv8.test
@@ -1,3 +1,3 @@
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=ARMV8-SOFT-NEON
-# CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8a_soft_neon{{$}}
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8_soft_neon{{$}}
 # CHECK-ARMV8-SOFT-NEON-EMPTY:

--- a/qualcomm-software/test/multilib/armv8.test
+++ b/qualcomm-software/test/multilib/armv8.test
@@ -1,0 +1,3 @@
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=ARMV8-SOFT-NEON
+# CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8a_soft_neon{{$}}
+# CHECK-ARMV8-SOFT-NEON-EMPTY:

--- a/qualcomm-software/test/multilib/riscv32.test
+++ b/qualcomm-software/test/multilib/riscv32.test
@@ -59,6 +59,10 @@
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=riscv32gc_ilp32d -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D
+# CHECK-GC-ILP32D-PIC: riscv32-unknown-elf/riscv32gc_ilp32d{{$}}
+# CHECK-GC-ILP32D-PIC-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
 # RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
 # CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC: riscv32-unknown-elf/riscv32im_xqci_ilp32_nothreads_nopic{{$}}

--- a/qualcomm-software/test/multilib/riscv32.test
+++ b/qualcomm-software/test/multilib/riscv32.test
@@ -59,7 +59,7 @@
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=riscv32gc_ilp32d -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D
+# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32gc -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D-PIC
 # CHECK-GC-ILP32D-PIC: riscv32-unknown-elf/riscv32gc_ilp32d{{$}}
 # CHECK-GC-ILP32D-PIC-EMPTY:
 


### PR DESCRIPTION
A few variants were missing tests checking that their multilib was being picked up appropriately:
- armv8_soft_neon
- armv7m_soft_nofp
- armv7m_soft_nofp_nopic
- riscv32gc_ilp32d

Add a few very basic tests to give at least *some* coverage that we're selecting the right variant.

As part of this, update the triple we match against for our armv8_soft_neon variant. Apparently clang will normalize these flags to `thumbv8a` (rather than `thumbv8`) so we couldn't really produce a match for this multilib variant.