### PR TITLE
[cpullvm][Github] Update QC preflight checks to v2.0.8 release

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   preflight:
     name: Run QC Preflight Checks
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@15377d14305caeaeacbda9b24f93f57258e55b37 # v2.0.8
     with:
       enable-semgrep-scan: true
       enable-dependency-review: true


### PR DESCRIPTION
This release contains fixes for a few things related to our repo (Apache license auto-detection, skipping email checks on pushes). So, update to this version to get these changes.