### PR TITLE
Revert "[cpullvm] Align retention days for all builds with the x86 Linux base, reducing from 7 to 2"

### DIFF
--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -99,7 +99,7 @@ jobs:
           path: |
             build*/cpullvm-*.tar.xz
             build*/cpullvm-*.zip
-          retention-days: 2
+          retention-days: 7
 
       - name: Test
         if: matrix.test_script != ''

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,7 +137,7 @@ jobs:
             build*/cpullvm-*.tar.xz
             build*/cpullvm-*.zip
             !build/cpullvm-*-Linux-x86_64.tar.xz
-          retention-days: 2
+          retention-days: 7
 
       - name: Test
         if: matrix.test_script != ''


### PR DESCRIPTION
Reverts qualcomm/cpullvm-toolchain#437

