### PR TITLE
[Compiler-rt][RISCV] Enable compiler-rt tests for RISCV

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32gc_ilp32d.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF",
             "DISABLE_THREADS": "ON"
         }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_ilp32_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zba_zbb_ilp32_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_ilp32_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_ilp32f.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zba_zbb_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zba_zbb_ilp32f.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imc_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imc_ilp32_nothreads_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF",
             "DISABLE_THREADS": "ON"
         }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF",
             "DISABLE_THREADS": "ON"
         }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_lp64d_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64gc_zba_zbb_lp64d_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imac_lp64_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF"
         }
     }

--- a/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv64imc_lp64_nothreads_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF",
             "DISABLE_THREADS": "ON"
         }


### PR DESCRIPTION
This PR enables compiler-rt tests for 19 RISCV variants which have set "ENABLE_LIBC_TESTS": "ON".

Compiler-rt tests for ARM were enabled in PR #383