### PR TITLE
[cpullvm] Add workflow step to log repository commit SHAs

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -55,6 +55,10 @@ jobs:
       - name: Build toolchain
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
+      - name:  echo git repo versions
+        if: always()
+        run: cat build/VERSION.txt
+
       - name: Upload built packages
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: success()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Build
         run: ./qualcomm-software/scripts/build.sh
 
+      - name:  echo git repo versions
+        if: always()
+        run: cat build/VERSION.txt
+
       - name: Upload built packages
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: success()


### PR DESCRIPTION
Add a new step in CI workflows to capture and print the commit SHA for all repositories involved in the build.

This improves traceability by allowing us to track the exact combination of repository revisions used in each nightly or CI build.

The logged information can be used for debugging, reproducibility, and auditing build configurations.

Change-Id: Ida520cc94eb81c3fbde14d6d769e27dd8c81ac57