### PR TITLE
[cpullvm] Use internal lit shell

### DIFF
--- a/qualcomm-software/embedded-runtimes/test-support/gen-picolibc-lit-tests.py
+++ b/qualcomm-software/embedded-runtimes/test-support/gen-picolibc-lit-tests.py
@@ -90,7 +90,7 @@ lit.llvm.initialize(lit_config, config)
 
 config.name = "%CONFIG_NAME%"
 config.suffixes = [".test"]
-config.test_format = lit.formats.ShTest(not lit.llvm.llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 config.test_source_root = os.path.join(os.path.dirname(__file__), "tests")
 """
     with open(os.path.join(args.output, "lit.cfg.py"), "w", encoding="utf-8") as f:

--- a/qualcomm-software/test/lit.cfg.py
+++ b/qualcomm-software/test/lit.cfg.py
@@ -9,7 +9,7 @@ from lit.llvm import llvm_config
 # Configuration file for the 'lit' test runner.
 
 config.name = "Toolchain regression tests"
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 config.suffixes = [".c", ".cpp", ".test"]
 config.excludes = ["CMakeLists.txt"]
 config.test_source_root = os.path.dirname(__file__)


### PR DESCRIPTION
Using an external shell is now deprecated in LLVM, see:
- https://github.com/llvm/llvm-project/commit/57109befac92811d2253109242ca6fa69c961fb2
- https://discourse.llvm.org/t/rfc-removal-of-the-lit-external-shell/90951
- https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179

This is breaking our builds as we explicitly force the external shell in a few places.

We can either:
- Bypass the errors and continue using the external shell via `force_execute_external` (until LLVM 24).
- Remove our dependencies on the external shell and migrate to the internal one.

I'm not entirely sure why we have the external shell dependency currently, but from what I can see we don't have anything that should be incompatible with lit's internal shell. So try that fix as it is what we need to do long term anyway.