### PR TITLE
[Compiler-rt][test] Fix circular link dependency between builtins and libc on Arm

### DIFF
--- a/compiler-rt/test/builtins/Unit/lit.cfg.py
+++ b/compiler-rt/test/builtins/Unit/lit.cfg.py
@@ -107,7 +107,9 @@ else:
     if config.target_os == "Haiku":
         config.substitutions.append(("%librt ", base_lib + " -lroot "))
     else:
-        config.substitutions.append(("%librt ", base_lib + " -lc -lm "))
+        config.substitutions.append(
+            ("%librt ", "-Wl,--start-group " + base_lib + " -lc -lm -Wl,--end-group ")
+        )
 
 builtins_test_crt = get_required_attr(config, "builtins_test_crt")
 if builtins_test_crt:


### PR DESCRIPTION

On AArch64, long double is IEEE 754 binary128 (quad-precision). There is no hardware support for 128-bit FP, so every long double operation is lowered by the compiler into calls to software builtins (__multf3, __divtf3, __addtf3, __subtf3, etc.) provided by libclang_rt.builtins.a.

Currently, the link order is `libclang_rt.builtins.a -lc -lm`. Builtins are scanned first after which symbols like `logbl/scalbnl/fmaxl/hypotl` are unresolved references that are resovled through libc.a. However, resolving the references to these symbols further lead to undefined references to `__multf3, __divtf3, __trunctfdf2` etc. that can only resolved through builtins. This circular dep is found in some compiler-rt tests such as `compiler_rt_logbl_test, compiler_rt_scalbnl_test, compiler_rt_fmaxl_test, divtc3_test`.

Fix this by wrapping the archives in a linker group (--start-group/--end-group), which instructs the linker to rescan all archives in the group until no new symbols can be resolved.