### PR TITLE
[Compiler-rt][test] Increase Flash size to support large compiler-rt tests

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
@@ -10,8 +10,8 @@
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "cortex-a57",
             "FLASH_ADDRESS": "0x40000000",
-            "FLASH_SIZE": "0x00400000",
-            "RAM_ADDRESS": "0x40400000",
+            "FLASH_SIZE": "0x01000000",
+            "RAM_ADDRESS": "0x41000000",
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
@@ -10,8 +10,8 @@
             "QEMU_MACHINE": "virt",
             "QEMU_CPU": "cortex-a57",
             "FLASH_ADDRESS": "0x40000000",
-            "FLASH_SIZE": "0x00400000",
-            "RAM_ADDRESS": "0x40400000",
+            "FLASH_SIZE": "0x01000000",
+            "RAM_ADDRESS": "0x41000000",
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },


### PR DESCRIPTION
udivmodti4_test.c overflows the 4MB (0x00400000) flash region on
aarch64a_tlsie and aarch64a_soft_nofp_tlsie by 0xc590 bytes. Increase
flash to 16MB (0x01000000) to accommodate large test binaries. Adjust
RAM_ADDRESS to 0x41000000 to avoid overlap with the larger flash region.

The RAM size increment is handled in PR #374

Reference: https://github.com/arm/arm-toolchain (branch arm-software)
  arm-software/embedded/arm-multilib/json/variants/aarch64a.json