### PR TITLE
[cpullvm] Enable automerge for 23.x release branch

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,6 +19,8 @@ jobs:
         branches:
           - from_branch: main
             to_branch: qualcomm-software
+          - from_branch: release/23.x
+            to_branch: release/qualcomm-software/23.x
     steps:
       - name: Configure Access Token
         uses: actions/create-github-app-token@f45685208fd9b88321d74015b5996fc8c3e43d18 # v1.0.0

--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'qualcomm/cpullvm-toolchain'
     strategy:
       matrix:
-        branch: [main]
+        branch: [main, release/23.x]
     env:
       UPSTREAM_REMOTE: https://github.com/llvm/llvm-project.git
     steps:


### PR DESCRIPTION
This change extends the automerge workflow to include 23.x release branch.