### PR TITLE
[cpullvm] Create separate non-'tlsie' musl-embedded configs

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -1,9 +1,16 @@
 {
     "libs": [
         {
+            "variant": "aarch64a",
+            "json": "aarch64a.json",
+            "flags": "--target=aarch64-unknown-none-elf",
+            "libraries_supported": "musl-embedded"
+        },
+        {
             "variant": "aarch64a_tlsie",
             "json": "aarch64a_tlsie.json",
-            "flags": "--target=aarch64-unknown-none-elf"
+            "flags": "--target=aarch64-unknown-none-elf",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64a_pacret",
@@ -16,14 +23,28 @@
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+bti"
         },
         {
+            "variant": "aarch64a_pacret_bkey_bti",
+            "json": "aarch64a_pacret_bkey_bti.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti",
+            "libraries_supported": "musl-embedded"
+        },
+        {
             "variant": "aarch64a_pacret_bkey_bti_tlsie",
             "json": "aarch64a_pacret_bkey_bti_tlsie.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti",
+            "libraries_supported": "picolibc"
+        },
+        {
+            "variant": "aarch64a_soft_nofp",
+            "json": "aarch64a_soft_nofp.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft",
+            "libraries_supported": "musl-embedded"
         },
         {
             "variant": "aarch64a_soft_nofp_tlsie",
             "json": "aarch64a_soft_nofp_tlsie.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft"
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64a_soft_nofp_pacret_bti",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a.json
@@ -2,7 +2,7 @@
     "args": {
         "common": {
             "TARGET_ARCH": "aarch64a",
-            "VARIANT": "aarch64a_tlsie",
+            "VARIANT": "aarch64a",
             "COMPILE_FLAGS": "-march=armv8-a -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
@@ -15,12 +15,12 @@
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
-        "picolibc": {
+        "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "TLS_MODEL": "initial-exec"
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
@@ -2,8 +2,8 @@
     "args": {
         "common": {
             "TARGET_ARCH": "aarch64a",
-            "VARIANT": "aarch64a_tlsie",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "VARIANT": "aarch64a_pacret_bkey_bti",
+            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
@@ -15,12 +15,12 @@
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
-        "picolibc": {
+        "musl-embedded": {
             "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "TLS_MODEL": "initial-exec"
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_tlsie.json
@@ -21,13 +21,6 @@
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
             "TLS_MODEL": "initial-exec"
-        },
-        "musl-embedded": {
-            "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "OFF",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp.json
@@ -2,8 +2,8 @@
     "args": {
         "common": {
             "TARGET_ARCH": "aarch64a",
-            "VARIANT": "aarch64a_tlsie",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "VARIANT": "aarch64a_soft_nofp",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
@@ -15,12 +15,13 @@
             "RAM_SIZE": "0x00200000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
-        "picolibc": {
-            "ENABLE_CXX_LIBS": "ON",
-            "ENABLE_LIBC_TESTS": "ON",
+        "musl-embedded": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
-            "TLS_MODEL": "initial-exec"
+            "EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS": "--quic-aarch64-nofp",
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
         }
     }
 }

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
@@ -21,14 +21,6 @@
             "ENABLE_COMPILER_RT_TESTS": "OFF",
             "ENABLE_LIBCXX_TESTS": "OFF",
             "TLS_MODEL": "initial-exec"
-        },
-        "musl-embedded": {
-            "ENABLE_CXX_LIBS": "OFF",
-            "ENABLE_LIBC_TESTS": "OFF",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
-            "ENABLE_LIBCXX_TESTS": "OFF",
-            "EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS": "--quic-aarch64-nofp",
-            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
         }
     }
 }


### PR DESCRIPTION
The naming here is confusing as we don't do anything related to TLS models for the musl-embedded configs. So, split these apart.