### PR TITLE
 [CPULLVM] - Fix QEMU_CPU comma encoding for RISC-V Zc-extension variants.

### DIFF
--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -205,12 +205,17 @@ if(ENABLE_LIBC_TESTS OR ENABLE_COMPILER_RT_TESTS OR ENABLE_LIBCXX_TESTS)
 
         if(QEMU_EXECUTABLE)
             # Use colon as a separator because comma and semicolon are used for
-            # other purposes in CMake.
+            # other purposes in CMake.  QEMU_CPU may contain commas (QEMU CPU
+            # feature syntax, e.g. "rv32,zcd=false,zcb=true") and QEMU_PARAMS
+            # may contain spaces; both are encoded with colons here so they
+            # survive the ExternalProject LIST_SEPARATOR , substitution and
+            # CMake list splitting.  lit-exec-qemu.py decodes them back.
             string(REPLACE " " ":" qemu_params_list "${QEMU_PARAMS}")
+            string(REPLACE "," ":" qemu_cpu_encoded "${QEMU_CPU}")
 
             set(test_executor_params --qemu-command ${QEMU_EXECUTABLE} --qemu-machine ${QEMU_MACHINE})
             if(QEMU_CPU)
-                list(APPEND test_executor_params --qemu-cpu ${QEMU_CPU})
+                list(APPEND test_executor_params --qemu-cpu ${qemu_cpu_encoded})
             endif()
             if(qemu_params_list)
                 list(APPEND test_executor_params "--qemu-params=${qemu_params_list}")

--- a/qualcomm-software/embedded-runtimes/test-support/lit-exec-qemu.py
+++ b/qualcomm-software/embedded-runtimes/test-support/lit-exec-qemu.py
@@ -71,10 +71,13 @@ def main():
         help="optional arguments for the image",
     )
     args = parser.parse_args()
+    # --qemu-cpu is encoded with colons instead of commas to survive CMake list
+    # separator substitution (LIST_SEPARATOR ,).  Decode it back here.
+    qemu_cpu = args.qemu_cpu.replace(":", ",") if args.qemu_cpu else None
     ret_code = run_qemu(
         args.qemu_command,
         args.qemu_machine,
-        args.qemu_cpu,
+        qemu_cpu,
         args.qemu_params.split(":") if args.qemu_params else [],
         args.image,
         [args.image] + args.arguments,

--- a/qualcomm-software/embedded-runtimes/test-support/picolibc-test-wrapper.py
+++ b/qualcomm-software/embedded-runtimes/test-support/picolibc-test-wrapper.py
@@ -70,6 +70,9 @@ def main():
         help="optional arguments for the image",
     )
     args = parser.parse_args()
+    # --qemu-cpu is encoded with colons instead of commas to survive CMake list
+    # separator substitution (LIST_SEPARATOR ,).  Decode it back here.
+    args.qemu_cpu = args.qemu_cpu.replace(":", ",") if args.qemu_cpu else None
     ret_code = run(args)
     sys.exit(ret_code)
 


### PR DESCRIPTION
QEMU_CPU values containing commas (e.g. RISC-V feature strings like
rv32,zcd=false,zcb=true) were being silently mangled by CMake's
LIST_SEPARATOR , substitution when passed through ExternalProject_Add.
This caused QEMU to receive a truncated or malformed --cpu argument,
breaking test execution for RISC-V Zc-extension variants. Fixes https://github.com/qualcomm/cpullvm-toolchain/issues/354

Fix:
- Encode commas in QEMU_CPU as colons before passing through
  ExternalProject in embedded-runtimes/CMakeLists.txt
- Decode colons back to commas in lit-exec-qemu.py and
  picolibc-test-wrapper.py before passing to QEMU