### PR TITLE
[DNM] Proof-of-concept picolibc-curr, picolibc-main overlays

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -39,6 +39,14 @@ jobs:
             target_os: Linux-x86_64
             runner: cpullvm-ubuntu24-x86_64
 
+          # FIXME: this should probably go in the nightlies instead like
+          # musl-embedded, but I don't want to keep triggering those
+          # for the proof-of-concept PR.
+          - build_script: build_picolibc-main_overlay.sh
+            test_script: test_picolibc-main.sh
+            target_os: Linux-x86_64
+            runner: cpullvm-ubuntu24-x86_64
+
     steps:
       - name: Checkout source
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -39,9 +39,14 @@ jobs:
             target_os: Linux-x86_64
             runner: cpullvm-ubuntu24-x86_64
 
-          # FIXME: this should probably go in the nightlies instead like
+          # FIXME: these should probably go in the nightlies instead like
           # musl-embedded, but I don't want to keep triggering those
           # for the proof-of-concept PR.
+          - build_script: build_picolibc-curr_overlay.sh
+            test_script: test_picolibc-curr.sh
+            target_os: Linux-x86_64
+            runner: cpullvm-ubuntu24-x86_64
+
           - build_script: build_picolibc-main_overlay.sh
             test_script: test_picolibc-main.sh
             target_os: Linux-x86_64

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -343,7 +343,12 @@ endif()
 ##################################################################################################
 
 if(NOT LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
-    set(libc_cfg_path ${CMAKE_CURRENT_BINARY_DIR}/${LLVM_TOOLCHAIN_C_LIBRARY}.cfg)
+    # Place <libc>.cfg in the same directory as where clang will end up so that
+    # it can be used in builds in the same way as final installs.
+    set(
+        libc_cfg_path
+        ${CMAKE_CURRENT_BINARY_DIR}/llvm/bin/${LLVM_TOOLCHAIN_C_LIBRARY}.cfg
+    )
 
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/libc.cfg.in

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -315,13 +315,11 @@ fetch_repo(eld)
 #
 # If you want to stop cmake updating the repos then run
 # cmake . -DFETCHCONTENT_FULLY_DISCONNECTED=ON
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
-    fetch_repo(picolibc)
-endif()
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded OR ENABLE_LINUX_LIBRARIES)
-    fetch_repo(musl-embedded)
-endif()
+fetch_repo(${LLVM_TOOLCHAIN_C_LIBRARY})
 if(ENABLE_LINUX_LIBRARIES)
+    if(NOT LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+        fetch_repo(musl-embedded)
+    endif()
     fetch_repo(musl)
 endif()
 
@@ -344,7 +342,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 ##################################################################################################
 
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+if(NOT LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
     set(libc_cfg_path ${CMAKE_CURRENT_BINARY_DIR}/${LLVM_TOOLCHAIN_C_LIBRARY}.cfg)
 
     configure_file(
@@ -495,14 +493,14 @@ add_custom_target(
     -Dllvmproject_src_dir=${llvmproject_src_dir}
     -Deld_SOURCE_DIR=${eld_SOURCE_DIR}
     -Deld_URL=${eld_URL}
-    # at most one of picolibc and musl options is needed, but easiest to
-    # specify both definitions
-    -Dpicolibc_SOURCE_DIR=${picolibc_SOURCE_DIR}
-    -Dpicolibc_URL=${picolibc_URL}
+    -D${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR=${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}
+    -D${LLVM_TOOLCHAIN_C_LIBRARY}_URL=${${LLVM_TOOLCHAIN_C_LIBRARY}_URL}
+    -DLLVM_TOOLCHAIN_C_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
+    # Always pass through the Linux library information--the script will
+    # determine if it is needed. This might be a repeat if musl-embedded
+    # is the selected C library, but repeating it is harmless.
     -Dmusl-embedded_SOURCE_DIR=${musl-embedded_SOURCE_DIR}
     -Dmusl-embedded_URL=${musl-embedded_URL}
-    # but we do tell the script which library we're actually using
-    -DLLVM_TOOLCHAIN_C_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
     -Dmusl_SOURCE_DIR=${musl_SOURCE_DIR}
     -Dmusl_URL=${musl_URL}
     -DENABLE_LINUX_LIBRARIES=${ENABLE_LINUX_LIBRARIES}
@@ -610,6 +608,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
     string(REPLACE ";" "," ENABLE_VARIANTS_PASSTHROUGH "${LLVM_TOOLCHAIN_LIBRARY_VARIANTS}")
 
     set(multilib_prefix ${CMAKE_BINARY_DIR}/multilib-builds)
+    string(TOUPPER ${LLVM_TOOLCHAIN_C_LIBRARY} toolchain_c_lib_upper)
 
     ExternalProject_Add(
         multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
@@ -630,8 +629,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         -DENABLE_PARALLEL_LIB_BUILD=${ENABLE_PARALLEL_LIB_BUILD}
         -DPARALLEL_LIB_BUILD_LEVELS=${PARALLEL_LIB_BUILD_LEVELS}
         -DENABLE_QEMU_TESTING=${ENABLE_QEMU_TESTING}
-        -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}
-        -DFETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED=${FETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED}
+        -DFETCHCONTENT_SOURCE_DIR_${toolchain_c_lib_upper}=${FETCHCONTENT_SOURCE_DIR_${toolchain_c_lib_upper}}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         -DPROJECT_PREFIX=${multilib_prefix}
         -DNUMERICAL_BUILD_NAMES=${SHORT_BUILD_PATHS}
@@ -816,7 +814,7 @@ install(
     COMPONENT llvm-toolchain-docs
 )
 
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
+if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^picolibc")
     string(APPEND LIBC_LICENSE_FILES " - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc\n")
 endif()
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded OR ENABLE_LINUX_LIBRARIES)
@@ -862,10 +860,10 @@ list(APPEND third_party_license_files
     ${CMAKE_CURRENT_LIST_DIR}/ATfE-LICENSE.txt ATfE-LICENSE.txt
 )
 
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
+if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^picolibc")
     list(APPEND third_party_license_files
-        ${picolibc_SOURCE_DIR}/COPYING.NEWLIB           COPYING.NEWLIB
-        ${picolibc_SOURCE_DIR}/COPYING.picolibc         COPYING.picolibc
+        ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.NEWLIB           COPYING.NEWLIB
+        ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.picolibc         COPYING.picolibc
     )
 elseif(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
     list(APPEND third_party_license_files

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -120,7 +120,7 @@ set(LLVM_TOOLCHAIN_C_LIBRARY
     "Which C library to use."
 )
 set_property(CACHE LLVM_TOOLCHAIN_C_LIBRARY
-    PROPERTY STRINGS picolibc musl-embedded)
+    PROPERTY STRINGS picolibc picolibc-main musl-embedded)
 
 option(
     SHORT_BUILD_PATHS
@@ -819,8 +819,11 @@ install(
     COMPONENT llvm-toolchain-docs
 )
 
-if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^picolibc")
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
     string(APPEND LIBC_LICENSE_FILES " - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc\n")
+endif()
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc-main)
+    string(APPEND LIBC_LICENSE_FILES " - Picolibc: third-party-licenses/COPYING.picolibc\n")
 endif()
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded OR ENABLE_LINUX_LIBRARIES)
     string(APPEND LIBC_LICENSE_FILES " - musl-embedded: third-party-licenses/musl-embedded-COPYRIGHT.txt\n")
@@ -867,9 +870,14 @@ list(APPEND third_party_license_files
 
 if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^picolibc")
     list(APPEND third_party_license_files
-        ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.NEWLIB           COPYING.NEWLIB
         ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.picolibc         COPYING.picolibc
     )
+    # COPYING.NEWLIB has been removed in mainline picolibc.
+    if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL "picolibc")
+        list(APPEND third_party_license_files
+            ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.NEWLIB         COPYING.NEWLIB
+        )
+    endif()
 elseif(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
     list(APPEND third_party_license_files
         ${musl-embedded_SOURCE_DIR}/COPYRIGHT musl-embedded-COPYRIGHT.txt

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -120,7 +120,7 @@ set(LLVM_TOOLCHAIN_C_LIBRARY
     "Which C library to use."
 )
 set_property(CACHE LLVM_TOOLCHAIN_C_LIBRARY
-    PROPERTY STRINGS picolibc picolibc-main musl-embedded)
+    PROPERTY STRINGS picolibc picolibc-main picolibc-curr musl-embedded)
 
 option(
     SHORT_BUILD_PATHS
@@ -819,7 +819,7 @@ install(
     COMPONENT llvm-toolchain-docs
 )
 
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc OR LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc-curr)
     string(APPEND LIBC_LICENSE_FILES " - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc\n")
 endif()
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc-main)
@@ -873,7 +873,7 @@ if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^picolibc")
         ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.picolibc         COPYING.picolibc
     )
     # COPYING.NEWLIB has been removed in mainline picolibc.
-    if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL "picolibc")
+    if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc OR LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc-curr)
         list(APPEND third_party_license_files
             ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.NEWLIB         COPYING.NEWLIB
         )

--- a/qualcomm-software/embedded-multilib/CMakeLists.txt
+++ b/qualcomm-software/embedded-multilib/CMakeLists.txt
@@ -28,6 +28,17 @@ set(MULTILIB_JSON "" CACHE STRING "JSON file to load library definitions from.")
 set(ENABLE_VARIANTS "all" CACHE STRING "Semicolon separated list of variants to build, or \"all\". Must match entries in the json.")
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
 set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc musl-embedded)
+
+# multilib.json and the per-variant JSON files only know about one
+# "picolibc" entry, shared by every fetched picolibc version (e.g.
+# picolibc-main), not a separate entry per version. So map C_LIBRARY to
+# its base library name before looking anything up there.
+if(C_LIBRARY MATCHES "^picolibc")
+    set(json_library_key picolibc)
+else()
+    set(json_library_key ${C_LIBRARY})
+endif()
+
 set(PROJECT_PREFIX "${CMAKE_BINARY_DIR}/lib-builds" CACHE STRING "Directory to build subprojects in.")
 option(
     NUMERICAL_BUILD_NAMES
@@ -84,13 +95,13 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter) # needed by fetch_repo.cma
 
 include(ExternalProject)
 include(${TOOLCHAIN_SOURCE_DIR}/cmake/fetch_repo.cmake)
-if(C_LIBRARY STREQUAL picolibc)
-    fetch_repo(picolibc)
-    list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}")
-elseif(C_LIBRARY STREQUAL musl-embedded)
-    fetch_repo(musl-embedded)
-    list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED=${FETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED}")
-endif()
+fetch_repo(${C_LIBRARY})
+string(TOUPPER ${C_LIBRARY} c_library_upper)
+list(
+    APPEND
+    passthrough_dirs
+    "-DFETCHCONTENT_SOURCE_DIR_${c_library_upper}=${FETCHCONTENT_SOURCE_DIR_${c_library_upper}}"
+)
 
 # Target for any dependencies to build the runtimes project.
 add_custom_target(runtimes-depends)
@@ -163,7 +174,7 @@ foreach(lib_idx RANGE ${lib_count_dec})
     if(NOT variant_support STREQUAL "libraries_supported-NOTFOUND")
         # Replace colons with semi-colons so CMake comprehends the list.
         string(REPLACE "," ";" variant_support ${variant_support})
-        if(NOT C_LIBRARY IN_LIST variant_support)
+        if(NOT json_library_key IN_LIST variant_support)
             continue()
         endif()
     endif()
@@ -211,7 +222,7 @@ foreach(lib_idx RANGE ${lib_count_dec})
                     ENABLE_COMPILER_RT_TESTS
                     ENABLE_LIBCXX_TESTS
                 )
-                    string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" ${C_LIBRARY} ${test_enable_var})
+                    string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" ${json_library_key} ${test_enable_var})
                     if(read_${test_enable_var} STREQUAL "json-NOTFOUND")
                         string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" "common" ${test_enable_var})
                         if(read_${test_enable_var} STREQUAL "json-NOTFOUND")

--- a/qualcomm-software/embedded-multilib/CMakeLists.txt
+++ b/qualcomm-software/embedded-multilib/CMakeLists.txt
@@ -27,7 +27,7 @@ set(llvmproject_src_dir ${TOOLCHAIN_SOURCE_DIR}/..)
 set(MULTILIB_JSON "" CACHE STRING "JSON file to load library definitions from.")
 set(ENABLE_VARIANTS "all" CACHE STRING "Semicolon separated list of variants to build, or \"all\". Must match entries in the json.")
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
-set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc picolibc-main musl-embedded)
+set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc picolibc-main picolibc-curr musl-embedded)
 
 # multilib.json and the per-variant JSON files only know about one
 # "picolibc" entry, shared by every fetched picolibc version (e.g.

--- a/qualcomm-software/embedded-multilib/CMakeLists.txt
+++ b/qualcomm-software/embedded-multilib/CMakeLists.txt
@@ -27,7 +27,7 @@ set(llvmproject_src_dir ${TOOLCHAIN_SOURCE_DIR}/..)
 set(MULTILIB_JSON "" CACHE STRING "JSON file to load library definitions from.")
 set(ENABLE_VARIANTS "all" CACHE STRING "Semicolon separated list of variants to build, or \"all\". Must match entries in the json.")
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
-set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc musl-embedded)
+set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc picolibc-main musl-embedded)
 
 # multilib.json and the per-variant JSON files only know about one
 # "picolibc" entry, shared by every fetched picolibc version (e.g.

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -41,7 +41,13 @@ if(VARIANT_JSON)
         set(${json_param}_def ${json_val})
     endforeach()
     # Load arguments specific to the chosen library, overwriting any existing values.
-    string(JSON json_args GET ${variant_json_read} "args" ${C_LIBRARY})
+    # Let all picolibc versions share the same library-specific settings.
+    if(C_LIBRARY MATCHES "^picolibc")
+        set(json_library_key picolibc)
+    else()
+        set(json_library_key ${C_LIBRARY})
+    endif()
+    string(JSON json_args GET ${variant_json_read} "args" ${json_library_key})
     string(JSON json_args_len LENGTH ${json_args})
     math(EXPR json_args_len_dec "${json_args_len} - 1")
     foreach(json_idx RANGE ${json_args_len_dec})
@@ -169,7 +175,7 @@ add_custom_target(check-all)
 # If any testing is enabled, prepare test executor settings.
 if(ENABLE_LIBC_TESTS OR ENABLE_COMPILER_RT_TESTS OR ENABLE_LIBCXX_TESTS)
     # Flags required to link tests.
-    if(C_LIBRARY STREQUAL picolibc)
+    if(C_LIBRARY MATCHES "^picolibc")
         if(TEST_EXECUTOR STREQUAL qemu)
             set(picocrt "crt0-semihost")
         endif()
