### PR TITLE
Disable LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS on Windows.

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -252,8 +252,12 @@ set(LIBCLANG_BUILD_STATIC ON CACHE BOOL "")
 set(LLVM_POLLY_LINK_INTO_TOOLS ON CACHE BOOL "")
 set(CLANG_DEFAULT_LINKER lld CACHE STRING "")
 set(LLDB_ENABLE_PYTHON ON CACHE BOOL "")
-# Allow using any version of Python at runtime.
-set(LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS ON CACHE BOOL "")
+# Allow using any version of Python at runtime.  We don't need to set this
+# on Windows because it uses a different mechanism to allow different
+# Python versions.
+if (NOT CMAKE_HOST_WIN32)
+  set(LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS ON CACHE BOOL "")
+endif()
 # LLDB tests don't work on x86 because clang defaults to AArch64 target triple.
 # See https://github.com/llvm/llvm-project/issues/203090 .  Using a clang
 # wrapper works around a few of the failures; we don't have any good workaround


### PR DESCRIPTION
We don't really need this on Windows, and it's currently not working on Windows (https://github.com/llvm/llvm-project/pull/200843), so disable it.