### PR TITLE
[cpullvm] Fix eld URL in VERSION.txt

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -483,6 +483,7 @@ add_custom_target(
     -DCPULLVMToolchain_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
     -Dllvmproject_src_dir=${llvmproject_src_dir}
     -Deld_SOURCE_DIR=${eld_SOURCE_DIR}
+    -Deld_URL=${eld_URL}
     # at most one of picolibc and musl options is needed, but easiest to
     # specify both definitions
     -Dpicolibc_SOURCE_DIR=${picolibc_SOURCE_DIR}


### PR DESCRIPTION
Currently it is showing up like this:

* eld:  (commit 7dba852597a7031e3329c9d290ee2203c2bcd3e4)

But it should look like this (and does with this patch):

* eld: https://github.com/qualcomm/eld (commit 50953e9094bcc5d6fb50fdc5b91ff3a674a8c55d)

I broke this in https://github.com/qualcomm/cpullvm-toolchain/pull/111 when I removed the hardcoded URL but apparently forgot to pass through `eld_URL`. Pass through the variable to fix it.