### PR TITLE
[cpullvm] Generate <libc>.cfg files from template

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -343,9 +343,17 @@ endif()
 ##################################################################################################
 
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+    set(libc_cfg_path ${CMAKE_CURRENT_BINARY_DIR}/${LLVM_TOOLCHAIN_C_LIBRARY}.cfg)
+
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/libc.cfg.in
+        ${libc_cfg_path}
+        @ONLY
+    )
+
     install(
         FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/${LLVM_TOOLCHAIN_C_LIBRARY}.cfg
+        ${libc_cfg_path}
         DESTINATION bin
         COMPONENT llvm-toolchain-${LLVM_TOOLCHAIN_C_LIBRARY}-configs
     )

--- a/qualcomm-software/cmake/libc.cfg.in
+++ b/qualcomm-software/cmake/libc.cfg.in
@@ -1,0 +1,1 @@
+--sysroot <CFGDIR>/../lib/clang-runtimes/@LLVM_TOOLCHAIN_C_LIBRARY@

--- a/qualcomm-software/cmake/libc.cfg.in
+++ b/qualcomm-software/cmake/libc.cfg.in
@@ -1,1 +1,4 @@
+# Config file to select @LLVM_TOOLCHAIN_C_LIBRARY@ libraries for multilib
+# matching.
+# Generated from libc.cfg.in.
 --sysroot <CFGDIR>/../lib/clang-runtimes/@LLVM_TOOLCHAIN_C_LIBRARY@

--- a/qualcomm-software/musl-embedded.cfg
+++ b/qualcomm-software/musl-embedded.cfg
@@ -1,1 +1,0 @@
---sysroot <CFGDIR>/../lib/clang-runtimes/musl-embedded


### PR DESCRIPTION
Rather than manually create new \<libc\>.cfg files when adding a new libc, just configure one automatically.

Note that this is derived from [1] in ATfE. We already have the appropriate license markings, etc. for this change I believe.

[1] https://github.com/arm/arm-toolchain/commit/bc86d60ae13fc8b6149aa93634658f2fb0e27681