### PR TITLE
[cpullvm][Github] Don't build musl overlay for PR premerge testing

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -39,11 +39,6 @@ jobs:
             target_os: Linux-x86_64
             runner: cpullvm-ubuntu24-x86_64
 
-          - build_script: build_musl-embedded_overlay.sh
-            test_script: ''
-            target_os: Linux-x86_64
-            runner: cpullvm-ubuntu24-x86_64
-
     steps:
       - name: Checkout source
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
This is one easy option to reduce the burden of PRs on our infrastructure--rather than each premerge build using two builders, removing the musl-embedded overlay should get us down to one.

Given that we're discussing removing the musl-embedded overlay from our releases anyway, it might be a worthwhile tradeoff (we'd still be building this in each of our nightlies).