### PR TITLE
[cpullvm] upgrade ram size for riscv variants

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_ilp32_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_ilp32f.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zba_zbb_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zba_zbb_ilp32f.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imc_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imc_ilp32_nothreads_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {


### PR DESCRIPTION
Tests such as dynamic_cast14.pass.cpp in libcxxabi fail due to
infsufficient RAM size. This patch fixes it by increasing the RAM size
allocated to qemu.

Tests such as dynamic_cast14.pass.cpp in libcxxabi fail due to
infsufficient RAM size. This patch fixes it by increasing the RAM size
allocated to qemu. The sizes are derived from the reports of failed test
cases empirically. dynamic_cast14 overflows by 7.7MB, its executable
size is 2MB, which implies a requirement of ~9.5MB. Therefore, a size
of 10MB is chosen for all riscv variants. Other tests, as they're
uncovered may demand a higher size, in which case this can be adjusted.