### PR TITLE
[Compiler-rt][Test] Increase QEMU RAM for RISC-V compiler-rt tests

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_ilp32_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_ilp32f.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zba_zbb_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zba_zbb_ilp32f.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imc_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imc_ilp32_nothreads_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
@@ -13,7 +13,7 @@
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x80400000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x01000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {


### PR DESCRIPTION
udivmodti4_test.c overflows the default 2MB RAM region on all RISC-V variants due to large 128-bit division test vectors. 
Increase RAM_SIZE from 0x00200000 (2MB) to 0x01000000 (16MB) for the 19 RISC-V variants that have compiler-rt tests enabled.

The size increase is in line with what was done for ARM variants in PR #374