@@ -455,8 +461,8 @@ ExternalProject_Add(
 # picolibc
 ###############################################################################
 
-if(C_LIBRARY STREQUAL picolibc)
-    fetch_repo(picolibc)
+if(C_LIBRARY MATCHES "^picolibc")
+    fetch_repo(${C_LIBRARY})
     include(${CMAKE_CURRENT_SOURCE_DIR}/to_meson_list.cmake)
 
     # For building picolibc use Meson.
@@ -504,12 +510,12 @@ if(C_LIBRARY STREQUAL picolibc)
     endif()
 
     ExternalProject_Add(
-        picolibc
-        STAMP_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/stamp
-        BINARY_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/build
-        DOWNLOAD_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/dl
-        TMP_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/tmp
-        SOURCE_DIR ${picolibc_SOURCE_DIR}
+        ${C_LIBRARY}
+        STAMP_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/stamp
+        BINARY_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/build
+        DOWNLOAD_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/dl
+        TMP_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/tmp
+        SOURCE_DIR ${${C_LIBRARY}_SOURCE_DIR}
         INSTALL_DIR ${TEMP_LIB_DIR}
         DEPENDS compiler_rt-install
         CONFIGURE_COMMAND
@@ -546,30 +552,30 @@ if(C_LIBRARY STREQUAL picolibc)
         STEP_TARGETS configure build install
     )
 
-    add_custom_target(check-picolibc)
-    add_dependencies(check-all check-picolibc)
+    add_custom_target(check-${C_LIBRARY})
+    add_dependencies(check-all check-${C_LIBRARY})
     if(ENABLE_LIBC_TESTS)
         # meson builds the tests at the same time as the library.
         # So reconfigure to enable tests at a later point.
         ExternalProject_Add_Step(
-            picolibc
+            ${C_LIBRARY}
             compile-tests
             COMMAND ${MESON_EXECUTABLE} setup -Dtests=true --reconfigure <BINARY_DIR> <SOURCE_DIR>
             COMMAND ${MESON_EXECUTABLE} compile -C <BINARY_DIR>
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE
         )
-        ExternalProject_Add_StepTargets(picolibc compile-tests)
+        ExternalProject_Add_StepTargets(${C_LIBRARY} compile-tests)
         ExternalProject_Add_StepDependencies(
-            picolibc
+            ${C_LIBRARY}
             compile-tests
-            picolibc-build
+            ${C_LIBRARY}-build
             compiler_rt-install
         )
 
         # Step target to run the picolibc test via meson.
         ExternalProject_Add_Step(
-            picolibc
+            ${C_LIBRARY}
             check-meson
             COMMAND ${MESON_EXECUTABLE} test -C <BINARY_DIR> --no-rebuild
             USES_TERMINAL TRUE
@@ -577,23 +583,23 @@ if(C_LIBRARY STREQUAL picolibc)
             ALWAYS TRUE
             DEPENDEES compile-tests
         )
-        ExternalProject_Add_StepTargets(picolibc check-meson)
+        ExternalProject_Add_StepTargets(${C_LIBRARY} check-meson)
 
         # Generate lit wrappers for the tests.
         set(picolibc_lit_dir ${CMAKE_CURRENT_BINARY_DIR}/picolibc_lit)
         ExternalProject_Add_Step(
-            picolibc
+            ${C_LIBRARY}
             gen-lit-tests
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-support/gen-picolibc-lit-tests.py
                 --meson ${MESON_EXECUTABLE}
                 --build <BINARY_DIR>
                 --output ${picolibc_lit_dir}
-                --name picolibc-${variant_xml_name}
+                --name ${C_LIBRARY}-${variant_xml_name}
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE
             DEPENDEES compile-tests
         )
-        ExternalProject_Add_StepTargets(picolibc gen-lit-tests)
+        ExternalProject_Add_StepTargets(${C_LIBRARY} gen-lit-tests)
 
         # Generate xfails for picolibc.
         set(picolibc_lit_xfails_path "${picolibc_lit_dir}/${VARIANT}_picolibc_lit_xfails.txt")
@@ -614,7 +620,7 @@ if(C_LIBRARY STREQUAL picolibc)
 
         # Step target to run the picolibc test via lit.
         ExternalProject_Add_Step(
-            picolibc
+            ${C_LIBRARY}
             check-lit
             COMMAND ${check_lit_cmd}
             USES_TERMINAL TRUE
@@ -622,13 +628,13 @@ if(C_LIBRARY STREQUAL picolibc)
             ALWAYS TRUE
             DEPENDEES gen-lit-tests
         )
-        ExternalProject_Add_StepTargets(picolibc check-lit)
+        ExternalProject_Add_StepTargets(${C_LIBRARY} check-lit)
         ExternalProject_Add_StepDependencies(
-            picolibc
+            ${C_LIBRARY}
             check-lit
             picolibc-xfail-lit-args
         )
-        add_dependencies(check-picolibc picolibc-check-lit)
+        add_dependencies(check-${C_LIBRARY} ${C_LIBRARY}-check-lit)
         add_dependencies(clib-build ${C_LIBRARY}-compile-tests)
     endif()
 
@@ -714,7 +720,7 @@ add_dependencies(clib-install ${C_LIBRARY}-install)
 ###############################################################################
 
 if(ENABLE_CXX_LIBS)
-    if(C_LIBRARY STREQUAL picolibc)
+    if(C_LIBRARY MATCHES "^picolibc")
         set(cxxlibs_extra_cmake_options
             -DLIBCXXABI_ENABLE_THREADS=OFF
             -DLIBCXX_ENABLE_MONOTONIC_CLOCK=OFF

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -25,7 +25,7 @@ set(llvmproject_src_dir ${TOOLCHAIN_SOURCE_DIR}/..)
 # CMake arguments are loaded from the JSON file depending on which C
 # library is used, so this must be set before the JSON is processed.
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
-set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc picolibc-main musl-embedded)
+set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc picolibc-main picolibc-curr musl-embedded)
 
 set(VARIANT_JSON "" CACHE STRING "JSON file to load args from.")
 if(VARIANT_JSON)

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -25,7 +25,7 @@ set(llvmproject_src_dir ${TOOLCHAIN_SOURCE_DIR}/..)
 # CMake arguments are loaded from the JSON file depending on which C
 # library is used, so this must be set before the JSON is processed.
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
-set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc musl-embedded)
+set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc picolibc-main musl-embedded)
 
 set(VARIANT_JSON "" CACHE STRING "JSON file to load args from.")
 if(VARIANT_JSON)

