### PR TITLE
[cpullvm] Freeze eld to a specific SHA on the 22.x branch

### DIFF
--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -22,8 +22,8 @@
     },
     "eld": {
       "url": "https://github.com/qualcomm/eld",
-      "tagType": "branch",
-      "tag": "release/22.x"
+      "tagType": "commithash",
+      "tag": "5f28fc25645afef4f54802dc503f872d344a3150"
     }
   }
 }


### PR DESCRIPTION
This way we don't necessarily have to take any commits they push onto their 22.x branch.