### PR TITLE
[cpullvm][Multilib] Fix armv7a and armv8a multilib matching

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -36,19 +36,19 @@
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft"
         },
         {
-            "variant": "armv8_soft_neon",
-            "json": "armv8_soft_neon.json",
-            "flags": "--target=thumbv8a-unknown-none-eabi -mfpu=neon-fp-armv8"
-        },
-        {
             "variant": "armv7a_soft_neon",
             "json": "armv7a_soft_neon.json",
-            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=neon"
+            "flags": "--target=armv7-unknown-none-eabi -mfpu=neon"
         },
         {
             "variant": "armv7a_soft_nofp",
             "json": "armv7a_soft_nofp.json",
-            "flags": "--target=thumbv7-unknown-none-eabi -mfpu=none"
+            "flags": "--target=armv7-unknown-none-eabi -mfpu=none"
+        },
+        {
+            "variant": "armv8_soft_neon",
+            "json": "armv8_soft_neon.json",
+            "flags": "--target=armv8a-unknown-none-eabi -mfpu=neon-fp-armv8"
         },
         {
             "variant": "armv7m_soft_nofp",

--- a/qualcomm-software/embedded-multilib/multilib.yaml.in
+++ b/qualcomm-software/embedded-multilib/multilib.yaml.in
@@ -129,8 +129,13 @@ Mappings:
   Flags:
   - --target=thumbebv7m-unknown-none-eabihf
 
-# v7-A and v7-R include the ISA in the triple, but that doesn't matter for
-# library selection, so canonicalise Thumb triples to ARM ones.
+# v7-A, v7-R, and v8-A include the ISA in the triple, but that doesn't matter
+# for library selection, so canonicalise Thumb triples to ARM ones.
+# This will also be needed for v8-A hard float and v8-R once suitable variants
+# are added.
+- Match: --target=thumbv8a-unknown-none-eabi
+  Flags:
+  - --target=armv8a-unknown-none-eabi
 - Match: --target=thumbv7r-unknown-none-eabi
   Flags:
   - --target=armv7r-unknown-none-eabi

--- a/qualcomm-software/test/multilib/armv7.test
+++ b/qualcomm-software/test/multilib/armv7.test
@@ -1,7 +1,11 @@
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
 # RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
 # CHECK-ARMV7: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
 # RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
 # CHECK-ARMV7-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-NOFP-EMPTY:

--- a/qualcomm-software/test/multilib/armv8.test
+++ b/qualcomm-software/test/multilib/armv8.test
@@ -1,3 +1,13 @@
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
 # RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -marm -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
 # CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8_soft_neon{{$}}
 # CHECK-ARMV8-SOFT-NEON-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=none | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NOFP
+# CHECK-ARMV7-SOFT-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
+# CHECK-ARMV7-SOFT-NOFP-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NEON
+# CHECK-ARMV7-SOFT-NEON: arm-none-eabi/armv7a_soft_neon{{$}}
+# CHECK-ARMV7-SOFT-NEON-EMPTY:


### PR DESCRIPTION
There's three intertwined things here:

1. Our armv7a/armv8a variants required a normalized `thumbv*` triple to match the variant, even though there isn't an issue mixing arm and thumb modes for the purposes of our libraries.

   Fix this by switching to requiring `armv*` triples as the rest of our multilib setup is written canonicalizing towards `armv*` so generally already handles the mappings we want/need.
2. Add `thumbv8a` -> `armv8a` triple mappings. We didn't have these previously as we inherited our setup from ATfE. I think they omit(ted) them only as they don't have any armv8a variants [1].
3. With 1 and 2 sorted, we have to move our armv8_soft_neon variant for it to layer correctly with our armv7a_soft_neon variant.

[1] https://github.com/arm/arm-toolchain/commit/29fd17cf82ce40e57f7d4d96a2b36b2048eecffe