### PR TITLE
[cpullvm] Pin host compiler to clang-cl-19 for Windows Builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,7 @@
 #
 # Other build configurations such as building the runtimes on non-Linux
 # x86_64 platforms are built and tested separately.
+# testing clang unification.
 
 name: Nightly Build and Test
 

--- a/qualcomm-software/scripts/build_copy_runtimes.ps1
+++ b/qualcomm-software/scripts/build_copy_runtimes.ps1
@@ -21,8 +21,8 @@ Set-VS-Env
 $repoRoot = git -C $PSScriptRoot rev-parse --show-toplevel
 $buildDir = (Join-Path $repoRoot build)
 
-$env:CC = 'clang-cl'
-$env:CXX = 'clang-cl'
+$env:CC = 'clang-cl-19'
+$env:CXX = 'clang-cl-19'
 
 mkdir $buildDir -Force
 cd $buildDir


### PR DESCRIPTION
Pin host compiler from generic 'clang-cl' to 'clang-cl-19', resolved from the LLVM installation pre-bundled with the GitHub=hosted windows-2025/windows-11-arm runners via the System Path.


Signed-off-by: Pranav Patil <pranpati@qti.qualcomm.com>