### PR TITLE
[cpullvm] Upgrade ram sizes for large test cases (for ARM/AArch64)

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
@@ -12,7 +12,7 @@
             "FLASH_ADDRESS": "0x40000000",
             "FLASH_SIZE": "0x01000000",
             "RAM_ADDRESS": "0x41000000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x00000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x20000000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x00000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x20000000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp.json
@@ -12,7 +12,7 @@
             "FLASH_ADDRESS": "0x00000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x20000000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00800000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
@@ -12,7 +12,7 @@
             "FLASH_ADDRESS": "0x00000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x20000000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00800000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv8_soft_neon.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv8_soft_neon.json
@@ -12,7 +12,7 @@
             "FLASH_ADDRESS": "0x40000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x40400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {


### PR DESCRIPTION
Many tests such as dynamic_cast14.pass.cpp in libcxxabi fail as their compiled binary does not fit in the RAM size set for qemu. This patch upgrades the RAM size of qemu configurations for each variant impacted (in this case, its all the variants). This PR deals with just ARM/AArch64 variants. Riscv variants are handled in https://github.com/qualcomm/cpullvm-toolchain/pull/364

RAM sizes directly from https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded/arm-multilib/json/variants