### PR TITLE
[RISCV][Compiler-rt] Enable compiler-rt tests for riscv32im_zb*_zc* variant

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp_ilp32_nothreads_nopic.json
@@ -19,7 +19,7 @@
         "picolibc": {
             "ENABLE_CXX_LIBS": "ON",
             "ENABLE_LIBC_TESTS": "ON",
-            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
             "ENABLE_LIBCXX_TESTS": "OFF",
             "DISABLE_THREADS": "ON"
         }


### PR DESCRIPTION
A new riscv variant was added in PR #338. This PR enables compiler-rt test for that variant in line with with enabling compiler-rt tests for riscv in PR #386