### PR TITLE
[cpullvm] Limit armv7a_hard_vfpv3 variant to picolibc

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -69,7 +69,8 @@
         {
             "variant": "armv7a_hard_vfpv3",
             "json": "armv7a_hard_vfpv3.json",
-            "flags": "--target=armv7-unknown-none-eabihf -mfpu=vfpv3 -munaligned-access"
+            "flags": "--target=armv7-unknown-none-eabihf -mfpu=vfpv3 -munaligned-access",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "armv8_soft_neon",


### PR DESCRIPTION
The `libraries_supported` line to limit this to picolibc was accidentally
omitted and is now currently breaking our musl-embedded overlay builds.

This variant isn't intended for musl, so disable it.