### PR TITLE
[Xqci] Remove Smrnmi Qemu CPU Options

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
@@ -8,7 +8,7 @@
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",
             "QEMU_MACHINE": "virt",
-            "QEMU_CPU": "rv32,zcd=false,d=false,zcb=true,zcmp=false,zilsd=true,zclsd=true,f=false,zfa=false,xqci=true,smrnmi=true,xqccmp=true",
+            "QEMU_CPU": "rv32,zcd=false,d=false,zcb=true,zcmp=false,zilsd=true,zclsd=true,f=false,zfa=false,xqci=true,xqccmp=true",
             "QEMU_PARAMS": "-bios none",
             "FLASH_ADDRESS": "0x80000000",
             "FLASH_SIZE": "0x00400000",

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -152,18 +152,6 @@ def main():
             description="Disable the tests for now while the issue is being fixed upstream (https://github.com/picolibc/picolibc/pull/1072).",
         ),
         XFail(
-            name="picolibc_rv32im_xqci",
-            testnames=[
-                "test-except.test"
-            ],
-            result=NewResult.EXCLUDE,
-            project="picolibc",
-            variants=[
-                "riscv32im_xqci_ilp32_nothreads_nopic"
-            ],
-            description="This test times out for some reason and we will most probably need a fix in QEMU. Disable until we have one.",
-        ),
-        XFail(
             name="emulated crash signals",
             testnames=[
                 "aarch64/emupac.c",


### PR DESCRIPTION
This was causing test-except to fail because our crt was not setting up Smrnmi correctly. It's not clear why Smrnmi was in the Qemu string to start with, as we don't build the libraries with Smrnmi enabled, and none of the Xqci extensions require Smrnmi, and Qemu does not think that any Xqci extensions need Smrnmi. Even if this is present on real hardware, the semihosting library we use for testing is specifically for use with Qemu as a simulator so it has a different startup sequence and therefore different crt library to a real chip.