### PR TITLE
[cpullvm] Added build-essential to restore missing C++ headers on ubu…

### DIFF
--- a/qualcomm-software/scripts/install_dependencies.sh
+++ b/qualcomm-software/scripts/install_dependencies.sh
@@ -3,7 +3,7 @@
 
 sudo apt-get update
 # Used by lldb
-sudo apt-get install swig libedit-dev
+sudo apt-get install swig libedit-dev build-essential
 
 # Install meson. eld support was added in v1.9.0, so we need at least that.
 pip install meson==1.10.0


### PR DESCRIPTION
Ubuntu 24.04 ARM runner no longer includes default C++ headers (libstdc++-dev).
This causes missing header errors like <cstdint> during builds.
Adding build-essential restores the standard C++ toolchain and fixes the issue.