### PR TITLE
[cpullvm] Increase RAM for two AArch64/ARM variants left out earlier

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie.json
@@ -12,7 +12,7 @@
             "FLASH_ADDRESS": "0x40000000",
             "FLASH_SIZE": "0x01000000",
             "RAM_ADDRESS": "0x41000000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x1000000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
@@ -12,7 +12,7 @@
             "FLASH_ADDRESS": "0x00000000",
             "FLASH_SIZE": "0x00400000",
             "RAM_ADDRESS": "0x20000000",
-            "RAM_SIZE": "0x00200000",
+            "RAM_SIZE": "0x00800000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {


### PR DESCRIPTION
Related to https://github.com/qualcomm/cpullvm-toolchain/pull/374

This patch increases ram size for two variants there were left out of the previous patch. Like the previous patch, ram sizes are derived from arm-toolchain
(https://github.com/arm/arm-toolchain/tree/arm-software/arm-software/embedded/arm-multilib/json/variants)