### PR TITLE
[Compiler-rt] Enable compiler-rt tests for ARM/AArch64 variants

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
@@ -18,7 +18,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "OFF",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF",
             "TLS_MODEL": "initial-exec"
         }

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
@@ -18,7 +18,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF",
             "TLS_MODEL": "initial-exec"
         }

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "musl-embedded": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "musl-embedded": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
@@ -18,7 +18,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp.json
@@ -18,7 +18,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "musl-embedded": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
@@ -18,7 +18,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/armv8_soft_neon.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv8_soft_neon.json
@@ -18,7 +18,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         },
         "musl-embedded": {


### PR DESCRIPTION
This PR enables compiler-rt testing for those variants which have set "ENABLE_LIBC_TESTS": "ON".

Compiler-rt tests for RISCV are enabled in PR #386 