### PR TITLE
[cpullvm] Install psutil to enhance test results reporting

### DIFF
--- a/qualcomm-software/scripts/install_dependencies.ps1
+++ b/qualcomm-software/scripts/install_dependencies.ps1
@@ -9,3 +9,6 @@ pip install pyyaml
 
 # Install meson. eld support was added in v1.9.0, so we need at least that.
 pip install meson==1.10.0
+
+# Install psutil
+python -m pip install psutil


### PR DESCRIPTION
Installing psutil will impact our Windows builds (Arm64), and it will improve reporting for tests that time out so developers can investigate them more easily.

It is currently not working on windows x86 as there are many python versions being invoked which will be addressed in follow up patch.

python -m pip install ensures pip installs into the exact Python interpreter you're invoking, while pip install uses whichever python is first on your PATH, which may point to a different Python version unexpectedly.

Signed-off-by: Pranav Patil <pranpati@qti.qualcomm.com>