### PR TITLE
[cpullvm] Switch musl-embedded to using the new versions.json SHA auto-update

### DIFF
--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -17,8 +17,9 @@
     },
     "musl-embedded": {
       "url": "https://github.com/qualcomm/musl-embedded",
-      "tagType": "branch",
-      "tag": "main"
+      "tagType": "commithash",
+      "tag": "9eafd9adeff02200cecb6a8a745898e33301f4f6",
+      "trackingBranch": "main"
     },
     "eld": {
       "url": "https://github.com/qualcomm/eld",


### PR DESCRIPTION
There are hardly any changes going into musl-embedded so it shouldn't make too much difference, but switch to using the SHA auto-update incase we do make any changes as it should again make bisecting a bit more consistent.