### PR TITLE
[cpullvm][Github] Update upload-artifact action to v7.0.1

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -56,7 +56,7 @@ jobs:
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -92,7 +92,7 @@ jobs:
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./qualcomm-software/scripts/build.sh
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-build.sh-Linux-x86
@@ -128,7 +128,7 @@ jobs:
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/zephyr-twister-tests.yml
+++ b/.github/workflows/zephyr-twister-tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./qualcomm-software/scripts/build.sh
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-build.sh-Linux-x86
@@ -118,7 +118,7 @@ jobs:
             -x=CONFIG_COMPILER_RT_RTLIB=y
 
       - name: Upload Twister results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: zephyr-twister-test-results-${{ matrix.platform }}-subset-${{ matrix.subset }}
@@ -147,7 +147,7 @@ jobs:
           junitparser merge --glob "split_xml/**/twister.xml" merged_twister.xml
 
       - name: Upload merged XML results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zephyr-merged-twister-test-results
           path: merged_twister.xml


### PR DESCRIPTION
Updating to the latest release. The primary motivation for doing this is it adds a `archive` option that let's us skip the extra zip step, which should simplify our workflows slightly.