### PR TITLE
[ARM] Skip debug instructions in Thumb1FrameLowering liveness scan

### DIFF
--- a/llvm/lib/Target/ARM/Thumb1FrameLowering.cpp
+++ b/llvm/lib/Target/ARM/Thumb1FrameLowering.cpp
@@ -668,10 +668,13 @@ bool Thumb1FrameLowering::emitPopSpecialFixUp(MachineBasicBlock &MBB,
   if (MBBI != MBB.end()) {
     dl = MBBI->getDebugLoc();
     auto InstUpToMBBI = MBB.end();
-    while (InstUpToMBBI != MBBI)
+    while (InstUpToMBBI != MBBI) {
       // The pre-decrement is on purpose here.
       // We want to have the liveness right before MBBI.
-      UsedRegs.stepBackward(*--InstUpToMBBI);
+      --InstUpToMBBI;
+      if (!InstUpToMBBI->isDebugInstr())
+        UsedRegs.stepBackward(*InstUpToMBBI);
+    }
   }
 
   // Look for a register that can be directly use in the POP.


### PR DESCRIPTION
## Problem

`LiveRegUnits::stepBackward` asserts that debug instructions must not be passed to it:
```
assert(!MI.isDebugInstr() && "Debug instructions must not affect liveness calculation")
```

`Thumb1FrameLowering::emitPopSpecialFixUp` iterates all instructions in the block without filtering debug `MachineInstr`s, causing a SIGABRT (exit 134) when compiling with debug info flags (`-g -gdwarf-4`).

This breaks `regress/plumhall/cvs11a` in HF nightly testing after PR #400 enabled `LLVM_ENABLE_ASSERTIONS` for Release+Asserts builds.

## Fix

Skip debug instructions before calling `stepBackward`, matching the pattern already used in `ARMLoadStoreOptimizer::moveLiveRegsBefore` (line 616).

## Testing

Verify by compiling any PlumHall exprtest file with:
```
clang -O2 -g -gdwarf-4 -mthumb -target arm-linux-gnueabihf <file.c>
```
Should produce output with exit 0 instead of SIGABRT.

Reported-by: akaver <akaver@qti.qualcomm.com>
Related: QTOOL-141413