### PR TITLE
[cpullvm] Temporarily disable localization for our picolibc builds

### DIFF
--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -717,6 +717,9 @@ if(ENABLE_CXX_LIBS)
             -DLIBCXX_ENABLE_EXCEPTIONS=${ENABLE_EXCEPTIONS}
             -DLIBCXX_ENABLE_RTTI=${ENABLE_RTTI}
             -DRUNTIMES_USE_LIBC=picolibc
+            # FIXME: This is currently broken after 8a531c36 from upstream.
+            # Re-enable once it is resolved.
+            -DLIBCXX_ENABLE_LOCALIZATION=OFF
         )
         if(ENABLE_LIBCXX_TESTS)
             # Generate xfails for libxx.


### PR DESCRIPTION
This is broken after https://github.com/llvm/llvm-project/commit/8a531c3608c722ad529be448d6ecef06ba107228

Temporarily disable localization until this is resolved upstream. I think this might break some Zephyr testing that uses C++, but will hopefully unblock our builders in the meantime.