### PR TITLE
[cpullvm] Specify and require `-munaligned-access` for Arm/AArch64 variants that currently build with unaligned access

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -3,73 +3,73 @@
         {
             "variant": "aarch64a",
             "json": "aarch64a.json",
-            "flags": "--target=aarch64-unknown-none-elf",
+            "flags": "--target=aarch64-unknown-none-elf -munaligned-access",
             "libraries_supported": "musl-embedded"
         },
         {
             "variant": "aarch64a_tlsie",
             "json": "aarch64a_tlsie.json",
-            "flags": "--target=aarch64-unknown-none-elf",
+            "flags": "--target=aarch64-unknown-none-elf -munaligned-access",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64a_pacret",
             "json": "aarch64a_pacret.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -mbranch-protection=pac-ret+leaf"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -mbranch-protection=pac-ret+leaf -munaligned-access"
         },
         {
             "variant": "aarch64a_pacret_bti",
             "json": "aarch64a_pacret_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+bti"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+bti -munaligned-access"
         },
         {
             "variant": "aarch64a_pacret_bkey_bti",
             "json": "aarch64a_pacret_bkey_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti -munaligned-access",
             "libraries_supported": "musl-embedded"
         },
         {
             "variant": "aarch64a_pacret_bkey_bti_tlsie",
             "json": "aarch64a_pacret_bkey_bti_tlsie.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti -munaligned-access",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64a_soft_nofp",
             "json": "aarch64a_soft_nofp.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft",
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -munaligned-access",
             "libraries_supported": "musl-embedded"
         },
         {
             "variant": "aarch64a_soft_nofp_tlsie",
             "json": "aarch64a_soft_nofp_tlsie.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft",
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -munaligned-access",
             "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64a_soft_nofp_pacret_bti",
             "json": "aarch64a_soft_nofp_pacret_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -munaligned-access"
         },
         {
             "variant": "aarch64a_soft_nofp_pacret_bkey_bti",
             "json": "aarch64a_soft_nofp_pacret_bkey_bti.json",
-            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft"
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft -munaligned-access"
         },
         {
             "variant": "armv8_soft_neon",
             "json": "armv8_soft_neon.json",
-            "flags": "--target=thumbv8a-unknown-none-eabi -mfpu=neon-fp-armv8"
+            "flags": "--target=thumbv8a-unknown-none-eabi -mfpu=neon-fp-armv8 -munaligned-access"
         },
         {
             "variant": "armv7a_soft_neon",
             "json": "armv7a_soft_neon.json",
-            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=neon"
+            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=neon -munaligned-access"
         },
         {
             "variant": "armv7a_soft_nofp",
             "json": "armv7a_soft_nofp.json",
-            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=none"
+            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=none -munaligned-access"
         },
         {
             "variant": "armv7m_soft_nofp",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_pacret",
-            "COMPILE_FLAGS": "-march=armv8.3a -mbranch-protection=pac-ret+leaf -fPIC",
+            "COMPILE_FLAGS": "-march=armv8.3a -mbranch-protection=pac-ret+leaf -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_pacret_bkey_bti",
-            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fPIC",
+            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_tlsie.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_pacret_bkey_bti_tlsie",
-            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fPIC",
+            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_pacret_bti",
-            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+bti -fPIC",
+            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+bti -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_soft_nofp",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bkey_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bkey_bti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_soft_nofp_pacret_bkey_bti",
-            "COMPILE_FLAGS": "-march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft -fPIC",
+            "COMPILE_FLAGS": "-march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_soft_nofp_pacret_bti",
-            "COMPILE_FLAGS": "-march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fPIC",
+            "COMPILE_FLAGS": "-march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_soft_nofp_tlsie",
-            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "aarch64a",
             "VARIANT": "aarch64a_tlsie",
-            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "COMPILE_FLAGS": "-march=armv8-a -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_neon.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv7a",
             "VARIANT": "armv7a_soft_neon",
-            "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7a -mthumb -mfpu=neon -fPIC",
+            "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7a -mthumb -mfpu=neon -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7a_soft_nofp.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv7a",
             "VARIANT": "armv7a_soft_nofp",
-            "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7a -mthumb -mfpu=none -mhwdiv=none -fPIC",
+            "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv7a -mthumb -mfpu=none -mhwdiv=none -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv7m",
             "VARIANT": "armv7m_hard_fpv5_d16_nopic",
-            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7m -mfpu=fpv5-d16",
+            "COMPILE_FLAGS": "-mfloat-abi=hard -march=armv7m -munaligned-access -mfpu=fpv5-d16",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/armv8_soft_neon.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv8_soft_neon.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "armv8",
             "VARIANT": "armv8_soft_neon",
-            "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv8 -mthumb -mfpu=neon-fp-armv8 -fPIC",
+            "COMPILE_FLAGS": "-mfloat-abi=softfp -march=armv8 -mthumb -mfpu=neon-fp-armv8 -munaligned-access -fPIC",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/test/multilib/aarch64.test
+++ b/qualcomm-software/test/multilib/aarch64.test
@@ -4,6 +4,7 @@
 # the original multilib.
 
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -munaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
 # CHECK-AARCH64: aarch64-none-elf/aarch64a_tlsie{{$}}
 # CHECK-AARCH64-EMPTY:
@@ -40,3 +41,6 @@
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # CHECK-NOFP-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bkey_bti{{$}}
 # CHECK-NOFP-PACRET-BKEY-BTI-EMPTY:
+
+# RUN: %clang -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7.test
+++ b/qualcomm-software/test/multilib/armv7.test
@@ -1,7 +1,11 @@
 # RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
 # CHECK-ARMV7: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
 # CHECK-ARMV7-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-NOFP-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7m.test
+++ b/qualcomm-software/test/multilib/armv7m.test
@@ -7,6 +7,7 @@
 # CHECK-SOFT-NOFP-NOPIC-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic -munaligned-access | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
 # RUN: %clang -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
 # CHECK-HARD-FPV5-D16-NOPIC: arm-none-eabi/armv7m_hard_fpv5_d16_nopic{{$}}
 # CHECK-HARD-FPV5-D16-NOPIC-EMPTY:

--- a/qualcomm-software/test/multilib/armv8.test
+++ b/qualcomm-software/test/multilib/armv8.test
@@ -1,3 +1,7 @@
 # RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
 # CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8_soft_neon{{$}}
 # CHECK-ARMV8-SOFT-NEON-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# NOT-FOUND: warning: no multilib found matching flags


### PR DESCRIPTION
Requiring `-munaligned-access` for multilib should provide better build-time
safeguards if people try using `-mno-unaligned-access` when they truly need it
disabled.

If people require an aligned variant, we'll consider adding one in the future.
And, if people want to mix and match (build with `-mno-unaligned-access` but
match against a library built with `-munaligned-access`) they can still
override multilib and point at the library variant manually.

At the same time, expicitly specify `-munaligned-access` for these configs in
the compile flags. This should be NFC, but will hopefully make it more clear
what our intent for these variants is and safeguard us from any unforseen
changes in defaults, etc.

Note that this also shouldn't impact our musl configs where we specify
`-mstrict-align`/`-mno-unaligned-access` via
`EXTRA_MUSL-EMBEDDED_CFLAGS`--those are used when building musl *only* and
those flags are placed after the generic `COMPILE_FLAGS` so will override them.

As mentioned above, this should resolve https://github.com/qualcomm/cpullvm-toolchain/issues/388
for now until we want to support aligned variants.