### PR TITLE
release/qualcomm-software/22.x: [cpullvm] Align retention days for all builds with the x86 Linux base, reducing from 7 to 2 (#437)

### DIFF
--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -94,7 +94,7 @@ jobs:
           path: |
             build*/cpullvm-*.tar.xz
             build*/cpullvm-*.zip
-          retention-days: 7
+          retention-days: 2
 
       - name: Test
         if: matrix.test_script != ''

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
           name: cpullvm-packages-build.sh-Linux-x86
           path: build*/cpullvm-*.tar.xz
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 2
 
       - name: Test
         run: ./qualcomm-software/scripts/test.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -132,7 +132,7 @@ jobs:
             build*/cpullvm-*.tar.xz
             build*/cpullvm-*.zip
             !build/cpullvm-*-Linux-x86_64.tar.xz
-          retention-days: 7
+          retention-days: 2
 
       - name: Test
         if: matrix.test_script != ''


### PR DESCRIPTION
Backport 6cf0121 b4e0413

Requested by: @navaneethshan