### PR TITLE
[cpullvm] Force a consistent TLS model for all library builds using picolibc

### DIFF
--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -88,11 +88,13 @@ set(DISABLE_THREADS ${DISABLE_THREADS_def} CACHE BOOL "Disable threads/atomic/TL
 set(SUPPORTED_TLS_MODELS local-exec initial-exec local-dynamic global-dynamic)
 if(NOT DEFINED TLS_MODEL_def)
     set(TLS_MODEL_def local-exec)
+elseif(C_LIBRARY STREQUAL musl-embedded)
+    message(FATAL_ERROR "TLS_MODEL is currently unsupported when using musl-embedded.")
 elseif(NOT TLS_MODEL_def IN_LIST SUPPORTED_TLS_MODELS)
     string(REPLACE ";" ", " SUPPORTED_TLS_MODELS_STR "${SUPPORTED_TLS_MODELS}")
     message(FATAL_ERROR "Unsupported TLS_MODEL value. Supported values are ${SUPPORTED_TLS_MODELS_STR}")
 endif()
-set(TLS_MODEL ${TLS_MODEL_def} CACHE STRING "TLS model to use. Currently only used by picolibc, other projects use the project/toolchain defaults.")
+set(TLS_MODEL ${TLS_MODEL_def} CACHE STRING "TLS model to use when building libraries. Unsupported for variants using musl-embedded.")
 set_property(CACHE TLS_MODEL PROPERTY STRINGS ${SUPPORTED_TLS_MODELS})
 set(LLVM_BINARY_DIR "" CACHE PATH "Path to LLVM toolchain root to build libraries with")
 
@@ -229,6 +231,9 @@ set(compile_arch_flags "--target=${target_triple} ${COMPILE_FLAGS} --sysroot ${T
 # Compiling the libraries benefits from some extra optimization
 # flags, and requires a sysroot.
 set(lib_compile_flags "${compile_arch_flags} -ffunction-sections -fdata-sections")
+if(NOT C_LIBRARY STREQUAL musl-embedded)
+    string(APPEND lib_compile_flags " -ftls-model=${TLS_MODEL}")
+endif()
 
 # Generic target names for the C library.
 # Declare these now, since compiler-rt requires the 'install' dependency.


### PR DESCRIPTION
Previously, a TLS model was only ever explicitly set for picolibc--other projects (libc++, etc.) would use whatever the compiler selected. This shouldn't necessarily be a problem, but in practice can cause issues when global-dynamic is selected and is implemented via calls to `__tls_get_addr` (ex: in our 32bit Arm and 32/64bit RISC-V PIC configs). Given we don't provide an implementation and we don't expect people to use a dynamic linker that would implement this, people will generally get undefined reference errors. See the discussion in https://github.com/qualcomm/cpullvm-toolchain/pull/341.

Note that this seems to primarily be an issue with picolibc as it uses "normal" TLS mechanisms [1]. musl-embedded doesn't seem to (see ex: `__errno_location`) and consequently I don't see any obvious TLS usage in any of our libraries built with musl-embedded as the libc.

To try and address this, consistently specify a TLS model across all of the libraries we are building when using picolibc. 

For musl-embedded, given that a) it is generally not expected to be thread safe b) it doesn't seem to use the "usual" TLS mechanisms from the toolchain as mentioned above and c) historically we haven't had any special handling downstream for this, musl-embedded configs are intentionally excluded here.

Since we're special casing the flag on the libc type now, at the same time add basic error checking so we aren't silently dropping this if it is specified via JSON.

[1] https://github.com/picolibc/picolibc/blob/main/doc/tls.md