### PR TITLE
[cpullvm] Add psutil to our install_dependency.[sh|ps1] scripts

### DIFF
--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -40,17 +40,22 @@ jobs:
         include:
           # FIXME: once we are able to source an up-to-date qemu in a reasonable
           # way, this should be changed to just an ordinary build.
-          - build_script: build_no_qemu.sh
-            test_script: test.sh
-            install_script: install_dependencies.sh
-            target_os: Linux-AArch64
-            runner: ubuntu-24.04-arm
+          # FIXME: Temporary change to just trigger the windows builders
+          # here. I'm curious if adding psutil will allow these runs to fail
+          # early instead of timing out after 6 hours like we occasionally
+          # see.
+          # This will be reverted before merging.
+          # - build_script: build_no_qemu.sh
+          #   test_script: test.sh
+          #   install_script: install_dependencies.sh
+          #   target_os: Linux-AArch64
+          #   runner: ubuntu-24.04-arm
 
-          - build_script: build_musl-embedded_overlay.sh
-            test_script: ''
-            install_script: ''
-            target_os: Linux-AArch64
-            runner: ubuntu-24.04-arm
+          # - build_script: build_musl-embedded_overlay.sh
+          #   test_script: ''
+          #   install_script: ''
+          #   target_os: Linux-AArch64
+          #   runner: ubuntu-24.04-arm
 
           - build_script: build.ps1
             test_script: test.ps1

--- a/qualcomm-software/scripts/install_dependencies.ps1
+++ b/qualcomm-software/scripts/install_dependencies.ps1
@@ -9,3 +9,6 @@ pip install pyyaml
 
 # Install meson. eld support was added in v1.9.0, so we need at least that.
 pip install meson==1.10.0
+
+# psutil is used to set per-test timeouts in lit
+pip install psutil

--- a/qualcomm-software/scripts/install_dependencies.sh
+++ b/qualcomm-software/scripts/install_dependencies.sh
@@ -12,3 +12,6 @@ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 
 
 # Install meson. eld support was added in v1.9.0, so we need at least that.
 pip install meson==1.10.0
+
+# psutil is used to set per-test timeouts in lit
+pip install psutil


### PR DESCRIPTION
psutil is used by lit to set per-test timeouts and is currently not installed
by default in any of our builders.

This should cover our Linux AArch64 and Windows AArch64/x86_64 builders,
Linux x86_64 needs to be handled separately.