### PR TITLE
[cpullvm][Multilib] Always enable experimental extensions when normalizing `-march`

### DIFF
--- a/qualcomm-software/cmake/get_canonical_riscv_march.cmake
+++ b/qualcomm-software/cmake/get_canonical_riscv_march.cmake
@@ -9,7 +9,10 @@
 # - `march_out` should contain the variable to be used to return the
 #   canonicalized arch string.
 function(get_canonical_riscv_march compiler_path build_args march_out)
-    set(command_args ${build_args} "--print-enabled-extensions")
+    # Always enable experimental extensions when normalizing the arch string
+    # to avoid needing to expose it as a multilib flag if experimental
+    # extensions are used.
+    set(command_args ${build_args} "-menable-experimental-extensions --print-enabled-extensions")
     execute_process(
         COMMAND ${compiler_path}
         ${command_args}

--- a/qualcomm-software/cmake/get_canonical_riscv_march.cmake
+++ b/qualcomm-software/cmake/get_canonical_riscv_march.cmake
@@ -12,7 +12,7 @@ function(get_canonical_riscv_march compiler_path build_args march_out)
     # Always enable experimental extensions when normalizing the arch string
     # to avoid needing to expose it as a multilib flag if experimental
     # extensions are used.
-    set(command_args ${build_args} "-menable-experimental-extensions --print-enabled-extensions")
+    set(command_args ${build_args} "-menable-experimental-extensions" "--print-enabled-extensions")
     execute_process(
         COMMAND ${compiler_path}
         ${command_args}


### PR DESCRIPTION
For the `clang ... --print-enabled-extensions` command to run successfully when experimental extensions are specified, `-menable-experimental-extensions` must be present.

Passing it through `flags` in multilib.json sort of works in that will allow the normalization to proceed, but:
1. It exposes `-menable-experimental-extensions` as a multilib flag for the variant
2. As a result of 1, we need to do some sort of additional fixup: teach clang to pass the flag through to multilib selection, add `Match` lines in multilib.yaml, etc.

I don't think it is really worth exposing this as a multilib flag as it doesn't give us any additional "safety" (clang will already have vetted that `-menable-experimental-extensions` is present by the time we're given normalized arguments for multilib matching if experimental extensions are needed). And depending on how we address 2 above we might have to do additional work to track what is/isn't experimental.

Always specifying it here is convenient in that:
* It should be safe even if no experimental extensions are used
* It doesn't expose any new multilib flags, etc.

So try this option for now.