### PR TITLE
release/qualcomm-software/23.x: [cpullvm] Switch musl-embedded to using the new versions.json SHA auto-update (#518)

### DIFF
--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -17,8 +17,9 @@
     },
     "musl-embedded": {
       "url": "https://github.com/qualcomm/musl-embedded",
-      "tagType": "branch",
-      "tag": "main"
+      "tagType": "commithash",
+      "tag": "9eafd9adeff02200cecb6a8a745898e33301f4f6",
+      "trackingBranch": "main"
     },
     "eld": {
       "url": "https://github.com/qualcomm/eld",


### PR DESCRIPTION
Backport f1e8604

Requested by: @jonathonpenix