### PR TITLE
[cpullvm] Add missing basic multilib tests, update armv8 multilib triple

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -38,7 +38,7 @@
         {
             "variant": "armv8_soft_neon",
             "json": "armv8_soft_neon.json",
-            "flags": "--target=thumbv8-unknown-none-eabi -mfpu=neon-fp-armv8"
+            "flags": "--target=thumbv8a-unknown-none-eabi -mfpu=neon-fp-armv8"
         },
         {
             "variant": "armv7a_soft_neon",

--- a/qualcomm-software/test/multilib/armv7m.test
+++ b/qualcomm-software/test/multilib/armv7m.test
@@ -1,3 +1,7 @@
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# CHECK-SOFT-NOFP: arm-none-eabi/armv7m_soft_nofp{{$}}
+# CHECK-SOFT-NOFP-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
 # RUN: %clang -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
 # CHECK-HARD-FPV5-D16-NOPIC: arm-none-eabi/armv7m_hard_fpv5_d16_nopic{{$}}

--- a/qualcomm-software/test/multilib/armv8.test
+++ b/qualcomm-software/test/multilib/armv8.test
@@ -1,0 +1,3 @@
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8_soft_neon{{$}}
+# CHECK-ARMV8-SOFT-NEON-EMPTY:


### PR DESCRIPTION
A few variants were missing tests checking that their multilib was being picked up appropriately:
- armv8_soft_neon
- armv7m_soft_nofp

Add a few very basic tests to give at least *some* coverage that we're selecting the right variant.

As part of this, update the triple we match against for our armv8_soft_neon variant. Apparently clang will normalize these flags to thumbv8a (rather than thumbv8) so we couldn't really produce a match for this multilib variant.