### PR TITLE
[cpullvm][Github] Don't re-zip our uploaded toolchains

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -59,9 +59,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
-          name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}
           path: |
             build*/cpullvm-*.tar.xz
+          archive: false
           retention-days: 1
 
       - name: Test

--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -56,7 +56,7 @@ jobs:
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -95,10 +95,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
-          name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}
           path: |
             build*/cpullvm-*.tar.xz
             build*/cpullvm-*.zip
+          archive: false
           retention-days: 7
 
       - name: Test

--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -92,7 +92,7 @@ jobs:
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./qualcomm-software/scripts/build.sh
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-build.sh-Linux-x86
@@ -128,7 +128,7 @@ jobs:
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,9 +53,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
-          name: cpullvm-packages-build.sh-Linux-x86
           path: build*/cpullvm-*.tar.xz
           if-no-files-found: error
+          archive: false
           retention-days: 7
 
       - name: Test
@@ -115,7 +115,7 @@ jobs:
       - name: Download Linux-x86 package
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: cpullvm-packages-build.sh-Linux-x86
+          pattern: cpullvm-*-Linux-x86_64
 
       - name: Install dependencies
         if: matrix.install_script != ''
@@ -131,11 +131,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
-          name: cpullvm-packages-${{ matrix.build_script }}-${{ matrix.target_os }}
           path: |
             build*/cpullvm-*.tar.xz
             build*/cpullvm-*.zip
             !build/cpullvm-*-Linux-x86_64.tar.xz
+          archive: false
           retention-days: 7
 
       - name: Test

--- a/.github/workflows/zephyr-twister-tests.yml
+++ b/.github/workflows/zephyr-twister-tests.yml
@@ -37,9 +37,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
-          name: cpullvm-packages-build.sh-Linux-x86
           path: build*/cpullvm-*.tar.xz
           if-no-files-found: error
+          archive: false
           retention-days: 1
 
   run-twister-tests:
@@ -83,7 +83,7 @@ jobs:
       - name: Download toolchain package
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: cpullvm-packages-build.sh-Linux-x86
+          pattern: cpullvm-*-Linux-x86_64
 
       - name: Unpack toolchain
         run: |
@@ -151,3 +151,4 @@ jobs:
         with:
           name: zephyr-merged-twister-test-results
           path: merged_twister.xml
+          archive: false

--- a/.github/workflows/zephyr-twister-tests.yml
+++ b/.github/workflows/zephyr-twister-tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./qualcomm-software/scripts/build.sh
 
       - name: Upload built packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
           name: cpullvm-packages-build.sh-Linux-x86
@@ -118,7 +118,7 @@ jobs:
             -x=CONFIG_COMPILER_RT_RTLIB=y
 
       - name: Upload Twister results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: zephyr-twister-test-results-${{ matrix.platform }}-subset-${{ matrix.subset }}
@@ -147,7 +147,7 @@ jobs:
           junitparser merge --glob "split_xml/**/twister.xml" merged_twister.xml
 
       - name: Upload merged XML results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zephyr-merged-twister-test-results
           path: merged_twister.xml


### PR DESCRIPTION
Right our toolchains are packaged as a zip or tarfile which is then
*re-zipped* by Github.

So we have `cpullvm-packages-*` as the uploaded artifact that unzips to
a `build/` folder with the real toolchain package inside.

Github's upload-artifact v7.0.1 added a new `archive` option that lets us
avoid this situation. This should make it a bit clearer what we're actually
intending to upload and avoids some extra steps when trying to extract the
toolchain after downloading.

=====

Stacked on https://github.com/qualcomm/cpullvm-toolchain/pull/472