--- a/qualcomm-software/patches/picolibc-curr/0001-Enable-libcxx-builds.patch
+++ b/qualcomm-software/patches/picolibc-curr/0001-Enable-libcxx-builds.patch
@@ -1,0 +1,52 @@
+From a59afdaf3697da7a1cfc62e0f957be780d6ae11a Mon Sep 17 00:00:00 2001
+From: Simi Pallipurath <simi.pallipurath@arm.com>
+Date: Thu, 14 Nov 2024 10:07:08 +0000
+Subject: Enable libcxx builds
+
+Modifications to build config and linker script required to enable
+libc++ builds.
+---
+ meson.build    | 12 ++++++++++++
+ picolibc.ld.in |  3 +++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index f33d011b2..2c653de02 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1340,6 +1340,18 @@ NEWLIB_MAJOR_VERSION=4
+ NEWLIB_MINOR_VERSION=3
+ NEWLIB_PATCHLEVEL_VERSION=0
+ 
++conf_data.set('_GNU_SOURCE', '',
++        description: '''Enable GNU functions like strtof_l.
++It's necessary to set this globally because inline functions in
++libc++ headers call the GNU functions.'''
++)
++
++conf_data.set('_PICOLIBC_CTYPE_SMALL', '0',
++        description: '''Disable picolibc's small ctype implementation.
++libc++ expects newlib-style ctype tables, and also expects support for locales
++and extended character sets, so picolibc's small ctype is not compatible with it'''
++)
++
+ conf_data.set('__HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
+ 	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
+ 	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
+diff --git a/picolibc.ld.in b/picolibc.ld.in
+index 0bcfe4ca8..c3055c49e 100644
+--- a/picolibc.ld.in
++++ b/picolibc.ld.in
+@@ -69,6 +69,9 @@ SECTIONS
+ 		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
+ 		*(SORT(.text.sorted.*))
+ 		*(.literal .text .literal.* .text.* .opd .opd.* .branch_lt .branch_lt.* @EXTRA_TEXT_SECTIONS@)
++		PROVIDE (__start___lcxx_override = .);
++		*(__lcxx_override)
++		PROVIDE (__stop___lcxx_override = .);
+ 		*(.gnu.linkonce.t.*)
+ 		KEEP (*(.fini .fini.*))
+ 		@PREFIX@__text_end = .;
+-- 
+2.43.0
+

--- a/qualcomm-software/patches/picolibc-curr/0002-Add-support-for-strict-align-no-unaligned-access-in-.patch
+++ b/qualcomm-software/patches/picolibc-curr/0002-Add-support-for-strict-align-no-unaligned-access-in-.patch
@@ -1,0 +1,431 @@
+From 8e46182db50f6a8ee0b67354887e606344303b7c Mon Sep 17 00:00:00 2001
+From: Lucas Prates <lucas.prates@arm.com>
+Date: Mon, 11 Nov 2024 16:37:04 +0000
+Subject: Add support for strict-align/no-unaligned-access in AArch64
+
+---
+ newlib/libc/machine/aarch64/memchr-stub.c    | 2 +-
+ newlib/libc/machine/aarch64/memchr.S         | 2 +-
+ newlib/libc/machine/aarch64/memcmp-stub.c    | 2 +-
+ newlib/libc/machine/aarch64/memcmp.S         | 2 +-
+ newlib/libc/machine/aarch64/memcpy-stub.c    | 2 +-
+ newlib/libc/machine/aarch64/memcpy.S         | 2 +-
+ newlib/libc/machine/aarch64/memmove-stub.c   | 2 +-
+ newlib/libc/machine/aarch64/memrchr-stub.c   | 2 +-
+ newlib/libc/machine/aarch64/memrchr.S        | 2 +-
+ newlib/libc/machine/aarch64/memset-stub.c    | 2 +-
+ newlib/libc/machine/aarch64/memset.S         | 2 +-
+ newlib/libc/machine/aarch64/rawmemchr-stub.c | 2 +-
+ newlib/libc/machine/aarch64/rawmemchr.S      | 2 +-
+ newlib/libc/machine/aarch64/stpcpy-stub.c    | 2 +-
+ newlib/libc/machine/aarch64/strchr-stub.c    | 2 +-
+ newlib/libc/machine/aarch64/strchr.S         | 2 +-
+ newlib/libc/machine/aarch64/strchrnul-stub.c | 2 +-
+ newlib/libc/machine/aarch64/strchrnul.S      | 2 +-
+ newlib/libc/machine/aarch64/strcmp-stub.c    | 2 +-
+ newlib/libc/machine/aarch64/strcmp.S         | 2 +-
+ newlib/libc/machine/aarch64/strcpy-stub.c    | 2 +-
+ newlib/libc/machine/aarch64/strcpy.S         | 2 +-
+ newlib/libc/machine/aarch64/strlen-stub.c    | 2 +-
+ newlib/libc/machine/aarch64/strlen.S         | 2 +-
+ newlib/libc/machine/aarch64/strncmp-stub.c   | 2 +-
+ newlib/libc/machine/aarch64/strncmp.S        | 2 +-
+ newlib/libc/machine/aarch64/strnlen-stub.c   | 2 +-
+ newlib/libc/machine/aarch64/strnlen.S        | 2 +-
+ newlib/libc/machine/aarch64/strrchr-stub.c   | 2 +-
+ newlib/libc/machine/aarch64/strrchr.S        | 2 +-
+ 30 files changed, 30 insertions(+), 30 deletions(-)
+
+diff --git a/newlib/libc/machine/aarch64/memchr-stub.c b/newlib/libc/machine/aarch64/memchr-stub.c
+index c2fabf07f..e688cf166 100644
+--- a/newlib/libc/machine/aarch64/memchr-stub.c
++++ b/newlib/libc/machine/aarch64/memchr-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ # include "../../string/memchr.c"
+ #else
+ /* See memchr.S  */
+diff --git a/newlib/libc/machine/aarch64/memchr.S b/newlib/libc/machine/aarch64/memchr.S
+index da1163221..dd5dec477 100644
+--- a/newlib/libc/machine/aarch64/memchr.S
++++ b/newlib/libc/machine/aarch64/memchr.S
+@@ -7,7 +7,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See memchr-stub.c  */
+ #else
+ /* Assumptions:
+diff --git a/newlib/libc/machine/aarch64/memcmp-stub.c b/newlib/libc/machine/aarch64/memcmp-stub.c
+index 74518257b..8b3e2b374 100644
+--- a/newlib/libc/machine/aarch64/memcmp-stub.c
++++ b/newlib/libc/machine/aarch64/memcmp-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ # include "../../string/memcmp.c"
+ #else
+ /* See memcmp.S  */
+diff --git a/newlib/libc/machine/aarch64/memcmp.S b/newlib/libc/machine/aarch64/memcmp.S
+index afe78fee3..9ca75c447 100644
+--- a/newlib/libc/machine/aarch64/memcmp.S
++++ b/newlib/libc/machine/aarch64/memcmp.S
+@@ -6,7 +6,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See memcmp-stub.c  */
+ #else
+ 
+diff --git a/newlib/libc/machine/aarch64/memcpy-stub.c b/newlib/libc/machine/aarch64/memcpy-stub.c
+index 6702a67dc..5ac7ca914 100644
+--- a/newlib/libc/machine/aarch64/memcpy-stub.c
++++ b/newlib/libc/machine/aarch64/memcpy-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
+ # include "../../string/memcpy.c"
+ #else
+ /* See memcpy.S  */
+diff --git a/newlib/libc/machine/aarch64/memcpy.S b/newlib/libc/machine/aarch64/memcpy.S
+index 7ba3fe347..6ac4ea577 100644
+--- a/newlib/libc/machine/aarch64/memcpy.S
++++ b/newlib/libc/machine/aarch64/memcpy.S
+@@ -13,7 +13,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See memcpy-stub.c  */
+ #else
+ #include "asmdefs.h"
+diff --git a/newlib/libc/machine/aarch64/memmove-stub.c b/newlib/libc/machine/aarch64/memmove-stub.c
+index 8b9154ffd..70e342a2c 100644
+--- a/newlib/libc/machine/aarch64/memmove-stub.c
++++ b/newlib/libc/machine/aarch64/memmove-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+ # include "../../string/memmove.c"
+ #else
+ /* See memcpy.S  */
+diff --git a/newlib/libc/machine/aarch64/memrchr-stub.c b/newlib/libc/machine/aarch64/memrchr-stub.c
+index 6d659d4d7..eea39c7ec 100644
+--- a/newlib/libc/machine/aarch64/memrchr-stub.c
++++ b/newlib/libc/machine/aarch64/memrchr-stub.c
+@@ -6,7 +6,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ #include "../../string/memrchr.c"
+ #else
+ /* See memrchr.S */
+diff --git a/newlib/libc/machine/aarch64/memrchr.S b/newlib/libc/machine/aarch64/memrchr.S
+index b0afa4eea..5c78cfb14 100644
+--- a/newlib/libc/machine/aarch64/memrchr.S
++++ b/newlib/libc/machine/aarch64/memrchr.S
+@@ -13,7 +13,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See memrchr-stub.c */
+ #else
+ #include "asmdefs.h"
+diff --git a/newlib/libc/machine/aarch64/memset-stub.c b/newlib/libc/machine/aarch64/memset-stub.c
+index a11c74573..c29cb0dae 100644
+--- a/newlib/libc/machine/aarch64/memset-stub.c
++++ b/newlib/libc/machine/aarch64/memset-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ # include "../../string/memset.c"
+ #else
+ /* See memset.S  */
+diff --git a/newlib/libc/machine/aarch64/memset.S b/newlib/libc/machine/aarch64/memset.S
+index 51ea476e3..7db2e3a85 100644
+--- a/newlib/libc/machine/aarch64/memset.S
++++ b/newlib/libc/machine/aarch64/memset.S
+@@ -13,7 +13,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See memset-stub.c  */
+ #else
+ #include "asmdefs.h"
+diff --git a/newlib/libc/machine/aarch64/rawmemchr-stub.c b/newlib/libc/machine/aarch64/rawmemchr-stub.c
+index 88d1e9472..3c379bfc4 100644
+--- a/newlib/libc/machine/aarch64/rawmemchr-stub.c
++++ b/newlib/libc/machine/aarch64/rawmemchr-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+ # include "../../string/rawmemchr.c"
+ #else
+ /* See rawmemchr.S.  */
+diff --git a/newlib/libc/machine/aarch64/rawmemchr.S b/newlib/libc/machine/aarch64/rawmemchr.S
+index 03e3b7525..9ed0464bf 100644
+--- a/newlib/libc/machine/aarch64/rawmemchr.S
++++ b/newlib/libc/machine/aarch64/rawmemchr.S
+@@ -32,7 +32,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See rawmemchr-stub.c.  */
+ #else
+ 
+diff --git a/newlib/libc/machine/aarch64/stpcpy-stub.c b/newlib/libc/machine/aarch64/stpcpy-stub.c
+index 0166c6785..9dd10b2a4 100644
+--- a/newlib/libc/machine/aarch64/stpcpy-stub.c
++++ b/newlib/libc/machine/aarch64/stpcpy-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
+ # include "../../string/stpcpy.c"
+ #else
+ /* See stpcpy.S  */
+diff --git a/newlib/libc/machine/aarch64/strchr-stub.c b/newlib/libc/machine/aarch64/strchr-stub.c
+index 0dcb5ca54..e187fcb4e 100644
+--- a/newlib/libc/machine/aarch64/strchr-stub.c
++++ b/newlib/libc/machine/aarch64/strchr-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
+ # include "../../string/strchr.c"
+ #else
+ /* See strchr.S  */
+diff --git a/newlib/libc/machine/aarch64/strchr.S b/newlib/libc/machine/aarch64/strchr.S
+index 2d79a3911..c22509df6 100644
+--- a/newlib/libc/machine/aarch64/strchr.S
++++ b/newlib/libc/machine/aarch64/strchr.S
+@@ -28,7 +28,7 @@
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See strchr-stub.c  */
+ #else
+ 
+diff --git a/newlib/libc/machine/aarch64/strchrnul-stub.c b/newlib/libc/machine/aarch64/strchrnul-stub.c
+index 407b949a6..7065c42b5 100644
+--- a/newlib/libc/machine/aarch64/strchrnul-stub.c
++++ b/newlib/libc/machine/aarch64/strchrnul-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ # include "../../string/strchrnul.c"
+ #else
+ /* See strchrnul.S  */
+diff --git a/newlib/libc/machine/aarch64/strchrnul.S b/newlib/libc/machine/aarch64/strchrnul.S
+index 5999c6d68..fff1102bd 100644
+--- a/newlib/libc/machine/aarch64/strchrnul.S
++++ b/newlib/libc/machine/aarch64/strchrnul.S
+@@ -28,7 +28,7 @@
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See strchrnul-stub.c  */
+ #else
+ 
+diff --git a/newlib/libc/machine/aarch64/strcmp-stub.c b/newlib/libc/machine/aarch64/strcmp-stub.c
+index 77177bfe0..f74140acd 100644
+--- a/newlib/libc/machine/aarch64/strcmp-stub.c
++++ b/newlib/libc/machine/aarch64/strcmp-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
+ # include "../../string/strcmp.c"
+ #else
+ /* See strcmp.S  */
+diff --git a/newlib/libc/machine/aarch64/strcmp.S b/newlib/libc/machine/aarch64/strcmp.S
+index 0c8371d22..ae52d3e0e 100644
+--- a/newlib/libc/machine/aarch64/strcmp.S
++++ b/newlib/libc/machine/aarch64/strcmp.S
+@@ -7,7 +7,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See strcmp-stub.c  */
+ #else
+ 
+diff --git a/newlib/libc/machine/aarch64/strcpy-stub.c b/newlib/libc/machine/aarch64/strcpy-stub.c
+index af2e1dd3c..5adc53f76 100644
+--- a/newlib/libc/machine/aarch64/strcpy-stub.c
++++ b/newlib/libc/machine/aarch64/strcpy-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
+ # include "../../string/strcpy.c"
+ #else
+ /* See strcpy.S  */
+diff --git a/newlib/libc/machine/aarch64/strcpy.S b/newlib/libc/machine/aarch64/strcpy.S
+index 5429c5c10..95987d4b3 100644
+--- a/newlib/libc/machine/aarch64/strcpy.S
++++ b/newlib/libc/machine/aarch64/strcpy.S
+@@ -28,7 +28,7 @@
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See strcpy-stub.c  */
+ #else
+ 
+diff --git a/newlib/libc/machine/aarch64/strlen-stub.c b/newlib/libc/machine/aarch64/strlen-stub.c
+index 59b1289ff..2f7aa7305 100644
+--- a/newlib/libc/machine/aarch64/strlen-stub.c
++++ b/newlib/libc/machine/aarch64/strlen-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ # include "../../string/strlen.c"
+ #else
+ /* See strlen.S  */
+diff --git a/newlib/libc/machine/aarch64/strlen.S b/newlib/libc/machine/aarch64/strlen.S
+index 8837c954b..f3b54c677 100644
+--- a/newlib/libc/machine/aarch64/strlen.S
++++ b/newlib/libc/machine/aarch64/strlen.S
+@@ -25,7 +25,7 @@
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See strlen-stub.c  */
+ #else
+ 
+diff --git a/newlib/libc/machine/aarch64/strncmp-stub.c b/newlib/libc/machine/aarch64/strncmp-stub.c
+index 2202cb79e..caca7fa83 100644
+--- a/newlib/libc/machine/aarch64/strncmp-stub.c
++++ b/newlib/libc/machine/aarch64/strncmp-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined (__ARM_FEATURE_UNALIGNED)
+ # include "../../string/strncmp.c"
+ #else
+ /* See strncmp.S  */
+diff --git a/newlib/libc/machine/aarch64/strncmp.S b/newlib/libc/machine/aarch64/strncmp.S
+index ba7b89313..3b64978bf 100644
+--- a/newlib/libc/machine/aarch64/strncmp.S
++++ b/newlib/libc/machine/aarch64/strncmp.S
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See strncmp-stub.c  */
+ #else
+ 
+diff --git a/newlib/libc/machine/aarch64/strnlen-stub.c b/newlib/libc/machine/aarch64/strnlen-stub.c
+index c4428f4f6..1e45ef066 100644
+--- a/newlib/libc/machine/aarch64/strnlen-stub.c
++++ b/newlib/libc/machine/aarch64/strnlen-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ # include "../../string/strnlen.c"
+ #else
+ /* See strnlen.S  */
+diff --git a/newlib/libc/machine/aarch64/strnlen.S b/newlib/libc/machine/aarch64/strnlen.S
+index f186fc13f..529e10276 100644
+--- a/newlib/libc/machine/aarch64/strnlen.S
++++ b/newlib/libc/machine/aarch64/strnlen.S
+@@ -28,7 +28,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See strnlen-stub.c  */
+ #else
+ 
+diff --git a/newlib/libc/machine/aarch64/strrchr-stub.c b/newlib/libc/machine/aarch64/strrchr-stub.c
+index 0ec573222..4dfedee46 100644
+--- a/newlib/libc/machine/aarch64/strrchr-stub.c
++++ b/newlib/libc/machine/aarch64/strrchr-stub.c
+@@ -26,7 +26,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined (__ARM_FEATURE_UNALIGNED)
+ # include "../../string/strrchr.c"
+ #else
+ /* See strrchr.S  */
+diff --git a/newlib/libc/machine/aarch64/strrchr.S b/newlib/libc/machine/aarch64/strrchr.S
+index a3ef3f8fe..f5ba3ad76 100644
+--- a/newlib/libc/machine/aarch64/strrchr.S
++++ b/newlib/libc/machine/aarch64/strrchr.S
+@@ -29,7 +29,7 @@
+ 
+ #include <picolibc.h>
+ 
+-#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON)
++#if (defined (__OPTIMIZE_SIZE__) || defined (__PREFER_SIZE_OVER_SPEED)) || !defined(__LP64__) || !defined(__ARM_NEON) || !defined(__ARM_FEATURE_UNALIGNED)
+ /* See strrchr-stub.c  */
+ #else
+ 
+-- 
+2.43.0
+

--- a/qualcomm-software/patches/picolibc-curr/0003-machine-riscv-Refactor-machine-specific-memcpy-overr.patch
+++ b/qualcomm-software/patches/picolibc-curr/0003-machine-riscv-Refactor-machine-specific-memcpy-overr.patch
@@ -1,0 +1,364 @@
+From 51fcccd1e9442e82d85080e13243dcf057b06781 Mon Sep 17 00:00:00 2001
+From: Venkata Ramanaiah Nalamothu <vnalamot@qti.qualcomm.com>
+Date: Tue, 16 Sep 2025 05:34:41 -0700
+Subject: [PATCH 3/5] machine/riscv: Refactor machine specific memcpy
+ overriding mechanism
+
+(cherry picked from commit 1a26807782ec810dce87f71b21c0335c17d3d7b9)
+(cherry picked from commit 94f1bdc48f9052c99650d88a78b2aa3b52a14ac2)
+(cherry picked from commit c1218d79199fbfbad400223502726563d24cb8e7)
+(cherry picked from commit 492d889b16457817f39ed85124327c6b3e6a8f03)
+---
+ newlib/libc/machine/riscv/CMakeLists.txt      |   2 +-
+ newlib/libc/machine/riscv/memcpy-asm.S        |   6 +-
+ newlib/libc/machine/riscv/memcpy.c            |   9 +-
+ newlib/libc/machine/riscv/memmove.S           |   6 +-
+ .../riscv/{memmove-stub.c => memmove.c}       |   4 +-
+ newlib/libc/machine/riscv/meson.build         |   2 +-
+ .../riscv/{rv_string.h => rv_strcpy.h}        |   6 +-
+ newlib/libc/machine/riscv/rv_string.h         | 143 +++---------------
+ newlib/libc/machine/riscv/stpcpy.c            |   2 +-
+ newlib/libc/machine/riscv/strcpy.c            |   2 +-
+ newlib/libc/machine/riscv/strlen.c            |   2 +-
+ 11 files changed, 40 insertions(+), 144 deletions(-)
+ rename newlib/libc/machine/riscv/{memmove-stub.c => memmove.c} (85%)
+ copy newlib/libc/machine/riscv/{rv_string.h => rv_strcpy.h} (98%)
+
+diff --git a/newlib/libc/machine/riscv/CMakeLists.txt b/newlib/libc/machine/riscv/CMakeLists.txt
+index 91a4b7a73..1ccfaad01 100644
+--- a/newlib/libc/machine/riscv/CMakeLists.txt
++++ b/newlib/libc/machine/riscv/CMakeLists.txt
+@@ -40,7 +40,7 @@ picolibc_sources_flags("-fno-builtin"
+   memcpy-asm.S
+   memcpy.c
+   memmove.S
+-  memmove-stub.c
++  memmove.c
+   memset.S
+   setjmp.S
+   stpcpy.c
+diff --git a/newlib/libc/machine/riscv/memcpy-asm.S b/newlib/libc/machine/riscv/memcpy-asm.S
+index 71758b415..61699849f 100644
+--- a/newlib/libc/machine/riscv/memcpy-asm.S
++++ b/newlib/libc/machine/riscv/memcpy-asm.S
+@@ -9,9 +9,9 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
+ 
+-#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++#ifdef _MACHINE_RISCV_MEMCPY_ASM_
+ .section .text.memcpy
+ .global memcpy
+ .type	memcpy, @function
+@@ -31,4 +31,4 @@ memcpy:
+   ret
+ 
+   .size	memcpy, .-memcpy
+-#endif
++#endif /* _MACHINE_RISCV_MEMCPY_ASM_ */
+diff --git a/newlib/libc/machine/riscv/memcpy.c b/newlib/libc/machine/riscv/memcpy.c
+index fe31bec59..5d15115fb 100644
+--- a/newlib/libc/machine/riscv/memcpy.c
++++ b/newlib/libc/machine/riscv/memcpy.c
+@@ -9,12 +9,9 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
+-
+-#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+-//memcpy defined in memcpy-asm.S
+-#else
++#include "rv_string.h"
+ 
++#ifdef _MACHINE_RISCV_MEMCPY_C_
+ #include <string.h>
+ #include <stdint.h>
+ #include "../../string/local.h"
+@@ -96,4 +93,4 @@ small:
+     goto small;
+   return aa;
+ }
+-#endif
++#endif /* _MACHINE_RISCV_MEMCPY_C_ */
+diff --git a/newlib/libc/machine/riscv/memmove.S b/newlib/libc/machine/riscv/memmove.S
+index 04334c36d..679dba66f 100644
+--- a/newlib/libc/machine/riscv/memmove.S
++++ b/newlib/libc/machine/riscv/memmove.S
+@@ -9,9 +9,9 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
+ 
+-#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++#ifdef _MACHINE_RISCV_MEMMOVE_ASM_
+ .section .text.memmove
+ .global memmove
+ .type	memmove, @function
+@@ -39,4 +39,4 @@ memmove:
+   ret
+ 
+   .size	memmove, .-memmove
+-#endif
++#endif /* _MACHINE_RISCV_MEMMOVE_ASM_ */
+diff --git a/newlib/libc/machine/riscv/memmove-stub.c b/newlib/libc/machine/riscv/memmove.c
+similarity index 85%
+rename from newlib/libc/machine/riscv/memmove-stub.c
+rename to newlib/libc/machine/riscv/memmove.c
+index 60b3239e9..0a8c601de 100644
+--- a/newlib/libc/machine/riscv/memmove-stub.c
++++ b/newlib/libc/machine/riscv/memmove.c
+@@ -9,8 +9,8 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
+ 
+-#if !defined(__PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
++#ifdef _MACHINE_RISCV_MEMMOVE_GENERIC_
+ #include "../../string/memmove.c"
+ #endif
+diff --git a/newlib/libc/machine/riscv/meson.build b/newlib/libc/machine/riscv/meson.build
+index 050e4cbd9..bf5a279d6 100644
+--- a/newlib/libc/machine/riscv/meson.build
++++ b/newlib/libc/machine/riscv/meson.build
+@@ -37,7 +37,7 @@ srcs_machine = [
+   'memcpy-asm.S',
+   'memcpy.c',
+   'memmove.S',
+-  'memmove-stub.c',
++  'memmove.c',
+   'memset.S',
+   'setjmp.S',
+   'stpcpy.c',
+diff --git a/newlib/libc/machine/riscv/rv_string.h b/newlib/libc/machine/riscv/rv_strcpy.h
+similarity index 98%
+copy from newlib/libc/machine/riscv/rv_string.h
+copy to newlib/libc/machine/riscv/rv_strcpy.h
+index da5798493..6b4a645be 100644
+--- a/newlib/libc/machine/riscv/rv_string.h
++++ b/newlib/libc/machine/riscv/rv_strcpy.h
+@@ -9,8 +9,8 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#ifndef _RV_STRING_H
+-#define _RV_STRING_H
++#ifndef _RV_STRCPY_H
++#define _RV_STRCPY_H
+ 
+ #include <stdbool.h>
+ #include <string.h>
+@@ -136,4 +136,4 @@ char *__libc_strcpy(char *dst, const char *src, bool ret_start)
+ }
+ 
+ 
+-#endif /* _RV_STRING_H */
++#endif /* _RV_STRCPY_H */
+diff --git a/newlib/libc/machine/riscv/rv_string.h b/newlib/libc/machine/riscv/rv_string.h
+index da5798493..4f40ab690 100644
+--- a/newlib/libc/machine/riscv/rv_string.h
++++ b/newlib/libc/machine/riscv/rv_string.h
+@@ -7,133 +7,32 @@
+    including the implied warranties of MERCHANTABILITY or FITNESS FOR
+    A PARTICULAR PURPOSE.  A copy of this license is available at
+    http://www.opensource.org/licenses.
+-*/
+-
+-#ifndef _RV_STRING_H
+-#define _RV_STRING_H
+ 
+-#include <stdbool.h>
+-#include <string.h>
+-#include "xlenint.h"
+-
+-#if __riscv_zbb
+-  // Determine which intrinsics to use based on XLEN and endianness
+-  #if __riscv_xlen == 64
+-    #if __has_builtin(__builtin_riscv_orc_b_64)
+-      #define __LIBC_RISCV_ZBB_ORC_B(x)       __builtin_riscv_orc_b_64 (x)
+-    #endif
++   Changes from Qualcomm Technologies, Inc. are provided under the following
++   license:
++   Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++   SPDX-License-Identifier: BSD-3-Clause-Clear
++*/
+ 
+-    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+-      #if __has_builtin(__builtin_riscv_ctz_64)
+-        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_ctz_64(x)
+-      #endif
+-    #else
+-      #if __has_builtin(__builtin_riscv_clz_64)
+-        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_clz_64(x)
+-      #endif
+-    #endif
+-  #else
+-    #if __has_builtin(__builtin_riscv_orc_b_32)
+-      #define __LIBC_RISCV_ZBB_ORC_B(x)       __builtin_riscv_orc_b_32(x)
+-    #endif
++#ifndef _RV_STRING_H_
++#define _RV_STRING_H_
+ 
+-    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+-      #if __has_builtin(__builtin_riscv_ctz_32)
+-        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_ctz_32(x)
+-      #endif
+-    #else
+-      #if __has_builtin(__builtin_riscv_clz_32)
+-        #define __LIBC_RISCV_ZBB_CNT_Z(x)     __builtin_riscv_clz_32(x)
+-      #endif
+-    #endif
+-  #endif
+-#endif
++/* This file defines macros to choose a specific custom implementation for
++ * 'string.h' APIs. The specialization is segretated per API to allow for
++ * different and/or complex scenarios for each API. */
+ 
++#include <picolibc.h>
+ 
+-static __inline uintxlen_t __libc_detect_null(uintxlen_t w)
+-{
+-#ifdef __LIBC_RISCV_ZBB_ORC_B
+-  /*
+-    If there are any zeros in each byte of the register, all bits will
+-    be unset for that byte value, otherwise, all bits will be set.
+-    If the value is -1, all bits are set, meaning no null byte was found.
+-  */
+-  return __LIBC_RISCV_ZBB_ORC_B(w) != (uintxlen_t) -1;
++#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++# define _MACHINE_RISCV_MEMCPY_ASM_
+ #else
+-  uintxlen_t mask = 0x7f7f7f7f;
+-  #if __riscv_xlen == 64
+-    mask = ((mask << 16) << 16) | mask;
+-  #endif
+-  return ~(((w & mask) + mask) | w | mask);
+-#endif
+-}
+-
+-
+-static __inline
+-#if __riscv_misaligned_slow || __riscv_misaligned_fast
+-__disable_sanitizer
+-#endif
+-char *__libc_strcpy(char *dst, const char *src, bool ret_start)
+-{
+-  char *dst0 = dst;
+-
+-#if !defined(PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+-#if !(__riscv_misaligned_slow || __riscv_misaligned_fast)
+-  int misaligned = ((uintxlen_t)dst | (uintxlen_t)src) & (sizeof (uintxlen_t) - 1);
+-  if (__builtin_expect(!misaligned, 1))
+-#endif
+-    {
+-      uintxlen_t *pdst = (uintxlen_t *)dst;
+-      const uintxlen_t *psrc = (const uintxlen_t *)src;
+-
+-      while (!__libc_detect_null(*psrc))
+-        *pdst++ = *psrc++;
+-
+-      dst = (char *)pdst;
+-      src = (const char *)psrc;
+-
+-      if (ret_start)
+-        {
+-          if (!(*dst++ = src[0])) return dst0;
+-          if (!(*dst++ = src[1])) return dst0;
+-          if (!(*dst++ = src[2])) return dst0;
+-          if (!(*dst++ = src[3])) return dst0;
+-          #if __riscv_xlen == 64
+-            if (!(*dst++ = src[4])) return dst0;
+-            if (!(*dst++ = src[5])) return dst0;
+-            if (!(*dst++ = src[6])) return dst0;
+-          #endif
+-        }
+-      else
+-        {
+-          if (!(*dst++ = src[0])) return dst - 1;
+-          if (!(*dst++ = src[1])) return dst - 1;
+-          if (!(*dst++ = src[2])) return dst - 1;
+-          if (!(*dst++ = src[3])) return dst - 1;
+-          #if __riscv_xlen == 64
+-            if (!(*dst++ = src[4])) return dst - 1;
+-            if (!(*dst++ = src[5])) return dst - 1;
+-            if (!(*dst++ = src[6])) return dst - 1;
+-            dst0 = dst;
+-          #endif
+-        }
+-
+-      *dst = 0;
+-      return dst0;
+-    }
+-#endif /* not PREFER_SIZE_OVER_SPEED */
+-
+-  char ch;
+-  do
+-    {
+-      ch = *src;
+-      src++;
+-      dst++;
+-      *(dst - 1) = ch;
+-    } while (ch);
+-
+-  return ret_start ? dst0 : dst - 1;
+-}
++# define _MACHINE_RISCV_MEMCPY_C_
++# endif
+ 
++#if !defined(__PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
++# define _MACHINE_RISCV_MEMMOVE_GENERIC_
++#else
++# define _MACHINE_RISCV_MEMMOVE_ASM_
++# endif
+ 
+-#endif /* _RV_STRING_H */
++#endif /* _RV_STRING_H_ */
+diff --git a/newlib/libc/machine/riscv/stpcpy.c b/newlib/libc/machine/riscv/stpcpy.c
+index 47fbf8499..eb9a67f21 100644
+--- a/newlib/libc/machine/riscv/stpcpy.c
++++ b/newlib/libc/machine/riscv/stpcpy.c
+@@ -11,7 +11,7 @@
+ 
+ #define _DEFAULT_SOURCE
+ #include <stdbool.h>
+-#include "rv_string.h"
++#include "rv_strcpy.h"
+ 
+ #undef stpcpy
+ 
+diff --git a/newlib/libc/machine/riscv/strcpy.c b/newlib/libc/machine/riscv/strcpy.c
+index 653985f91..ad4658f55 100644
+--- a/newlib/libc/machine/riscv/strcpy.c
++++ b/newlib/libc/machine/riscv/strcpy.c
+@@ -10,7 +10,7 @@
+ */
+ 
+ #include <stdbool.h>
+-#include "rv_string.h"
++#include "rv_strcpy.h"
+ 
+ #undef strcpy
+ 
+diff --git a/newlib/libc/machine/riscv/strlen.c b/newlib/libc/machine/riscv/strlen.c
+index 064157515..e93e492ff 100644
+--- a/newlib/libc/machine/riscv/strlen.c
++++ b/newlib/libc/machine/riscv/strlen.c
+@@ -13,7 +13,7 @@
+ 
+ #include <string.h>
+ #include <stdint.h>
+-#include "rv_string.h"
++#include "rv_strcpy.h"
+ 
+ size_t strlen(const char *str)
+ {
+-- 
+2.51.0
+

--- a/qualcomm-software/patches/picolibc-curr/0004-Add-optimized-memset-memcpy-strcpy-strcmp-for-Xqci.patch
+++ b/qualcomm-software/patches/picolibc-curr/0004-Add-optimized-memset-memcpy-strcpy-strcmp-for-Xqci.patch
@@ -1,0 +1,818 @@
+From 54fba7248ced01b6a8a97756701869d716a0f0df Mon Sep 17 00:00:00 2001
+From: Venkata Ramanaiah Nalamothu <vnalamot@qti.qualcomm.com>
+Date: Mon, 16 Mar 2026 03:31:04 -0700
+Subject: [PATCH 4/5] Add optimized memset/memcpy/strcpy/strcmp for Xqci
+
+The optimized implementations for Xqci will override the other
+existing corresponding varients when Xqci extenions are enabled.
+
+The orverriding happens using the interface implemented in the
+upstream Picolibc pull requests 1090, 1092 and 1098.
+---
+ newlib/libc/machine/riscv/CMakeLists.txt |   4 +
+ newlib/libc/machine/riscv/memcpy-xqci.S  | 283 +++++++++++++++++++++++
+ newlib/libc/machine/riscv/memset-xqci.S  | 161 +++++++++++++
+ newlib/libc/machine/riscv/memset.S       |   6 +-
+ newlib/libc/machine/riscv/meson.build    |   4 +
+ newlib/libc/machine/riscv/rv_string.h    |  26 ++-
+ newlib/libc/machine/riscv/strcmp-xqci.S  |  83 +++++++
+ newlib/libc/machine/riscv/strcmp.S       |   6 +-
+ newlib/libc/machine/riscv/strcpy-xqci.S  |  87 +++++++
+ newlib/libc/machine/riscv/strcpy.c       |   5 +
+ 10 files changed, 660 insertions(+), 5 deletions(-)
+ create mode 100644 newlib/libc/machine/riscv/memcpy-xqci.S
+ create mode 100644 newlib/libc/machine/riscv/memset-xqci.S
+ create mode 100644 newlib/libc/machine/riscv/strcmp-xqci.S
+ create mode 100644 newlib/libc/machine/riscv/strcpy-xqci.S
+
+diff --git a/newlib/libc/machine/riscv/CMakeLists.txt b/newlib/libc/machine/riscv/CMakeLists.txt
+index 1ccfaad01..82a8b9ec5 100644
+--- a/newlib/libc/machine/riscv/CMakeLists.txt
++++ b/newlib/libc/machine/riscv/CMakeLists.txt
+@@ -38,13 +38,17 @@ add_subdirectory(machine)
+ picolibc_sources_flags("-fno-builtin"
+   ieeefp.c
+   memcpy-asm.S
++  memcpy-xqci.S
+   memcpy.c
+   memmove.S
+   memmove.c
+   memset.S
++  memset-xqci.S
+   setjmp.S
+   stpcpy.c
++  strcmp-xqci.S
+   strcmp.S
++  strcpy-xqci.S
+   strcpy.c
+   strlen.c
+   )
+diff --git a/newlib/libc/machine/riscv/memcpy-xqci.S b/newlib/libc/machine/riscv/memcpy-xqci.S
+new file mode 100644
+index 000000000..c3bb96743
+--- /dev/null
++++ b/newlib/libc/machine/riscv/memcpy-xqci.S
+@@ -0,0 +1,283 @@
++/*****************************************************************
++Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++SPDX-License-Identifier: BSD-3-Clause-Clear
++*****************************************************************/
++
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_MEMCPY_ASM_XQCI_
++
++.text
++
++/*===========================================================================
++
++  void *memcpy(void *dest, const void *src, size_t n)
++
++  void __xqci_memcpy(void *dest, const void *src, size_t n)
++
++  void __xqci_memcpy_aligned(void *dest, void *src, size_t n)
++
++  void __xqci_memcpy_words(void *dest, void *src, size_t nwords)
++
++===========================================================================*/
++/*!
++    @brief
++    memcpy() is standard libc memcpy().
++    It returns the "dest" argument.
++
++    __xqci_memcpy is called by the compiler memcpy() builtin if it can't
++    inline. It is identical to standard memcpy(), except it does not
++    return a value.
++
++    __xqci_memcpy_aligned assumes that dest/src are 32-bit word aligned,
++    and n is a multiple of words (n==0 is allowed).
++    Alignment is not checked, behavior is undefined if not satisfied.
++
++    __xqci_memcpy_words is like __xqci_memcpy_aligned, except that length
++    is in units of 32-bit words instead of bytes.
++
++    For word-aligned src/dest/size, these functions are guaranteed to
++    do only word accesses, in sequential order, so they are safe to use
++    for HW peripherals.
++    For byte alignment on src/dest/size, access order may be non-sequential,
++    and some locations may be read/written multiple times.
++    In all cases, only bytes strictly within the src/dest regions will be
++    accessed, with no over-read.
++*/
++/*=========================================================================*/
++
++// Inputs:
++#define dest          a0
++#define src           a1
++#define n             a2
++#define nwords        n
++
++#define BUFSZ         4
++
++// Locals:
++#define dst           a3
++#define buf00         a4
++#define buf01         a5
++#define buf02         a6
++#define buf03         a7
++#define buf10         t3
++#define buf11         t4
++#define buf12         t5
++#define buf13         t6
++#define buf_size      t0
++#define len0          t1
++#define len1          t2
++#define tmp           buf00
++#define src_end       len0
++#define dst_end       len1
++
++#ifndef MEMSET_TEST
++.global       memcpy
++.type         memcpy, @function
++memcpy:
++#endif
++
++.global       __xqci_memcpy
++.type         __xqci_memcpy, @function
++__xqci_memcpy:
++    // Check for src/dest/size alignment
++    or        tmp, dest, src
++    or        tmp, tmp, n
++    andi      tmp, tmp, 0x3                           # LSB of dest, src, and n are 0
++    bnez      tmp,.Lunaligned                         # Unaligned, take slow path
++
++.size         memcpy, . - memcpy
++
++.global       __xqci_memcpy_aligned
++.type         __xqci_memcpy_aligned, @function
++__xqci_memcpy_aligned:
++
++    srli      nwords, n, 2                            # Number of words
++
++.global       __xqci_memcpy_words
++.type         __xqci_memcpy_words, @function
++__xqci_memcpy_words:
++    mv        dst, dest
++
++.Lmemcpy_words_cont:
++    qc.bgeui  nwords, (BUFSZ*2+1), .Lmemcpy_words_long
++
++.Lmemcpy_words_short:
++    li        buf_size, BUFSZ
++    minu      len0, nwords, buf_size                  # Limit to nwords or bufsize (can be 0)
++    qc.lwm    buf00, len0, 0(src)                     # Load first buffer (can be 0 size)
++    sub       nwords, nwords, len0                    # adjust remind words number
++    minu      len1, nwords, buf_size                  # Second buffer size (can be 0)
++    qc.lwm    buf10, len1, (BUFSZ*4)(src)             # Load second buffer (can be 0 size)
++    qc.swm    buf00, len0, 0(dst)                     # Store first buffer (can be 0 size)
++    qc.swm    buf10, len1, (BUFSZ*4)(dst)             # Store second buffer (can be 0 size)
++    ret
++
++.Lmemcpy_words_long:
++    addi      dst, dst, -(BUFSZ*4*2)                  # pre-decrement destination pointer
++
++.Lmemcpy_words_loop:
++    qc.lwmi   buf00, BUFSZ, 0(src)                    # Load first buffer (can be 0 size)
++    qc.lwmi   buf10, BUFSZ, (BUFSZ*4)(src)            # Load second buffer (can be 0 size)
++    addi      src, src, (BUFSZ*4*2)                   # Increment source pointer
++    addi      dst, dst, (BUFSZ*4*2)                   # increment destination pointer
++    qc.swmi   buf00, BUFSZ, 0(dst)                    # Store first buffer (can be 0 size)
++    qc.swmi   buf10, BUFSZ, (BUFSZ*4)(dst)            # Store second buffer (can be 0 size)
++    addi      nwords, nwords, -(BUFSZ*2)              # adjust remind words number
++    qc.bgeui  nwords, (BUFSZ*2), .Lmemcpy_words_loop
++
++    addi      dst, dst, (BUFSZ*4*2)                   # increment destination pointer
++    bnez      nwords, .Lmemcpy_words_short
++    ret
++
++// src and/or dest and/or size are not word aligned.
++.Lunaligned:
++    mv        dst, dest
++    qc.bltui  n, 16, .Lbytecopy                       # Buffer is <= 15 bytes, copy directly
++
++    // Copy 3 bytes from the beginning and end of the buffer to handle
++    // realignment and over-read prevention. These will never overlap.
++    // Some of these may be re-copied after realignment.
++
++    lbu       buf00, 0(src)                           # Start of buffer
++    lbu       buf01, 1(src)
++    lbu       buf02, 2(src)
++    add       src_end, src, n                         # doing this add here to avoid bubble
++    sb        buf00, 0(dst)
++    sb        buf01, 1(dst)
++    sb        buf02, 2(dst)
++
++    lbu       buf00, -3(src_end)
++    lbu       buf01, -2(src_end)
++    lbu       buf02, -1(src_end)
++    add       dst_end, dst, n                         # doing this add here to avoid bubble
++    sb        buf00, -3(dst_end)
++    sb        buf01, -2(dst_end)
++    sb        buf02, -1(dst_end)
++
++    // Add 4 to avoid over-read in src, and +3 to round up dest to word boundary.
++    // Subtract 4 to avoid over-read in src_end, and round down to word boundary.
++    addi      dst, dst, 3
++    andi      dst, dst, -4                            # dest+7, rounded down
++    sub       tmp, dst, dest                          # Offset from original dest
++    add       src, src, tmp                           # Offset src by same amount (may not align)
++    andi      dst_end, dst_end, -4                    # -4 and round down on end of dest
++    sub       n, dst_end, dst                         # Updated n. Word multiple, >= 4
++
++    // dest and n are now word aligned.
++    // If src is also aligned, do remainder, as word aligned copy.
++    srli      nwords, n, 2                            # Number of words
++    andi      tmp, src, 0x3
++    beqz      tmp, .Lmemcpy_words_cont                # we are ready to branch to aligned word loop
++
++#define buf04         s2
++#define buf05         s3
++#define buf06         s4
++#define buf07         s5
++#define desc          s0
++#define len           s1
++#define limit         buf_size
++#define LIMIT_WORDS   (BUFSZ*2-1)
++#define LIMIT_BYTES   (LIMIT_WORDS*4)
++
++    // src is not aligned to dest. Realign src data.
++    qc.cm.push {ra,s0-s5}, -32
++    li        desc, 0x200000                          # Width=32 in upper halfword
++    qc.insb   desc, src, 2, 3                         # Byte offset*8 in lower halfword
++    andi      src, src, -4                            # Word align src
++    lw        buf07, 0(src)                           # Load first word
++    addi      dst, dst, -LIMIT_BYTES                  # Pre-subtract dest
++
++    // We don't expect to be doing unaligned access to cache.
++    // Pipeline less aggressively to save code, do bookkeeping
++    // between load and access which should hide memory latency.
++    // This loop copies <= 7 words per iteration.
++
++    li        limit, LIMIT_WORDS
++.Lunaligned_word_loop:
++    mv        buf00, buf07                            # Copy last word from previous buf
++    minu      len, nwords, limit                      # Maximum 7 words per iteration
++    qc.lwm    buf01, len, 4(src)                      # Load next buffer, offset by 1 word
++    addi      src, src, LIMIT_BYTES                   # Inc src for next iteration
++    addi      dst, dst, LIMIT_BYTES                   # Pre-inc dest
++    qc.extdur buf00, buf00, desc                      # Realign each word
++    qc.extdur buf01, buf01, desc
++    qc.extdur buf02, buf02, desc
++    qc.extdur buf03, buf03, desc
++    qc.extdur buf04, buf04, desc
++    qc.extdur buf05, buf05, desc
++    qc.extdur buf06, buf06, desc
++    qc.swm    buf00, len, 0(dst)                      # Store realigned data
++    sub       nwords, nwords, len
++    bnez      nwords, .Lunaligned_word_loop
++    qc.cm.popret {ra,s0-s5}, 32
++
++#undef buf04
++#undef buf05
++#undef buf06
++#undef buf07
++#undef limit
++#undef desc
++#undef LIMIT_WORDS
++#undef LIMIT_BYTES
++
++// Copy buffer directly, size is <= 15 bytes
++// Try to hide load latency, within reason.
++.Lbytecopy:
++    qc.bltui  n, 4, .Lbytecopy_2
++
++.Lbytecopy_4:
++    // Copy 4 bytes per iteration
++    lbu       buf00, 0(src)
++    lbu       buf01, 1(src)
++    lbu       buf02, 2(src)
++    lbu       buf03, 3(src)
++    addi      src, src, 4
++    sb        buf00, 0(dst)
++    sb        buf01, 1(dst)
++    sb        buf02, 2(dst)
++    sb        buf03, 3(dst)
++    addi      dst, dst, 4
++    addi      n, n, -4
++    qc.bgeui  n, 4, .Lbytecopy_4                    # Repeat until < 4 bytes remaining
++
++.Lbytecopy_2:
++    qc.bltui  n, 2, .Lbytecopy_1_check
++    // Copy 2 bytes.
++    lbu       buf00, 0(src)
++    lbu       buf01, 1(src)
++    addi      src, src, 2
++    addi      n, n, -2
++    sb        buf00, 0(dst)
++    sb        buf01, 1(dst)
++    addi      dst, dst, 2
++
++.Lbytecopy_1_check:
++    bnez      n, .Lbytecopy_1
++    ret
++
++.Lbytecopy_1:
++    lbu       buf00, 0(src)
++    sb        buf00, 0(dst)
++    ret
++
++#undef BUFSZ
++#undef src_end
++#undef dst_end
++#undef tmp
++#undef dst
++#undef len0
++#undef len1
++#undef buf_size
++#undef buf00
++#undef buf01
++#undef buf02
++#undef buf03
++#undef buf10
++#undef buf11
++#undef buf12
++#undef buf13
++
++.size         __xqci_memcpy, . - __xqci_memcpy
++
++#endif /*_MACHINE_RISCV_MEMCPY_ASM_XQCI_ */
+diff --git a/newlib/libc/machine/riscv/memset-xqci.S b/newlib/libc/machine/riscv/memset-xqci.S
+new file mode 100644
+index 000000000..361fdb7b3
+--- /dev/null
++++ b/newlib/libc/machine/riscv/memset-xqci.S
+@@ -0,0 +1,161 @@
++/*****************************************************************
++Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++SPDX-License-Identifier: BSD-3-Clause-Clear
++*****************************************************************/
++
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_MEMSET_ASM_XQCI_
++
++.text
++
++/*===========================================================================
++
++  void *memset(void *s, int c, size_t n)
++
++  void __xqci_memset(void *s, int c, size_t n)
++
++  void __xqci_memset_aligned(unsigned *s, int c, size_t n)
++
++  void __xqci_memset_words(unsigned *s, unsigned w, size_t nwords)
++
++===========================================================================*/
++/*!
++    @brief
++    memset() is the standard libc implementation.
++    It returns the "s" argument.
++
++    __xqci_memset() is called by the compiler memset() builtin if it can't
++    inline. It is identical to standard memset(), except it does not
++    return a value.
++
++    __xqci_memset_aligned() works similarly to __xqci_memset(), except it assumes
++    s is 32-bit aligned, and n is a multiple of 32 bits (n==0 is allowed).
++    Alignment is not checked, behavior is undefined if not satisfied.
++
++    __xqci_memset_words() also requires s to be 32-bit aligned.
++    w has the value replicated in each byte, and nwords is the length
++    in units of 32-bit words.
++
++    For word aligned address/length, these functions are guaranteed to do
++    only word access, in sequential order, so they are safe to use for
++    HW peripherals.
++    If address or length have byte alignment, then sequential access
++    is not guaranteed, and some locations may be written multiple times.
++*/
++/*=========================================================================*/
++
++#ifndef MEMSET_TEST
++.global     memset
++.type       memset, @function
++memset:
++#endif
++
++.global     __xqci_memset
++.type       __xqci_memset, @function
++__xqci_memset:
++// Inputs:
++#define s               a0
++#define c               a1
++#define w               c
++#define n               a2
++#define nwords          n
++// Locals:
++#define len             a3
++#define end             a5
++
++#define BLOCK_WORDS     (28)
++#define BLOCK_BYTES     (BLOCK_WORDS*4)
++
++    // Common case: if s and n are word aligned, use aligned function.
++#define a               a4
++    or       a, s, n
++    andi     a, a, 0x3
++    bnez     a, .Lunaligned                          # Skip if unaligned
++#undef a
++    // Fallthrough to aligned memset
++
++#define p               a4
++// External entry for __xqci_memset_aligned
++.global     __xqci_memset_aligned
++.type       __xqci_memset_aligned, @function
++__xqci_memset_aligned:
++    mv       p, s                                    # keep s value since it is return value
++.L__xqci_memset_aligned:
++
++    srli     nwords, n, 2                            # Convert to nwords
++    qc.insb  w, c, 8, 8                              # Splat c over all 4 bytes
++    qc.insb  w, w, 16, 16
++    qc.e.bgeui nwords, 32, .Llong                    # Long memset if >= 32 words
++    qc.setwm w, nwords, 0(p)                         # Short memset (1..31 words) is fast path
++    ret
++
++.Llong:
++    // Long memset, 32 or more words.
++    // Align the address to a 128-bit PDMEM boundary so block stores
++    // are more efficient.
++    qc.extu  len, p, 2, 2                            # Word address mod 4
++    not      len, len
++    addi     len, len, 5                             # Residual to next 4-word multiple
++    qc.setwm w, len, 0(p)                            # Store 1..4 words for alignment
++    sh2add   p, len, p                               # p += alignment words*4
++    sub      nwords, nwords, len                     # nwords -= alignment words
++    qc.e.bltui nwords, 32, .Ltail
++
++    // Store in blocks of 28 words, except for last block.
++.Lblocks:
++    qc.setwmi w, BLOCK_WORDS, 0(p)                   # Store block size words
++    addi     p, p, BLOCK_BYTES                       # Increment ptr, may overflow but not used in
++    addi     nwords, nwords, -BLOCK_WORDS            # nwords -= length
++    qc.bgeui nwords, BLOCK_WORDS, .Lblocks
++
++.Ltail:
++    qc.setwm w, nwords, 0(p)                         # Store reminder of words, if any
++    ret
++
++    // Unaligned start address and/or length.
++.Lunaligned:
++    // Do byte stores at start/end of buffer.
++    // Some locations may be written multiple times for small buffers.
++    mv       p, s                                     # keep s value since it is return value
++    add      end, p, n                                # End of buffer
++    beqz     n, .Lroundup
++    sb       c, 0(p)
++    sb       c, -1(end)
++    addi     n, n, -1
++    beqz     n, .Lroundup
++    sb       c, 1(p)
++    sb       c, -2(end)
++    addi     n, n, -1
++    beqz     n, .Lroundup
++    sb       c, 2(p)
++    sb       c, -3(end)
++
++    // Any residual bytes at start/end of buffer have been set.
++    // Round up starting address and round down size to word boundaries and
++    // continue with alignment memset.
++    // Some bytes may be written again by word writes.
++.Lroundup:
++    addi     p, p, 3
++    andi     p, p, -4                                # Round up p
++    sub      n, end, p                               # n = end - p  (may be negative)
++                                                     # __xqci_memset_aligned will round down n
++    qc.bgei  n, 4, .L__xqci_memset_aligned           # Set middle of buffer as words
++
++    // Short buffer, return immediately
++    ret
++
++// External entry for __xqci_memset_words
++.global     __xqci_memset_words
++.type       __xqci_memset_words, @function
++__xqci_memset_words:
++    mv       p, s                                    # keep s value since it is return value
++    qc.e.bgeui nwords, 32, .Llong                    # Long memset if >= 32 words
++    qc.setwm w, nwords, 0(s)                         # Short memset (1..31 words) is fast path
++    ret
++
++#undef p
++
++.size       __xqci_memset, . - __xqci_memset
++
++#endif /* _MACHINE_RISCV_MEMSET_ASM_XQCI_ */
+diff --git a/newlib/libc/machine/riscv/memset.S b/newlib/libc/machine/riscv/memset.S
+index 3f09fc067..5355d6898 100644
+--- a/newlib/libc/machine/riscv/memset.S
++++ b/newlib/libc/machine/riscv/memset.S
+@@ -9,7 +9,9 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_MEMSET_ASM_
+ 
+ .section .text.memset
+ .global memset
+@@ -113,3 +115,5 @@ memset:
+   j .Laligned
+ #endif
+   .size	memset, .-memset
++
++#endif /* _MACHINE_RISCV_MEMSET_ASM_ */
+diff --git a/newlib/libc/machine/riscv/meson.build b/newlib/libc/machine/riscv/meson.build
+index bf5a279d6..af2060e3c 100644
+--- a/newlib/libc/machine/riscv/meson.build
++++ b/newlib/libc/machine/riscv/meson.build
+@@ -35,13 +35,17 @@
+ srcs_machine = [
+   'ieeefp.c',
+   'memcpy-asm.S',
++  'memcpy-xqci.S',
+   'memcpy.c',
+   'memmove.S',
+   'memmove.c',
+   'memset.S',
++  'memset-xqci.S',
+   'setjmp.S',
+   'stpcpy.c',
++  'strcmp-xqci.S',
+   'strcmp.S',
++  'strcpy-xqci.S',
+   'strcpy.c',
+   'strlen.c',
+ ]
+diff --git a/newlib/libc/machine/riscv/rv_string.h b/newlib/libc/machine/riscv/rv_string.h
+index 4f40ab690..92e59f997 100644
+--- a/newlib/libc/machine/riscv/rv_string.h
++++ b/newlib/libc/machine/riscv/rv_string.h
+@@ -23,16 +23,36 @@
+ 
+ #include <picolibc.h>
+ 
+-#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++#ifdef __riscv_xqci
++# define _MACHINE_RISCV_MEMCPY_ASM_XQCI_
++#elif defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+ # define _MACHINE_RISCV_MEMCPY_ASM_
+ #else
+ # define _MACHINE_RISCV_MEMCPY_C_
+-# endif
++#endif
+ 
+ #if !defined(__PREFER_SIZE_OVER_SPEED) && !defined(__OPTIMIZE_SIZE__)
+ # define _MACHINE_RISCV_MEMMOVE_GENERIC_
+ #else
+ # define _MACHINE_RISCV_MEMMOVE_ASM_
+-# endif
++#endif
++
++#if defined(__riscv_xqci)
++# define _MACHINE_RISCV_MEMSET_ASM_XQCI_
++#else
++# define _MACHINE_RISCV_MEMSET_ASM_
++#endif
++
++#if defined(__riscv_xqci)
++# define _MACHINE_RISCV_STRCMP_ASM_XQCI_
++#else
++# define _MACHINE_RISCV_STRCMP_ASM_
++#endif
++
++#if defined(__riscv_xqci)
++# define _MACHINE_RISCV_STRCPY_ASM_XQCI_
++#else
++# define _MACHINE_RISCV_STRCPY_ASM_
++#endif
+ 
+ #endif /* _RV_STRING_H_ */
+diff --git a/newlib/libc/machine/riscv/strcmp-xqci.S b/newlib/libc/machine/riscv/strcmp-xqci.S
+new file mode 100644
+index 000000000..1a7fdda89
+--- /dev/null
++++ b/newlib/libc/machine/riscv/strcmp-xqci.S
+@@ -0,0 +1,83 @@
++/*****************************************************************
++Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++SPDX-License-Identifier: BSD-3-Clause-Clear
++*****************************************************************/
++
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_STRCMP_ASM_XQCI_
++
++.text
++
++/*===========================================================================
++
++  int strcmp(const char *s1, const char *s2)
++
++===========================================================================*/
++
++    /*
++     * Returns
++     *   a0 - comparison result, value like strcmp
++     *
++     * Parameters
++     *   a0 - string1
++     *   a1 - string2
++     *
++     * Clobbers
++     *   a2, a3, a4, a5, a6
++     */
++.global strcmp
++.type strcmp, @function
++strcmp:
++    mv      a6, a0
++    or      a5, a6, a1
++    and     a5, a5, 3
++    li      a4, 0
++    bnez    a5, 3f
++
++    /* Main loop for aligned string.  */
++1:
++    qc.lrw  a2, a6, a4, 0
++    qc.lrw  a3, a1, a4, 0
++    orc.b   a5, a2
++    qc.bnei a5, -1, 2f
++    addi    a4, a4, 4
++    beq     a2, a3, 1b
++
++    /*
++     * Words don't match, and no null byte in the first word.
++     * Compute the first differing byte and return unsigned difference.
++     */
++    xor     a5, a2, a3
++    ctz     a5, a5          # bit offset to first differing bit
++    andi    a5, a5, -0x8    # bit offset to first differing byte
++    srl     a0, a2, a5
++    andi    a0, a0, 0xFF
++    srl     a3, a3, a5
++    andi    a3, a3, 0xFF
++    sub     a0, a0, a3
++    ret
++
++2:
++    /*
++     * Found a null byte.
++     * If words don't match, fall back to simple loop.
++     */
++    xor     a0, a2, a3
++    bnez    a0, 3f
++    /* Otherwise, strings are equal. */
++    ret
++
++    /* Simple loop for misaligned strings. */
++3:
++    qc.lrbu a2, a6, a4, 0
++    qc.lrbu a3, a1, a4, 0
++    addi    a4, a4, 1
++    bne     a2, a3, 4f
++    bnez    a2, 3b
++
++4:
++    sub     a0, a2, a3
++    ret
++
++#endif /* _MACHINE_RISCV_STRCMP_ASM_XQCI_ */
+diff --git a/newlib/libc/machine/riscv/strcmp.S b/newlib/libc/machine/riscv/strcmp.S
+index 1b9869e72..ffb7f2215 100644
+--- a/newlib/libc/machine/riscv/strcmp.S
++++ b/newlib/libc/machine/riscv/strcmp.S
+@@ -9,7 +9,9 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_STRCMP_ASM_
+ 
+ #include "asm.h"
+ 
+@@ -202,3 +204,5 @@ mask:
+ .size	strcmp, .-strcmp
+ 
+ #endif
++
++#endif /* _MACHINE_RISCV_STRCMP_ASM_ */
+diff --git a/newlib/libc/machine/riscv/strcpy-xqci.S b/newlib/libc/machine/riscv/strcpy-xqci.S
+new file mode 100644
+index 000000000..56d82fe85
+--- /dev/null
++++ b/newlib/libc/machine/riscv/strcpy-xqci.S
+@@ -0,0 +1,87 @@
++/*****************************************************************
++Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++SPDX-License-Identifier: BSD-3-Clause-Clear
++*****************************************************************/
++
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_STRCPY_ASM_XQCI_
++
++.text
++
++/*===========================================================================
++
++  char * strcpy(char *dst, const char *src)
++
++===========================================================================*/
++
++    /*
++     * Returns
++     *   a0 - destination string
++     *
++     * Parameters
++     *   a0 - destination
++     *   a1 - source
++     *
++     * Clobbers
++     *   a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
++     */
++.global strcpy
++.type strcpy, @function
++strcpy:
++    mv      a7, a0
++    or      a2, a0, a1
++    and     a2, a1, 3
++    bnez    a2, 4f
++1:
++    qc.lwmi t3, 4, 0(a1)
++    add     a1, a1, 16
++    li      a2, -1
++    orc.b   a3, t3
++    and     a2, a2, a3
++    orc.b   a4, t4
++    and     a2, a2, a4
++    orc.b   a5, t5
++    and     a2, a2, a5
++    orc.b   a6, t6
++    and     a2, a2, a6
++    qc.bnei a2, -1, 2f
++    qc.swmi t3, 4, 0(a7)
++    add     a7, a7, 16
++    j       1b
++
++2:
++    add     a1, a1, -16
++    li      a2, 0
++    qc.bnei a3, -1, 3f
++    qc.srw  t3, a7, a2, 0
++    add     a2, a2, 4
++    qc.bnei a4, -1, 3f
++    qc.srw  t4, a7, a2, 0
++    add     a2, a2, 4
++    qc.bnei a5, -1, 3f
++    qc.srw  t5, a7, a2, 0
++    add     a2, a2, 4
++
++3:
++    add     a7, a7, a2
++    add     a1, a1, a2
++4:
++    lbu     a2, 0(a1)
++    lbu     a3, 1(a1)
++    lbu     a4, 2(a1)
++    lbu     a5, 3(a1)
++    sb      a2, 0(a7)
++    beqz    a2, 5f
++    sb      a3, 1(a7)
++    beqz    a3, 5f
++    sb      a4, 2(a7)
++    beqz    a4, 5f
++    sb      a5, 3(a7)
++    beqz    a5, 5f
++    li      a2,    4
++    j       3b
++5:
++    ret
++
++#endif /* _MACHINE_RISCV_STRCPY_ASM_XQCI_ */
+diff --git a/newlib/libc/machine/riscv/strcpy.c b/newlib/libc/machine/riscv/strcpy.c
+index ad4658f55..f1791c602 100644
+--- a/newlib/libc/machine/riscv/strcpy.c
++++ b/newlib/libc/machine/riscv/strcpy.c
+@@ -11,6 +11,9 @@
+ 
+ #include <stdbool.h>
+ #include "rv_strcpy.h"
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_STRCPY_ASM_
+ 
+ #undef strcpy
+ 
+@@ -18,3 +21,5 @@ char *strcpy(char *dst, const char *src)
+ {
+   return __libc_strcpy(dst, src, true);
+ }
++
++#endif /* _MACHINE_RISCV_STRCPY_ASM_ */
+-- 
+2.51.0
+

--- a/qualcomm-software/patches/picolibc-curr/0005-riscv-crt-Add-Support-for-Zcmt.patch
+++ b/qualcomm-software/patches/picolibc-curr/0005-riscv-crt-Add-Support-for-Zcmt.patch
@@ -1,0 +1,287 @@
+From 02ba9150018b65d10fae64613a2c285a03a22390 Mon Sep 17 00:00:00 2001
+From: Sam Elliott <aelliott@qti.qualcomm.com>
+Date: Wed, 10 Jun 2026 17:43:48 -0700
+Subject: [PATCH 5/5] [riscv][crt] Add Support for Zcmt
+
+Zcmt is the "jump table" extension for RISC-V. Broadly, how this is
+supported in the CRT is that the weak symbol `__riscv_jvt$` is defined
+if the toolchain has created a jump table, and this variable needs to be
+used to initialize the `jvt` csr. The jump table itself will be placed
+in an (executable) `.riscv.jvt` section, because the `cm.jt` and
+`cm.jalt` instructions access the table as if it were instruction
+memory, not data memory.
+
+The test here is designed to create its own jump table using the C
+compiler and inline assembly, and to use it, and does not rely on a
+Linker to create the jump table, as would usually be the case. I can
+rewrite this in assembly if preferred.
+
+This slightly reorganises the riscv crt0.c, to bring comments back to
+the code they relate to, and to align the _start and _trap
+implementations.
+---
+ meson.build                  |  8 ++++
+ picocrt/machine/riscv/crt0.c | 69 ++++++++++++++++++++++-----
+ picolibc.ld.in               |  2 +
+ test/meson.build             |  1 +
+ test/test-riscv-jvt.c        | 92 ++++++++++++++++++++++++++++++++++++
+ 5 files changed, 160 insertions(+), 12 deletions(-)
+ create mode 100644 test/test-riscv-jvt.c
+
+diff --git a/meson.build b/meson.build
+index 5fd9d790a..5ce9b0c38 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1053,6 +1053,14 @@ foreach params : [default_target] + targets
+       picolibc_linker_type_data.set('TLS_INIT_SEG', 'tls_init')
+     endif
+ 
++    if host_cpu_family == 'riscv'
++      picolibc_linker_type_data.set('RISCV_START', '/* For RISC-V Only: */')
++      picolibc_linker_type_data.set('RISCV_END', '')
++    else
++      picolibc_linker_type_data.set('RISCV_START', '/* For RISC-V Only:')
++      picolibc_linker_type_data.set('RISCV_END', '*/')
++    endif
++
+     init_memory_template = '''
+ 	@0@ (rx!w) :
+ 		ORIGIN = DEFINED(__@0@) ? __@0@ : @1@,
+diff --git a/picocrt/machine/riscv/crt0.c b/picocrt/machine/riscv/crt0.c
+index cbf267b2d..fc75d7cb3 100644
+--- a/picocrt/machine/riscv/crt0.c
++++ b/picocrt/machine/riscv/crt0.c
+@@ -158,18 +158,30 @@ _trap(void)
+         SAVE_CSR(mcause);
+         SAVE_CSR(mtval);
+ 
+-        /*
+-         * Pass pointer to saved registers in first parameter register
+-         */
+-	__asm__(".option	push\n"
+-                ".option	norelax\n"
++    /*
++     * Ensure GP and JVT are initialized before calling C
++     */
++    __asm__(".option	push\n"
++            ".option	norelax\n"
+ #ifdef __riscv_cmodel_large
+                 "ld     gp,.trap_gp\n"
+ #else
+                 "la	gp, __global_pointer$\n"
+ #endif
+-                ".option	pop");
+-        __asm__("mv     a0, sp");
++            ".option	pop");
++
++#ifdef __riscv_zcmt
++    __asm__(".weak __jvt_base$\n"
++#ifdef __riscv_cmodel_large
++            "ld t0, .trap_jvt_base\n"
++#else
++            "la t0, __jvt_base$\n"
++#endif
++            // __jvt_base$ is weak, so skip initializing `CSR[jvt]` if it is zero (undefined)
++            "beqz t0, .Lafter_jvt_init_trap\n"
++            "csrw jvt, t0\n"
++            ".Lafter_jvt_init_trap:\n");
++#endif
+ 
+         /* Enable FPU (just in case) */
+ #ifdef __riscv_flen
+@@ -179,10 +191,21 @@ _trap(void)
+                 "csrw	mstatus, t0\n"
+                 "csrwi	fcsr, 0");
+ #endif
+-        __asm__("jal    _ctrap");
++
++    /*
++     * Call to C passing the saved registers as the first parameter.
++     */
++    __asm__("mv     a0, sp\n"
++            "jal    _ctrap");
++
+ #ifdef __riscv_cmodel_large
+-        __asm__(".align 3\n.trap_sp:\n.dword __stack");
+-        __asm__(".align 3\n.trap_gp:\n.dword __global_pointer$");
++    __asm__(".align 3\n"
++            ".trap_sp: .dword __stack\n" /* FIXME: this is __heap_end in non-large code models. */
++            ".trap_gp: .dword __global_pointer$\n"
++#ifdef __riscv_zcmt
++            ".trap_jvt_base: .dword __jvt_base$\n"
++#endif
++    );
+ #endif
+ }
+ #endif
+@@ -228,6 +251,20 @@ _start(void)
+                 "csrw	mstatus, t0\n"
+                 "csrwi	vxrm, 1");
+ #endif
++
++#ifdef __riscv_zcmt
++    __asm__(".weak __jvt_base$\n"
++#ifdef __riscv_cmodel_large
++            "ld t0, .start_jvt_base\n"
++#else
++            "la t0, __jvt_base$\n"
++#endif
++            // __jvt_base$ is weak, so skip initializing `CSR[jvt]` if it is zero (undefined)
++            "beqz t0, .Lafter_jvt_init\n"
++            "csrw jvt, t0\n"
++            ".Lafter_jvt_init:\n");
++#endif
++
+ #ifdef CRT0_SEMIHOST
+ #ifdef __riscv_cmodel_large
+         __asm__("ld     t0,.start_trap");
+@@ -237,13 +274,21 @@ _start(void)
+         __asm__("csrw   mtvec, t0");
+         __asm__("csrr   t1, mtvec");
+ #endif
+-        __asm__("j      _cstart");
++
++    /*
++     * Call into C start function
++     */
++    __asm__("j      _cstart");
++
+ #ifdef __riscv_cmodel_large
+         __asm__(".align 3\n"
+                 ".start_sp: .dword __stack\n"
+                 ".start_gp: .dword __global_pointer$\n"
+ #ifdef CRT0_SEMIHOST
+-                ".start_trap: .dword _trap"
++            ".start_trap: .dword _trap\n"
++#endif
++#ifdef __riscv_zcmt
++            ".start_jvt_base: .dword __jvt_base$\n"
+ #endif
+             );
+ #endif
+diff --git a/picolibc.ld.in b/picolibc.ld.in
+index c766e60a6..490d81427 100644
+--- a/picolibc.ld.in
++++ b/picolibc.ld.in
+@@ -101,6 +101,8 @@ SECTIONS
+ 		KEEP (*(.fini_array*))
+ 		PROVIDE_HIDDEN ( @PREFIX@__fini_array_end = . );
+ 
++		@RISCV_START@ KEEP (*(.riscv.jvt)) @RISCV_END@
++
+ 	} >flash AT>flash :text
+ 
+ 	.rodata : {
+diff --git a/test/meson.build b/test/meson.build
+index 8e6a72869..f042890a5 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -48,6 +48,7 @@ plain_tests_common = ['regex', 'ungetc',
+                       'test-scmpu',
+                       'test-strncpy',
+                       'time-tests',
++                      'test-riscv-jvt',
+ 	      ]
+ 
+ math_tests_common = [
+diff --git a/test/test-riscv-jvt.c b/test/test-riscv-jvt.c
+new file mode 100644
+index 000000000..e9539bd08
+--- /dev/null
++++ b/test/test-riscv-jvt.c
+@@ -0,0 +1,92 @@
++/*
++ * SPDX-License-Identifier: BSD-3-Clause
++ *
++ * Copyright © 2022 Keith Packard
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *
++ * 2. Redistributions in binary form must reproduce the above
++ *    copyright notice, this list of conditions and the following
++ *    disclaimer in the documentation and/or other materials provided
++ *    with the distribution.
++ *
++ * 3. Neither the name of the copyright holder nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
++ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
++ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
++ * OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#include <stdio.h>
++#include <stdlib.h>
++
++#if !defined(__riscv) || !defined(__riscv_jvt)
++
++const char    *get_message(void);
++
++_Noreturn void print_message(const char *);
++
++/*
++ * The Jump Table has 256 entries, the first 32 are for `cm.jt` and the rest are
++ * for `cm.jalt`. The former is for `tail` and the latter is for `call`.
++ */
++__attribute__((aligned(64))) __attribute__((section(".riscv.jvt"))) void *func_table[256] = {
++    [0] = &print_message,
++    [32] = &get_message,
++};
++
++__asm__(".weak __jvt_base$\n"
++        ".set __jvt_base$, func_table\n");
++
++const char *
++get_message(void)
++{
++    return "retrieved message correctly";
++}
++
++void
++print_message(const char *message)
++{
++    printf("SUCCESS: %s\n", message);
++    exit(0);
++}
++
++#endif
++
++int
++main(void)
++{
++    printf("executing jvt tests\n");
++
++    /*
++     * This is a RISC-V specific feature.
++     */
++#if !defined(__riscv) || !defined(__riscv_zcmt)
++    printf("jvt not supported for this target\n");
++    return 77;
++#else
++
++    __asm__("cm.jalt 32\n" // This is equivalent to `call func_table[32]`
++            "cm.jt 0\n"    // This is equivalent to `tail func_table[0]`
++    );
++
++    printf("ERROR: cm.jt returned\n");
++    return 1;
++#endif
++}
+-- 
+2.51.0
+

--- a/qualcomm-software/patches/picolibc-curr/0006-riscv-crt-Add-Support-for-Xqccmt.patch
+++ b/qualcomm-software/patches/picolibc-curr/0006-riscv-crt-Add-Support-for-Xqccmt.patch
@@ -1,0 +1,81 @@
+From 614406dc2f321973091be75d7f9d4763c8839fae Mon Sep 17 00:00:00 2001
+From: Sam Elliott <aelliott@qti.qualcomm.com>
+Date: Mon, 6 Jul 2026 11:13:11 -0700
+Subject: [PATCH] [riscv][crt] Add Support for Xqccmt
+
+Xqccmt is a vendor-specific variant of Zcmt with additional
+capabilities. Enabling it in the CRT is exactly the same as for Zcmt -
+the `jvt` csr nees to be initialised with `__jvt_base$`.
+
+Signed-off-by: Sam Elliott <aelliott@qti.qualcomm.com>
+(cherry picked from commit 3faeb852f82ea88395847b33f4680d43ac96a022)
+---
+ picocrt/machine/riscv/crt0.c | 8 ++++----
+ test/test-riscv-jvt.c        | 4 ++--
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/picocrt/machine/riscv/crt0.c b/picocrt/machine/riscv/crt0.c
+index fc75d7cb3..a194681aa 100644
+--- a/picocrt/machine/riscv/crt0.c
++++ b/picocrt/machine/riscv/crt0.c
+@@ -170,7 +170,7 @@ _trap(void)
+ #endif
+             ".option	pop");
+ 
+-#ifdef __riscv_zcmt
++#if defined(__riscv_zcmt) || defined(__riscv_xqccmt)
+     __asm__(".weak __jvt_base$\n"
+ #ifdef __riscv_cmodel_large
+             "ld t0, .trap_jvt_base\n"
+@@ -202,7 +202,7 @@ _trap(void)
+     __asm__(".align 3\n"
+             ".trap_sp: .dword __stack\n" /* FIXME: this is __heap_end in non-large code models. */
+             ".trap_gp: .dword __global_pointer$\n"
+-#ifdef __riscv_zcmt
++#if defined(__riscv_zcmt) || defined(__riscv_xqccmt)
+             ".trap_jvt_base: .dword __jvt_base$\n"
+ #endif
+     );
+@@ -252,7 +252,7 @@ _start(void)
+                 "csrwi	vxrm, 1");
+ #endif
+ 
+-#ifdef __riscv_zcmt
++#if defined(__riscv_zcmt) || defined(__riscv_xqccmt)
+     __asm__(".weak __jvt_base$\n"
+ #ifdef __riscv_cmodel_large
+             "ld t0, .start_jvt_base\n"
+@@ -287,7 +287,7 @@ _start(void)
+ #ifdef CRT0_SEMIHOST
+             ".start_trap: .dword _trap\n"
+ #endif
+-#ifdef __riscv_zcmt
++#if defined(__riscv_zcmt) || defined(__riscv_xqccmt)
+             ".start_jvt_base: .dword __jvt_base$\n"
+ #endif
+             );
+diff --git a/test/test-riscv-jvt.c b/test/test-riscv-jvt.c
+index e9539bd08..cb22a7c22 100644
+--- a/test/test-riscv-jvt.c
++++ b/test/test-riscv-jvt.c
+@@ -36,7 +36,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
+-#if !defined(__riscv) || !defined(__riscv_jvt)
++#if !defined(__riscv) || (!defined(__riscv_zcmt) && !defined(__riscv_xqccmt))
+ 
+ const char    *get_message(void);
+ 
+@@ -77,7 +77,7 @@ main(void)
+     /*
+      * This is a RISC-V specific feature.
+      */
+-#if !defined(__riscv) || !defined(__riscv_zcmt)
++#if !defined(__riscv) || (!defined(__riscv_zcmt) && !defined(__riscv_xqccmt))
+     printf("jvt not supported for this target\n");
+     return 77;
+ #else
+-- 
+2.51.0
+

--- a/qualcomm-software/patches/picolibc-curr/0007-riscv-crt-Fix-Xqccmt-Support.patch
+++ b/qualcomm-software/patches/picolibc-curr/0007-riscv-crt-Fix-Xqccmt-Support.patch
@@ -1,0 +1,60 @@
+From 1bf1a2ae4e9901cdd96ea883eb2b593db5558491 Mon Sep 17 00:00:00 2001
+From: Sam Elliott <aelliott@qti.qualcomm.com>
+Date: Thu, 9 Jul 2026 17:57:30 -0700
+Subject: [PATCH] [riscv][crt] Fix Xqccmt Support
+
+This fixes two issues:
+- Using the wrong mnemonics with Xqccmt (the encodings are the same, the
+  mnemonics are different), and
+- A logic error in the ifdefs.
+
+Signed-off-by: Sam Elliott <aelliott@qti.qualcomm.com>
+---
+ test/test-riscv-jvt.c | 19 +++++++++++++------
+ 1 file changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/test/test-riscv-jvt.c b/test/test-riscv-jvt.c
+index cb22a7c22..65aff459d 100644
+--- a/test/test-riscv-jvt.c
++++ b/test/test-riscv-jvt.c
+@@ -36,7 +36,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
+-#if !defined(__riscv) || (!defined(__riscv_zcmt) && !defined(__riscv_xqccmt))
++#if defined(__riscv) && (defined(__riscv_zcmt) || defined(__riscv_xqccmt))
+ 
+ const char    *get_message(void);
+ 
+@@ -77,16 +77,23 @@ main(void)
+     /*
+      * This is a RISC-V specific feature.
+      */
+-#if !defined(__riscv) || (!defined(__riscv_zcmt) && !defined(__riscv_xqccmt))
+-    printf("jvt not supported for this target\n");
+-    return 77;
+-#else
+-
++#if defined(__riscv) && defined(__riscv_zcmt)
+     __asm__("cm.jalt 32\n" // This is equivalent to `call func_table[32]`
+             "cm.jt 0\n"    // This is equivalent to `tail func_table[0]`
+     );
+ 
+     printf("ERROR: cm.jt returned\n");
+     return 1;
++#elif defined(__riscv) && defined(__riscv_xqccmt)
++    __asm__("qc.cm.jalt 32\n" // This is equivalent to `call func_table[32]`
++            "qc.cm.jt 0\n"    // This is equivalent to `tail func_table[0]`
++    );
++
++    printf("ERROR: qc.cm.jt returned\n");
++    return 1;
++#else
++    printf("jvt not supported for this target\n");
++    return 77;
+ #endif
++
+ }
+-- 
+2.51.0
+

--- a/qualcomm-software/patches/picolibc-main/0001-Enable-libcxx-builds.patch
+++ b/qualcomm-software/patches/picolibc-main/0001-Enable-libcxx-builds.patch
@@ -1,0 +1,52 @@
+From a59afdaf3697da7a1cfc62e0f957be780d6ae11a Mon Sep 17 00:00:00 2001
+From: Simi Pallipurath <simi.pallipurath@arm.com>
+Date: Thu, 14 Nov 2024 10:07:08 +0000
+Subject: Enable libcxx builds
+
+Modifications to build config and linker script required to enable
+libc++ builds.
+---
+ meson.build    | 12 ++++++++++++
+ picolibc.ld.in |  3 +++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index f33d011b2..2c653de02 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1340,6 +1340,18 @@ NEWLIB_MAJOR_VERSION=4
+ NEWLIB_MINOR_VERSION=3
+ NEWLIB_PATCHLEVEL_VERSION=0
+ 
++conf_data.set('_GNU_SOURCE', '',
++        description: '''Enable GNU functions like strtof_l.
++It's necessary to set this globally because inline functions in
++libc++ headers call the GNU functions.'''
++)
++
++conf_data.set('_PICOLIBC_CTYPE_SMALL', '0',
++        description: '''Disable picolibc's small ctype implementation.
++libc++ expects newlib-style ctype tables, and also expects support for locales
++and extended character sets, so picolibc's small ctype is not compatible with it'''
++)
++
+ conf_data.set('__HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
+ 	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
+ 	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
+diff --git a/picolibc.ld.in b/picolibc.ld.in
+index 0bcfe4ca8..c3055c49e 100644
+--- a/picolibc.ld.in
++++ b/picolibc.ld.in
+@@ -69,6 +69,9 @@ SECTIONS
+ 		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
+ 		*(SORT(.text.sorted.*))
+ 		*(.literal .text .literal.* .text.* .opd .opd.* .branch_lt .branch_lt.* @EXTRA_TEXT_SECTIONS@)
++		PROVIDE (__start___lcxx_override = .);
++		*(__lcxx_override)
++		PROVIDE (__stop___lcxx_override = .);
+ 		*(.gnu.linkonce.t.*)
+ 		KEEP (*(.fini .fini.*))
+ 		@PREFIX@__text_end = .;
+-- 
+2.43.0
+

--- a/qualcomm-software/scripts/build_picolibc-curr_overlay.sh
+++ b/qualcomm-software/scripts/build_picolibc-curr_overlay.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to build the picolibc-curr overlay.
+
+# The script creates a build of the toolchain in the 'build_picolibc-curr_overlay'
+# directory, inside the repository tree.
+
+set -ex
+
+export CC=clang
+export CXX=clang++
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+BUILD_DIR=${REPO_ROOT}/build_picolibc-curr_overlay
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+cmake ../qualcomm-software -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=picolibc-curr -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
+ninja package-llvm-toolchain
+
+# The package-llvm-toolchain target will produce a .tar.xz package, but we also
+# want a zip version for Windows users
+cpack -G ZIP

--- a/qualcomm-software/scripts/build_picolibc-main_overlay.sh
+++ b/qualcomm-software/scripts/build_picolibc-main_overlay.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to build the picolibc-main overlay.
+
+# The script creates a build of the toolchain in the 'build_picolibc-main_overlay'
+# directory, inside the repository tree.
+
+set -ex
+
+export CC=clang
+export CXX=clang++
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+BUILD_DIR=${REPO_ROOT}/build_picolibc-main_overlay
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+cmake ../qualcomm-software -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=picolibc-main -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
+ninja package-llvm-toolchain
+
+# The package-llvm-toolchain target will produce a .tar.xz package, but we also
+# want a zip version for Windows users
+cpack -G ZIP

--- a/qualcomm-software/scripts/test_picolibc-curr.sh
+++ b/qualcomm-software/scripts/test_picolibc-curr.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# The script assumes a successful build of the toolchain exists in the
+# 'build_picolibc-curr_overlay' directory inside the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+
+# Run only the library and multilib lit tests. Only a few libc++ variants
+# are tested to keep the runtime acceptable.
+cd "${REPO_ROOT}"/build_picolibc-curr_overlay
+ninja check-llvm-toolchain
+ninja check-cxxabi
+ninja check-cxx-aarch64a_tlsie
+ninja check-cxx-armv7a_soft_nofp
+ninja check-cxx-riscv32imac_ilp32
+ninja check-cxx-riscv64gc_lp64_nopic

--- a/qualcomm-software/scripts/test_picolibc-main.sh
+++ b/qualcomm-software/scripts/test_picolibc-main.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# The script assumes a successful build of the toolchain exists in the
+# 'build_picolibc-main_overlay' directory inside the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+
+# Run only the library and multilib lit tests. Only a few libc++ variants
+# are tested to keep the runtime acceptable.
+cd "${REPO_ROOT}"/build_picolibc-main_overlay
+ninja check-llvm-toolchain
+ninja check-cxxabi
+ninja check-cxx-aarch64a_tlsie
+ninja check-cxx-armv7a_soft_nofp
+ninja check-cxx-riscv32imac_ilp32
+ninja check-cxx-riscv64gc_lp64_nopic

--- a/qualcomm-software/test/CMakeLists.txt
+++ b/qualcomm-software/test/CMakeLists.txt
@@ -7,6 +7,7 @@ llvm_canonicalize_cmake_booleans(
 
 if(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL)
   set(EMBEDDED_LIBS_DIR_SUFFIX "/${LLVM_TOOLCHAIN_C_LIBRARY}")
+  set(LLVM_TOOLCHAIN_LIBC_CFG " --config=${LLVM_TOOLCHAIN_C_LIBRARY}.cfg")
 endif()
 
 configure_lit_site_cfg(

--- a/qualcomm-software/test/CMakeLists.txt
+++ b/qualcomm-software/test/CMakeLists.txt
@@ -5,6 +5,10 @@ llvm_canonicalize_cmake_booleans(
   ENABLE_BACKTRACES
 )
 
+if(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL)
+  set(EMBEDDED_LIBS_DIR_SUFFIX "/${LLVM_TOOLCHAIN_C_LIBRARY}")
+endif()
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/qualcomm-software/test/lit.site.cfg.py.in
+++ b/qualcomm-software/test/lit.site.cfg.py.in
@@ -11,7 +11,9 @@ config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@LLVM_DEFAULT_TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
-config.substitutions.append(("%llvm_embedded_libs_dir", "@LLVM_BINARY_DIR@/lib/clang-runtimes"))
+llvm_embedded_libs_dir = "@LLVM_BINARY_DIR@/lib/clang-runtimes@EMBEDDED_LIBS_DIR_SUFFIX@"
+config.substitutions.append(("%llvm_embedded_libs_dir", llvm_embedded_libs_dir))
+config.substitutions.append(("%clang_with_sysroot", "%clang --sysroot=" + llvm_embedded_libs_dir))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/qualcomm-software/test/lit.site.cfg.py.in
+++ b/qualcomm-software/test/lit.site.cfg.py.in
@@ -13,7 +13,7 @@ config.python_executable = "@Python3_EXECUTABLE@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
 llvm_embedded_libs_dir = "@LLVM_BINARY_DIR@/lib/clang-runtimes@EMBEDDED_LIBS_DIR_SUFFIX@"
 config.substitutions.append(("%llvm_embedded_libs_dir", llvm_embedded_libs_dir))
-config.substitutions.append(("%clang_with_sysroot", "%clang --sysroot=" + llvm_embedded_libs_dir))
+config.substitutions.append(("%clang_with_libc_cfg", "%clang" + @LLVM_TOOLCHAIN_LIBC_CFG@))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/qualcomm-software/test/lit.site.cfg.py.in
+++ b/qualcomm-software/test/lit.site.cfg.py.in
@@ -13,7 +13,7 @@ config.python_executable = "@Python3_EXECUTABLE@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
 llvm_embedded_libs_dir = "@LLVM_BINARY_DIR@/lib/clang-runtimes@EMBEDDED_LIBS_DIR_SUFFIX@"
 config.substitutions.append(("%llvm_embedded_libs_dir", llvm_embedded_libs_dir))
-config.substitutions.append(("%clang_with_libc_cfg", "%clang" + @LLVM_TOOLCHAIN_LIBC_CFG@))
+config.substitutions.append(("%clang_with_libc_cfg", "%clang" + "@LLVM_TOOLCHAIN_LIBC_CFG@"))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/qualcomm-software/test/multilib/aarch64.test
+++ b/qualcomm-software/test/multilib/aarch64.test
@@ -3,44 +3,44 @@
 # Should also revisit whether there are relevant tests we can reuse even without
 # the original multilib.
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -munaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -munaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
 # CHECK-AARCH64: aarch64-none-elf/aarch64a_tlsie{{$}}
 # CHECK-AARCH64-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
 # CHECK-PACRET: aarch64-none-elf/aarch64a_pacret{{$}}
 # CHECK-PACRET-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
 # CHECK-PACRET-BTI: aarch64-none-elf/aarch64a_pacret_bti{{$}}
 # CHECK-PACRET-BTI-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
 # CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti_tlsie{{$}}
 # CHECK-PACRET-BKEY-BTI-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp_tlsie{{$}}
 # CHECK-NOFP-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
 # CHECK-NOFP-PACRET-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti{{$}}
 # CHECK-NOFP-PACRET-BTI-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # CHECK-NOFP-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bkey_bti{{$}}
 # CHECK-NOFP-PACRET-BKEY-BTI-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/aarch64.test
+++ b/qualcomm-software/test/multilib/aarch64.test
@@ -3,44 +3,44 @@
 # Should also revisit whether there are relevant tests we can reuse even without
 # the original multilib.
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -munaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -munaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
 # CHECK-AARCH64: aarch64-none-elf/aarch64a_tlsie{{$}}
 # CHECK-AARCH64-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
 # CHECK-PACRET: aarch64-none-elf/aarch64a_pacret{{$}}
 # CHECK-PACRET-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
 # CHECK-PACRET-BTI: aarch64-none-elf/aarch64a_pacret_bti{{$}}
 # CHECK-PACRET-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
 # CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti_tlsie{{$}}
 # CHECK-PACRET-BKEY-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp_tlsie{{$}}
 # CHECK-NOFP-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
 # CHECK-NOFP-PACRET-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti{{$}}
 # CHECK-NOFP-PACRET-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # CHECK-NOFP-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bkey_bti{{$}}
 # CHECK-NOFP-PACRET-BKEY-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7.test
+++ b/qualcomm-software/test/multilib/armv7.test
@@ -1,24 +1,24 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
 # CHECK-ARMV7: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
 # CHECK-ARMV7-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-NOFP-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -marm -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mthumb -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -marm -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mthumb -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
 # CHECK-ARMV7-HARD-VFPV3: arm-none-eabi/armv7a_hard_vfpv3{{$}}
 # CHECK-ARMV7-HARD-VFPV3-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7.test
+++ b/qualcomm-software/test/multilib/armv7.test
@@ -1,24 +1,24 @@
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
 # CHECK-ARMV7: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
 # CHECK-ARMV7-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-NOFP-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -marm -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mthumb -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -marm -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mthumb -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
 # CHECK-ARMV7-HARD-VFPV3: arm-none-eabi/armv7a_hard_vfpv3{{$}}
 # CHECK-ARMV7-HARD-VFPV3-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7m.test
+++ b/qualcomm-software/test/multilib/armv7m.test
@@ -1,17 +1,17 @@
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
 # CHECK-SOFT-NOFP: arm-none-eabi/armv7m_soft_nofp{{$}}
 # CHECK-SOFT-NOFP-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
 # CHECK-SOFT-NOFP-NOPIC: arm-none-eabi/armv7m_soft_nofp_nopic{{$}}
 # CHECK-SOFT-NOFP-NOPIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic -munaligned-access | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
-# RUN: %clang -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic -munaligned-access | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
 # CHECK-HARD-FPV5-D16-NOPIC: arm-none-eabi/armv7m_hard_fpv5_d16_nopic{{$}}
 # CHECK-HARD-FPV5-D16-NOPIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fPIC 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fPIC 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7m.test
+++ b/qualcomm-software/test/multilib/armv7m.test
@@ -1,17 +1,17 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
 # CHECK-SOFT-NOFP: arm-none-eabi/armv7m_soft_nofp{{$}}
 # CHECK-SOFT-NOFP-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
 # CHECK-SOFT-NOFP-NOPIC: arm-none-eabi/armv7m_soft_nofp_nopic{{$}}
 # CHECK-SOFT-NOFP-NOPIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic -munaligned-access | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic -munaligned-access | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
 # CHECK-HARD-FPV5-D16-NOPIC: arm-none-eabi/armv7m_hard_fpv5_d16_nopic{{$}}
 # CHECK-HARD-FPV5-D16-NOPIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fPIC 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fPIC 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv8.test
+++ b/qualcomm-software/test/multilib/armv8.test
@@ -1,24 +1,24 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -marm -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -marm -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
 # CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8_soft_neon{{$}}
 # CHECK-ARMV8-SOFT-NEON-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=none | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=none | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NOFP
 # CHECK-ARMV7-SOFT-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-SOFT-NOFP-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NEON
 # CHECK-ARMV7-SOFT-NEON: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-SOFT-NEON-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -marm -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -marm -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
 # CHECK-ARMV7-HARD-VFPV3: arm-none-eabi/armv7a_hard_vfpv3{{$}}
 # CHECK-ARMV7-HARD-VFPV3-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv8.test
+++ b/qualcomm-software/test/multilib/armv8.test
@@ -1,24 +1,24 @@
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -marm -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -marm -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
 # CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8_soft_neon{{$}}
 # CHECK-ARMV8-SOFT-NEON-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=none | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=none | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NOFP
 # CHECK-ARMV7-SOFT-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-SOFT-NOFP-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NEON
 # CHECK-ARMV7-SOFT-NEON: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-SOFT-NEON-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -marm -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -marm -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
 # CHECK-ARMV7-HARD-VFPV3: arm-none-eabi/armv7a_hard_vfpv3{{$}}
 # CHECK-ARMV7-HARD-VFPV3-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/riscv32.test
+++ b/qualcomm-software/test/multilib/riscv32.test
@@ -1,105 +1,105 @@
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-NO-THREADS-FNO-PIC
 # CHECK-IMC-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_ilp32_nothreads_nopic{{$}}
 # CHECK-IMC-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMC-SCS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_ilp32_scs_nothreads_nopic{{$}}
 # CHECK-IMC-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc_zba_zbb_zbc_zbs -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc_zba_zbb_zbc_zbs -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC
 # CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic{{$}}
 # CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC
 # CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp_ilp32_nothreads_nopic{{$}}
 # CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
 # CHECK-IMAC-PIC: riscv32-unknown-elf/riscv32imac_ilp32{{$}}
 # CHECK-IMAC-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-FNO-PIC
 # CHECK-IMAC-SCS-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_scs_nopic{{$}}
 # CHECK-IMAC-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMAC-SCS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_scs_nothreads_nopic{{$}}
 # CHECK-IMAC-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
 # CHECK-IMAC-ZBA-ZBB: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32{{$}}
 # CHECK-IMAC-ZBA-ZBB-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
 # CHECK-IMAC-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-NO-PIC
 # CHECK-IMAC-ZCB-ZCMP-NO-PIC: riscv32-unknown-elf/riscv32imac_zcb_zcmp_ilp32_nopic{{$}}
 # CHECK-IMAC-ZCB-ZCMP-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp_zba_zbb -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp_zba_zbb -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC
 # CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ILP32F-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ILP32F-PIC
 # CHECK-IMAFC-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_ilp32f{{$}}
 # CHECK-IMAFC-ILP32F-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC
 # CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zcb_zcmp_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zcb_zcmp_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32gc -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32gc -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D-PIC
 # CHECK-GC-ILP32D-PIC: riscv32-unknown-elf/riscv32gc_ilp32d{{$}}
 # CHECK-GC-ILP32D-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -mabi=ilp32f -fmultilib-flag=no-threads -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -mabi=ilp32f -fmultilib-flag=no-threads -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC
 # CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC: riscv32-unknown-elf/riscv32imaf_zve32f_zvfh_zba_zbb_ilp32f_nothreads{{$}}
 # CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
 # CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC: riscv32-unknown-elf/riscv32im_xqci_ilp32_nothreads_nopic{{$}}
 # CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC-EMPTY:
 
 # Xqci + atomic variant test
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
 # CHECK-IMA-XQCI-ILP32-NO-PIC: riscv32-unknown-elf/riscv32ima_xqci_ilp32_nopic{{$}}
 # CHECK-IMA-XQCI-ILP32-NO-PIC-EMPTY:
 
 # Xqci + atomic + z*inx variant test
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
 # CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC: riscv32-unknown-elf/riscv32ima_zinx_xqci_ilp32_nopic{{$}}
 # CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags
 
 
 ## Check that we only find libraries for `-fcf-protection=none`
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=none | FileCheck %s --check-prefix=FCF-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=none | FileCheck %s --check-prefix=FCF-FOUND
 # FCF-FOUND: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # FCF-FOUND-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=branch 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=return 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=all 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=branch 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=return 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=all 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
 # FCF-NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/riscv32.test
+++ b/qualcomm-software/test/multilib/riscv32.test
@@ -1,105 +1,105 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-NO-THREADS-FNO-PIC
 # CHECK-IMC-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_ilp32_nothreads_nopic{{$}}
 # CHECK-IMC-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMC-SCS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_ilp32_scs_nothreads_nopic{{$}}
 # CHECK-IMC-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc_zba_zbb_zbc_zbs -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc_zba_zbb_zbc_zbs -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC
 # CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic{{$}}
 # CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC
 # CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp_ilp32_nothreads_nopic{{$}}
 # CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
 # CHECK-IMAC-PIC: riscv32-unknown-elf/riscv32imac_ilp32{{$}}
 # CHECK-IMAC-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-FNO-PIC
 # CHECK-IMAC-SCS-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_scs_nopic{{$}}
 # CHECK-IMAC-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMAC-SCS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_scs_nothreads_nopic{{$}}
 # CHECK-IMAC-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
 # CHECK-IMAC-ZBA-ZBB: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32{{$}}
 # CHECK-IMAC-ZBA-ZBB-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
 # CHECK-IMAC-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-NO-PIC
 # CHECK-IMAC-ZCB-ZCMP-NO-PIC: riscv32-unknown-elf/riscv32imac_zcb_zcmp_ilp32_nopic{{$}}
 # CHECK-IMAC-ZCB-ZCMP-NO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp_zba_zbb -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp_zba_zbb -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC
 # CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ILP32F-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ILP32F-PIC
 # CHECK-IMAFC-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_ilp32f{{$}}
 # CHECK-IMAFC-ILP32F-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC
 # CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zcb_zcmp_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zcb_zcmp_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32gc -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32gc -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D-PIC
 # CHECK-GC-ILP32D-PIC: riscv32-unknown-elf/riscv32gc_ilp32d{{$}}
 # CHECK-GC-ILP32D-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -mabi=ilp32f -fmultilib-flag=no-threads -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -mabi=ilp32f -fmultilib-flag=no-threads -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC
 # CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC: riscv32-unknown-elf/riscv32imaf_zve32f_zvfh_zba_zbb_ilp32f_nothreads{{$}}
 # CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
 # CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC: riscv32-unknown-elf/riscv32im_xqci_ilp32_nothreads_nopic{{$}}
 # CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC-EMPTY:
 
 # Xqci + atomic variant test
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
 # CHECK-IMA-XQCI-ILP32-NO-PIC: riscv32-unknown-elf/riscv32ima_xqci_ilp32_nopic{{$}}
 # CHECK-IMA-XQCI-ILP32-NO-PIC-EMPTY:
 
 # Xqci + atomic + z*inx variant test
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
 # CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC: riscv32-unknown-elf/riscv32ima_zinx_xqci_ilp32_nopic{{$}}
 # CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags
 
 
 ## Check that we only find libraries for `-fcf-protection=none`
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=none | FileCheck %s --check-prefix=FCF-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=none | FileCheck %s --check-prefix=FCF-FOUND
 # FCF-FOUND: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # FCF-FOUND-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=branch 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=return 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=all 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=branch 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=return 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=all 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
 # FCF-NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/riscv64.test
+++ b/qualcomm-software/test/multilib/riscv64.test
@@ -1,43 +1,43 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-NO-THREADS-FNO-PIC
 # CHECK-IMC-LP64-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_nothreads_nopic{{$}}
 # CHECK-IMC-LP64-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_scs_nothreads_nopic{{$}}
 # CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
 # CHECK-GC-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64d_nopic{{$}}
 # CHECK-GC-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64d_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
 # CHECK-GC-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_nopic{{$}}
 # CHECK-GC-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
 # CHECK-IMAC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_scs_nopic{{$}}
 # CHECK-IMAC-LP64-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
 # CHECK-GC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_scs_nopic{{$}}
 # CHECK-GC-LP64-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/riscv64.test
+++ b/qualcomm-software/test/multilib/riscv64.test
@@ -1,43 +1,43 @@
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-NO-THREADS-FNO-PIC
 # CHECK-IMC-LP64-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_nothreads_nopic{{$}}
 # CHECK-IMC-LP64-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_scs_nothreads_nopic{{$}}
 # CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
 # CHECK-GC-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64d_nopic{{$}}
 # CHECK-GC-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64d_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
 # CHECK-GC-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_nopic{{$}}
 # CHECK-GC-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
 # CHECK-IMAC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_scs_nopic{{$}}
 # CHECK-IMAC-LP64-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
 # CHECK-GC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_scs_nopic{{$}}
 # CHECK-GC-LP64-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -10,6 +10,11 @@
       "tagType": "commithash",
       "tag": "01254932e8e81085817ed61fd858648584ffe37c"
     },
+    "picolibc-main": {
+      "url": "https://github.com/picolibc/picolibc.git",
+      "tagType": "branch",
+      "tag": "main"
+    },
     "musl": {
       "url": "git://git.musl-libc.org/musl",
       "tagType": "tag",

--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -15,6 +15,11 @@
       "tagType": "branch",
       "tag": "main"
     },
+    "picolibc-curr": {
+      "url": "https://github.com/picolibc/picolibc.git",
+      "tagType": "commithash",
+      "tag": "01254932e8e81085817ed61fd858648584ffe37c"
+    },
     "musl": {
       "url": "git://git.musl-libc.org/musl",
       "tagType": "tag",


### PR DESCRIPTION
This adds two proof-of-concept picolibc overlays:
* `picolibc-main` tracking picolibc's main branch
    * Note that there's currently some XPASS-ing tests for this. Unclear to me if this is something new with mainline picolibc, or if there is an issue in one of these patches. Need to investigate further.
    * Note that the picolibc patch adding xqci memcpy/etc. is omitted. It needed enough rebasing that it didn't seem worth the time for the purposes of this PR.
* `picolibc-curr` that should be identical to our current `picolibc`

I don't think we actually want to merge this right now (we don't have a need for `picolibc-main`/`-curr` library). This is only intended to help test #540, #541, and #542 and show that those changes are sufficient for supporting this sort of thing.

---

Stacked on #542