### PR TITLE
release/qualcomm-software/23.x: [cpullvm][Github] Update QC preflight checks to v2.0.8 release (#523)

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   preflight:
     name: Run QC Preflight Checks
-    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@v2
+    uses: qualcomm/qcom-reusable-workflows/.github/workflows/reusable-qcom-preflight-checks-orchestrator.yml@15377d14305caeaeacbda9b24f93f57258e55b37 # v2.0.8
     with:
       enable-semgrep-scan: true
       enable-dependency-review: true


### PR DESCRIPTION
Backport d1b81f9

Note that the original motivation was slightly mistaken in that the `v2` already included these changes since it is a mutable tag. But, rewriting the tag aligns with best practices and this way we have control over the upgrades that come into our branch which seems beneficial. So, still backport this.

Requested by: @jonathonpenix