### PR TITLE
[RISCV][Compiler-rt]Add libc before libsemihost to link line for RISC-V compiler-rt tests

### DIFF
--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -172,7 +172,9 @@ if(ENABLE_LIBC_TESTS OR ENABLE_COMPILER_RT_TESTS OR ENABLE_LIBCXX_TESTS)
         if(TEST_EXECUTOR STREQUAL qemu)
             set(picocrt "crt0-semihost")
         endif()
-        set(test_link_flags "-fuse-ld=eld -nostartfiles -l${picocrt} -lsemihost -T picolibcpp.ld")
+        # To run compiler-rt tests on qemu, libc must be linked before
+        #  libsemihost to resolve semihost's references into libc.
+        set(test_link_flags "-fuse-ld=eld -nostartfiles -l${picocrt} -lc -lsemihost -T picolibcpp.ld")
     else()
         message(FATAL_ERROR "Tests can only be enabled using picolibc.")
     endif()


### PR DESCRIPTION
Currently the link order is `... -lcrt0-semihost -lsemihost ... -lc`.
This causes unresovled errors with some riscv compiler-rt tests because
`-lcrt0-semihost` has refernces to `printf(...)` function which in turn
has references to `stdout\stderr` that are only defined in `-lsemihost`.
However `-lc` comes much after `-lsemihost` in the link line. Because of this,
for eld like linkers, at the end of link command there are unresolved references
to `stdout/stderr` symbols as eld only knows about these symbols when
it scans `-lc`.

This patch fixes this issue by adding `-lc` before `-lsemihost` only for
riscv target when QEMU testing is enabled.

This issue was not observed with arm/aarch64 because `-lcrt0-semihost` for
arm/aarch64 directly use `fputs` instead of `printf`which directly uses
`stdout/stderr` therefore there is no dependency on libc.

This issue cannot be fixed in lit.cfg file in upstream because clang
currently does not have support for adding `-lsemihost` to linker job
for baremetal targets when qemu testing is enabled and this will make
it out of sync with what is passed through config file.

Additionally, this issue is specific to picolibc and this change might not
be needed in with other libc depending on the contents of
lcrt0-semihost. Therefore fixing this in CPULLVM specific CMakeFile.