### PR TITLE
[cpullvm] Support additional picolibc versions as overlays

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -343,7 +343,12 @@ endif()
 ##################################################################################################
 
 if(NOT LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
-    set(libc_cfg_path ${CMAKE_CURRENT_BINARY_DIR}/${LLVM_TOOLCHAIN_C_LIBRARY}.cfg)
+    # Place <libc>.cfg in the same directory as where clang will end up so that
+    # it can be used in builds in the same way as final installs.
+    set(
+        libc_cfg_path
+        ${CMAKE_CURRENT_BINARY_DIR}/llvm/bin/${LLVM_TOOLCHAIN_C_LIBRARY}.cfg
+    )
 
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/libc.cfg.in

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -315,13 +315,11 @@ fetch_repo(eld)
 #
 # If you want to stop cmake updating the repos then run
 # cmake . -DFETCHCONTENT_FULLY_DISCONNECTED=ON
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
-    fetch_repo(picolibc)
-endif()
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded OR ENABLE_LINUX_LIBRARIES)
-    fetch_repo(musl-embedded)
-endif()
+fetch_repo(${LLVM_TOOLCHAIN_C_LIBRARY})
 if(ENABLE_LINUX_LIBRARIES)
+    if(NOT LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+        fetch_repo(musl-embedded)
+    endif()
     fetch_repo(musl)
 endif()
 
@@ -344,7 +342,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 ##################################################################################################
 
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
+if(NOT LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
     set(libc_cfg_path ${CMAKE_CURRENT_BINARY_DIR}/${LLVM_TOOLCHAIN_C_LIBRARY}.cfg)
 
     configure_file(
@@ -495,14 +493,14 @@ add_custom_target(
     -Dllvmproject_src_dir=${llvmproject_src_dir}
     -Deld_SOURCE_DIR=${eld_SOURCE_DIR}
     -Deld_URL=${eld_URL}
-    # at most one of picolibc and musl options is needed, but easiest to
-    # specify both definitions
-    -Dpicolibc_SOURCE_DIR=${picolibc_SOURCE_DIR}
-    -Dpicolibc_URL=${picolibc_URL}
+    -D${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR=${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}
+    -D${LLVM_TOOLCHAIN_C_LIBRARY}_URL=${${LLVM_TOOLCHAIN_C_LIBRARY}_URL}
+    -DLLVM_TOOLCHAIN_C_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
+    # Always pass through the Linux library information--the script will
+    # determine if it is needed. This might be a repeat if musl-embedded
+    # is the selected C library, but repeating it is harmless.
     -Dmusl-embedded_SOURCE_DIR=${musl-embedded_SOURCE_DIR}
     -Dmusl-embedded_URL=${musl-embedded_URL}
-    # but we do tell the script which library we're actually using
-    -DLLVM_TOOLCHAIN_C_LIBRARY=${LLVM_TOOLCHAIN_C_LIBRARY}
     -Dmusl_SOURCE_DIR=${musl_SOURCE_DIR}
     -Dmusl_URL=${musl_URL}
     -DENABLE_LINUX_LIBRARIES=${ENABLE_LINUX_LIBRARIES}
@@ -610,6 +608,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
     string(REPLACE ";" "," ENABLE_VARIANTS_PASSTHROUGH "${LLVM_TOOLCHAIN_LIBRARY_VARIANTS}")
 
     set(multilib_prefix ${CMAKE_BINARY_DIR}/multilib-builds)
+    string(TOUPPER ${LLVM_TOOLCHAIN_C_LIBRARY} toolchain_c_lib_upper)
 
     ExternalProject_Add(
         multilib-${LLVM_TOOLCHAIN_C_LIBRARY}
@@ -630,8 +629,7 @@ if(NOT PREBUILT_TARGET_LIBRARIES)
         -DENABLE_PARALLEL_LIB_BUILD=${ENABLE_PARALLEL_LIB_BUILD}
         -DPARALLEL_LIB_BUILD_LEVELS=${PARALLEL_LIB_BUILD_LEVELS}
         -DENABLE_QEMU_TESTING=${ENABLE_QEMU_TESTING}
-        -DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}
-        -DFETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED=${FETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED}
+        -DFETCHCONTENT_SOURCE_DIR_${toolchain_c_lib_upper}=${FETCHCONTENT_SOURCE_DIR_${toolchain_c_lib_upper}}
         -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
         -DPROJECT_PREFIX=${multilib_prefix}
         -DNUMERICAL_BUILD_NAMES=${SHORT_BUILD_PATHS}
@@ -816,7 +814,7 @@ install(
     COMPONENT llvm-toolchain-docs
 )
 
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
+if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^picolibc")
     string(APPEND LIBC_LICENSE_FILES " - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc\n")
 endif()
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded OR ENABLE_LINUX_LIBRARIES)
@@ -862,10 +860,10 @@ list(APPEND third_party_license_files
     ${CMAKE_CURRENT_LIST_DIR}/ATfE-LICENSE.txt ATfE-LICENSE.txt
 )
 
-if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
+if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^picolibc")
     list(APPEND third_party_license_files
-        ${picolibc_SOURCE_DIR}/COPYING.NEWLIB           COPYING.NEWLIB
-        ${picolibc_SOURCE_DIR}/COPYING.picolibc         COPYING.picolibc
+        ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.NEWLIB           COPYING.NEWLIB
+        ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.picolibc         COPYING.picolibc
     )
 elseif(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
     list(APPEND third_party_license_files

--- a/qualcomm-software/embedded-multilib/CMakeLists.txt
+++ b/qualcomm-software/embedded-multilib/CMakeLists.txt
@@ -28,6 +28,17 @@ set(MULTILIB_JSON "" CACHE STRING "JSON file to load library definitions from.")
 set(ENABLE_VARIANTS "all" CACHE STRING "Semicolon separated list of variants to build, or \"all\". Must match entries in the json.")
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
 set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc musl-embedded)
+
+# multilib.json and the per-variant JSON files only know about one
+# "picolibc" entry, shared by every fetched picolibc version (e.g.
+# picolibc-main), not a separate entry per version. So map C_LIBRARY to
+# its base library name before looking anything up there.
+if(C_LIBRARY MATCHES "^picolibc")
+    set(json_library_key picolibc)
+else()
+    set(json_library_key ${C_LIBRARY})
+endif()
+
 set(PROJECT_PREFIX "${CMAKE_BINARY_DIR}/lib-builds" CACHE STRING "Directory to build subprojects in.")
 option(
     NUMERICAL_BUILD_NAMES
@@ -84,13 +95,13 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter) # needed by fetch_repo.cma
 
 include(ExternalProject)
 include(${TOOLCHAIN_SOURCE_DIR}/cmake/fetch_repo.cmake)
-if(C_LIBRARY STREQUAL picolibc)
-    fetch_repo(picolibc)
-    list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_PICOLIBC=${FETCHCONTENT_SOURCE_DIR_PICOLIBC}")
-elseif(C_LIBRARY STREQUAL musl-embedded)
-    fetch_repo(musl-embedded)
-    list(APPEND passthrough_dirs "-DFETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED=${FETCHCONTENT_SOURCE_DIR_MUSL-EMBEDDED}")
-endif()
+fetch_repo(${C_LIBRARY})
+string(TOUPPER ${C_LIBRARY} c_library_upper)
+list(
+    APPEND
+    passthrough_dirs
+    "-DFETCHCONTENT_SOURCE_DIR_${c_library_upper}=${FETCHCONTENT_SOURCE_DIR_${c_library_upper}}"
+)
 
 # Target for any dependencies to build the runtimes project.
 add_custom_target(runtimes-depends)
@@ -163,7 +174,7 @@ foreach(lib_idx RANGE ${lib_count_dec})
     if(NOT variant_support STREQUAL "libraries_supported-NOTFOUND")
         # Replace colons with semi-colons so CMake comprehends the list.
         string(REPLACE "," ";" variant_support ${variant_support})
-        if(NOT C_LIBRARY IN_LIST variant_support)
+        if(NOT json_library_key IN_LIST variant_support)
             continue()
         endif()
     endif()
@@ -211,7 +222,7 @@ foreach(lib_idx RANGE ${lib_count_dec})
                     ENABLE_COMPILER_RT_TESTS
                     ENABLE_LIBCXX_TESTS
                 )
-                    string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" ${C_LIBRARY} ${test_enable_var})
+                    string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" ${json_library_key} ${test_enable_var})
                     if(read_${test_enable_var} STREQUAL "json-NOTFOUND")
                         string(JSON read_${test_enable_var} ERROR_VARIABLE json_error GET ${variant_json_str} "args" "common" ${test_enable_var})
                         if(read_${test_enable_var} STREQUAL "json-NOTFOUND")

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -41,7 +41,13 @@ if(VARIANT_JSON)
         set(${json_param}_def ${json_val})
     endforeach()
     # Load arguments specific to the chosen library, overwriting any existing values.
-    string(JSON json_args GET ${variant_json_read} "args" ${C_LIBRARY})
+    # Let all picolibc versions share the same library-specific settings.
+    if(C_LIBRARY MATCHES "^picolibc")
+        set(json_library_key picolibc)
+    else()
+        set(json_library_key ${C_LIBRARY})
+    endif()
+    string(JSON json_args GET ${variant_json_read} "args" ${json_library_key})
     string(JSON json_args_len LENGTH ${json_args})
     math(EXPR json_args_len_dec "${json_args_len} - 1")
     foreach(json_idx RANGE ${json_args_len_dec})
@@ -169,7 +175,7 @@ add_custom_target(check-all)
 # If any testing is enabled, prepare test executor settings.
 if(ENABLE_LIBC_TESTS OR ENABLE_COMPILER_RT_TESTS OR ENABLE_LIBCXX_TESTS)
     # Flags required to link tests.
-    if(C_LIBRARY STREQUAL picolibc)
+    if(C_LIBRARY MATCHES "^picolibc")
         if(TEST_EXECUTOR STREQUAL qemu)
             set(picocrt "crt0-semihost")
         endif()
@@ -455,8 +461,8 @@ ExternalProject_Add(
 # picolibc
 ###############################################################################
 
-if(C_LIBRARY STREQUAL picolibc)
-    fetch_repo(picolibc)
+if(C_LIBRARY MATCHES "^picolibc")
+    fetch_repo(${C_LIBRARY})
     include(${CMAKE_CURRENT_SOURCE_DIR}/to_meson_list.cmake)
 
     # For building picolibc use Meson.
@@ -504,12 +510,12 @@ if(C_LIBRARY STREQUAL picolibc)
     endif()
 
     ExternalProject_Add(
-        picolibc
-        STAMP_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/stamp
-        BINARY_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/build
-        DOWNLOAD_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/dl
-        TMP_DIR ${PROJECT_PREFIX}/picolibc/${VARIANT_BUILD_ID}/tmp
-        SOURCE_DIR ${picolibc_SOURCE_DIR}
+        ${C_LIBRARY}
+        STAMP_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/stamp
+        BINARY_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/build
+        DOWNLOAD_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/dl
+        TMP_DIR ${PROJECT_PREFIX}/${C_LIBRARY}/${VARIANT_BUILD_ID}/tmp
+        SOURCE_DIR ${${C_LIBRARY}_SOURCE_DIR}
         INSTALL_DIR ${TEMP_LIB_DIR}
         DEPENDS compiler_rt-install
         CONFIGURE_COMMAND
@@ -546,30 +552,30 @@ if(C_LIBRARY STREQUAL picolibc)
         STEP_TARGETS configure build install
     )
 
-    add_custom_target(check-picolibc)
-    add_dependencies(check-all check-picolibc)
+    add_custom_target(check-${C_LIBRARY})
+    add_dependencies(check-all check-${C_LIBRARY})
     if(ENABLE_LIBC_TESTS)
         # meson builds the tests at the same time as the library.
         # So reconfigure to enable tests at a later point.
         ExternalProject_Add_Step(
-            picolibc
+            ${C_LIBRARY}
             compile-tests
             COMMAND ${MESON_EXECUTABLE} setup -Dtests=true --reconfigure <BINARY_DIR> <SOURCE_DIR>
             COMMAND ${MESON_EXECUTABLE} compile -C <BINARY_DIR>
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE
         )
-        ExternalProject_Add_StepTargets(picolibc compile-tests)
+        ExternalProject_Add_StepTargets(${C_LIBRARY} compile-tests)
         ExternalProject_Add_StepDependencies(
-            picolibc
+            ${C_LIBRARY}
             compile-tests
-            picolibc-build
+            ${C_LIBRARY}-build
             compiler_rt-install
         )
 
         # Step target to run the picolibc test via meson.
         ExternalProject_Add_Step(
-            picolibc
+            ${C_LIBRARY}
             check-meson
             COMMAND ${MESON_EXECUTABLE} test -C <BINARY_DIR> --no-rebuild
             USES_TERMINAL TRUE
@@ -577,23 +583,23 @@ if(C_LIBRARY STREQUAL picolibc)
             ALWAYS TRUE
             DEPENDEES compile-tests
         )
-        ExternalProject_Add_StepTargets(picolibc check-meson)
+        ExternalProject_Add_StepTargets(${C_LIBRARY} check-meson)
 
         # Generate lit wrappers for the tests.
         set(picolibc_lit_dir ${CMAKE_CURRENT_BINARY_DIR}/picolibc_lit)
         ExternalProject_Add_Step(
-            picolibc
+            ${C_LIBRARY}
             gen-lit-tests
             COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test-support/gen-picolibc-lit-tests.py
                 --meson ${MESON_EXECUTABLE}
                 --build <BINARY_DIR>
                 --output ${picolibc_lit_dir}
-                --name picolibc-${variant_xml_name}
+                --name ${C_LIBRARY}-${variant_xml_name}
             USES_TERMINAL TRUE
             EXCLUDE_FROM_MAIN TRUE
             DEPENDEES compile-tests
         )
-        ExternalProject_Add_StepTargets(picolibc gen-lit-tests)
+        ExternalProject_Add_StepTargets(${C_LIBRARY} gen-lit-tests)
 
         # Generate xfails for picolibc.
         set(picolibc_lit_xfails_path "${picolibc_lit_dir}/${VARIANT}_picolibc_lit_xfails.txt")
@@ -614,7 +620,7 @@ if(C_LIBRARY STREQUAL picolibc)
 
         # Step target to run the picolibc test via lit.
         ExternalProject_Add_Step(
-            picolibc
+            ${C_LIBRARY}
             check-lit
             COMMAND ${check_lit_cmd}
             USES_TERMINAL TRUE
@@ -622,13 +628,13 @@ if(C_LIBRARY STREQUAL picolibc)
             ALWAYS TRUE
             DEPENDEES gen-lit-tests
         )
-        ExternalProject_Add_StepTargets(picolibc check-lit)
+        ExternalProject_Add_StepTargets(${C_LIBRARY} check-lit)
         ExternalProject_Add_StepDependencies(
-            picolibc
+            ${C_LIBRARY}
             check-lit
             picolibc-xfail-lit-args
         )
-        add_dependencies(check-picolibc picolibc-check-lit)
+        add_dependencies(check-${C_LIBRARY} ${C_LIBRARY}-check-lit)
         add_dependencies(clib-build ${C_LIBRARY}-compile-tests)
     endif()
 
@@ -714,7 +720,7 @@ add_dependencies(clib-install ${C_LIBRARY}-install)
 ###############################################################################
 
 if(ENABLE_CXX_LIBS)
-    if(C_LIBRARY STREQUAL picolibc)
+    if(C_LIBRARY MATCHES "^picolibc")
         set(cxxlibs_extra_cmake_options
             -DLIBCXXABI_ENABLE_THREADS=OFF
             -DLIBCXX_ENABLE_MONOTONIC_CLOCK=OFF

--- a/qualcomm-software/test/CMakeLists.txt
+++ b/qualcomm-software/test/CMakeLists.txt
@@ -7,6 +7,7 @@ llvm_canonicalize_cmake_booleans(
 
 if(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL)
   set(EMBEDDED_LIBS_DIR_SUFFIX "/${LLVM_TOOLCHAIN_C_LIBRARY}")
+  set(LLVM_TOOLCHAIN_LIBC_CFG " --config=${LLVM_TOOLCHAIN_C_LIBRARY}.cfg")
 endif()
 
 configure_lit_site_cfg(

--- a/qualcomm-software/test/CMakeLists.txt
+++ b/qualcomm-software/test/CMakeLists.txt
@@ -5,6 +5,10 @@ llvm_canonicalize_cmake_booleans(
   ENABLE_BACKTRACES
 )
 
+if(LLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL)
+  set(EMBEDDED_LIBS_DIR_SUFFIX "/${LLVM_TOOLCHAIN_C_LIBRARY}")
+endif()
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/qualcomm-software/test/lit.site.cfg.py.in
+++ b/qualcomm-software/test/lit.site.cfg.py.in
@@ -11,7 +11,9 @@ config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@LLVM_DEFAULT_TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
-config.substitutions.append(("%llvm_embedded_libs_dir", "@LLVM_BINARY_DIR@/lib/clang-runtimes"))
+llvm_embedded_libs_dir = "@LLVM_BINARY_DIR@/lib/clang-runtimes@EMBEDDED_LIBS_DIR_SUFFIX@"
+config.substitutions.append(("%llvm_embedded_libs_dir", llvm_embedded_libs_dir))
+config.substitutions.append(("%clang_with_sysroot", "%clang --sysroot=" + llvm_embedded_libs_dir))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/qualcomm-software/test/lit.site.cfg.py.in
+++ b/qualcomm-software/test/lit.site.cfg.py.in
@@ -13,7 +13,7 @@ config.python_executable = "@Python3_EXECUTABLE@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
 llvm_embedded_libs_dir = "@LLVM_BINARY_DIR@/lib/clang-runtimes@EMBEDDED_LIBS_DIR_SUFFIX@"
 config.substitutions.append(("%llvm_embedded_libs_dir", llvm_embedded_libs_dir))
-config.substitutions.append(("%clang_with_sysroot", "%clang --sysroot=" + llvm_embedded_libs_dir))
+config.substitutions.append(("%clang_with_libc_cfg", "%clang" + @LLVM_TOOLCHAIN_LIBC_CFG@))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/qualcomm-software/test/lit.site.cfg.py.in
+++ b/qualcomm-software/test/lit.site.cfg.py.in
@@ -13,7 +13,7 @@ config.python_executable = "@Python3_EXECUTABLE@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
 llvm_embedded_libs_dir = "@LLVM_BINARY_DIR@/lib/clang-runtimes@EMBEDDED_LIBS_DIR_SUFFIX@"
 config.substitutions.append(("%llvm_embedded_libs_dir", llvm_embedded_libs_dir))
-config.substitutions.append(("%clang_with_libc_cfg", "%clang" + @LLVM_TOOLCHAIN_LIBC_CFG@))
+config.substitutions.append(("%clang_with_libc_cfg", "%clang" + "@LLVM_TOOLCHAIN_LIBC_CFG@"))
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/qualcomm-software/test/multilib/aarch64.test
+++ b/qualcomm-software/test/multilib/aarch64.test
@@ -3,44 +3,44 @@
 # Should also revisit whether there are relevant tests we can reuse even without
 # the original multilib.
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -munaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -munaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
 # CHECK-AARCH64: aarch64-none-elf/aarch64a_tlsie{{$}}
 # CHECK-AARCH64-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
 # CHECK-PACRET: aarch64-none-elf/aarch64a_pacret{{$}}
 # CHECK-PACRET-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
 # CHECK-PACRET-BTI: aarch64-none-elf/aarch64a_pacret_bti{{$}}
 # CHECK-PACRET-BTI-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
 # CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti_tlsie{{$}}
 # CHECK-PACRET-BKEY-BTI-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp_tlsie{{$}}
 # CHECK-NOFP-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
 # CHECK-NOFP-PACRET-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti{{$}}
 # CHECK-NOFP-PACRET-BTI-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # CHECK-NOFP-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bkey_bti{{$}}
 # CHECK-NOFP-PACRET-BKEY-BTI-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/aarch64.test
+++ b/qualcomm-software/test/multilib/aarch64.test
@@ -3,44 +3,44 @@
 # Should also revisit whether there are relevant tests we can reuse even without
 # the original multilib.
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -munaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -munaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
 # CHECK-AARCH64: aarch64-none-elf/aarch64a_tlsie{{$}}
 # CHECK-AARCH64-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
 # CHECK-PACRET: aarch64-none-elf/aarch64a_pacret{{$}}
 # CHECK-PACRET-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+bti | FileCheck %s --check-prefix=CHECK-PACRET-BTI
 # CHECK-PACRET-BTI: aarch64-none-elf/aarch64a_pacret_bti{{$}}
 # CHECK-PACRET-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI
 # CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti_tlsie{{$}}
 # CHECK-PACRET-BKEY-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp_tlsie{{$}}
 # CHECK-NOFP-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
 # CHECK-NOFP-PACRET-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti{{$}}
 # CHECK-NOFP-PACRET-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
-# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
+# RUN: %clang_with_sysroot -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # CHECK-NOFP-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bkey_bti{{$}}
 # CHECK-NOFP-PACRET-BKEY-BTI-EMPTY:
 
-# RUN: %clang -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7.test
+++ b/qualcomm-software/test/multilib/armv7.test
@@ -1,24 +1,24 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
 # CHECK-ARMV7: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
 # CHECK-ARMV7-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-NOFP-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -marm -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mthumb -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -marm -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mthumb -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
 # CHECK-ARMV7-HARD-VFPV3: arm-none-eabi/armv7a_hard_vfpv3{{$}}
 # CHECK-ARMV7-HARD-VFPV3-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7.test
+++ b/qualcomm-software/test/multilib/armv7.test
@@ -1,24 +1,24 @@
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV7
 # CHECK-ARMV7: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -marm -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=none -mhwdiv=none | FileCheck %s --check-prefix=CHECK-ARMV7-NOFP
 # CHECK-ARMV7-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-NOFP-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -marm -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mthumb -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -marm -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mthumb -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
 # CHECK-ARMV7-HARD-VFPV3: arm-none-eabi/armv7a_hard_vfpv3{{$}}
 # CHECK-ARMV7-HARD-VFPV3-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv7a -mfloat-abi=softfp -mthumb -mfpu=neon -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7m.test
+++ b/qualcomm-software/test/multilib/armv7m.test
@@ -1,17 +1,17 @@
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
 # CHECK-SOFT-NOFP: arm-none-eabi/armv7m_soft_nofp{{$}}
 # CHECK-SOFT-NOFP-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
 # CHECK-SOFT-NOFP-NOPIC: arm-none-eabi/armv7m_soft_nofp_nopic{{$}}
 # CHECK-SOFT-NOFP-NOPIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic -munaligned-access | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
-# RUN: %clang -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic -munaligned-access | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
 # CHECK-HARD-FPV5-D16-NOPIC: arm-none-eabi/armv7m_hard_fpv5_d16_nopic{{$}}
 # CHECK-HARD-FPV5-D16-NOPIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fPIC 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fPIC 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv7m.test
+++ b/qualcomm-software/test/multilib/armv7m.test
@@ -1,17 +1,17 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fPIC | FileCheck %s --check-prefix=CHECK-SOFT-NOFP
 # CHECK-SOFT-NOFP: arm-none-eabi/armv7m_soft_nofp{{$}}
 # CHECK-SOFT-NOFP-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabi -mfpu=none -fno-pic | FileCheck %s --check-prefix=CHECK-SOFT-NOFP-NOPIC
 # CHECK-SOFT-NOFP-NOPIC: arm-none-eabi/armv7m_soft_nofp_nopic{{$}}
 # CHECK-SOFT-NOFP-NOPIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic -munaligned-access | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic -munaligned-access | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7em-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fno-pic | FileCheck %s --check-prefix=CHECK-HARD-FPV5-D16-NOPIC
 # CHECK-HARD-FPV5-D16-NOPIC: arm-none-eabi/armv7m_hard_fpv5_d16_nopic{{$}}
 # CHECK-HARD-FPV5-D16-NOPIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fPIC 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -fPIC 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=armv7m-none-eabihf -mfloat-abi=hard -mfpu=fpv5-d16 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv8.test
+++ b/qualcomm-software/test/multilib/armv8.test
@@ -1,24 +1,24 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -marm -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -marm -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
 # CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8_soft_neon{{$}}
 # CHECK-ARMV8-SOFT-NEON-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=none | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NOFP
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=none | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NOFP
 # CHECK-ARMV7-SOFT-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-SOFT-NOFP-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NEON
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NEON
 # CHECK-ARMV7-SOFT-NEON: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-SOFT-NEON-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -marm -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -marm -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
 # CHECK-ARMV7-HARD-VFPV3: arm-none-eabi/armv7a_hard_vfpv3{{$}}
 # CHECK-ARMV7-HARD-VFPV3-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/armv8.test
+++ b/qualcomm-software/test/multilib/armv8.test
@@ -1,24 +1,24 @@
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -marm -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -marm -mfpu=neon-fp-armv8 | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -munaligned-access | FileCheck %s --check-prefix=CHECK-ARMV8-SOFT-NEON
 # CHECK-ARMV8-SOFT-NEON: arm-none-eabi/armv8_soft_neon{{$}}
 # CHECK-ARMV8-SOFT-NEON-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=none | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NOFP
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=none | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NOFP
 # CHECK-ARMV7-SOFT-NOFP: arm-none-eabi/armv7a_soft_nofp{{$}}
 # CHECK-ARMV7-SOFT-NOFP-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NEON
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=softfp -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-SOFT-NEON
 # CHECK-ARMV7-SOFT-NEON: arm-none-eabi/armv7a_soft_neon{{$}}
 # CHECK-ARMV7-SOFT-NEON-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -marm -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=vfpv3 | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -marm -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mthumb -mfloat-abi=hard -mfpu=neon | FileCheck %s --check-prefix=CHECK-ARMV7-HARD-VFPV3
 # CHECK-ARMV7-HARD-VFPV3: arm-none-eabi/armv7a_hard_vfpv3{{$}}
 # CHECK-ARMV7-HARD-VFPV3-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=arm-none-eabi -march=armv8a -mfloat-abi=softfp -mthumb -mfpu=neon-fp-armv8 -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/riscv32.test
+++ b/qualcomm-software/test/multilib/riscv32.test
@@ -1,105 +1,105 @@
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-NO-THREADS-FNO-PIC
 # CHECK-IMC-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_ilp32_nothreads_nopic{{$}}
 # CHECK-IMC-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMC-SCS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_ilp32_scs_nothreads_nopic{{$}}
 # CHECK-IMC-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc_zba_zbb_zbc_zbs -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc_zba_zbb_zbc_zbs -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC
 # CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic{{$}}
 # CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC
 # CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp_ilp32_nothreads_nopic{{$}}
 # CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
 # CHECK-IMAC-PIC: riscv32-unknown-elf/riscv32imac_ilp32{{$}}
 # CHECK-IMAC-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-FNO-PIC
 # CHECK-IMAC-SCS-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_scs_nopic{{$}}
 # CHECK-IMAC-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMAC-SCS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_scs_nothreads_nopic{{$}}
 # CHECK-IMAC-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
 # CHECK-IMAC-ZBA-ZBB: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32{{$}}
 # CHECK-IMAC-ZBA-ZBB-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
 # CHECK-IMAC-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-NO-PIC
 # CHECK-IMAC-ZCB-ZCMP-NO-PIC: riscv32-unknown-elf/riscv32imac_zcb_zcmp_ilp32_nopic{{$}}
 # CHECK-IMAC-ZCB-ZCMP-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp_zba_zbb -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp_zba_zbb -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC
 # CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ILP32F-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ILP32F-PIC
 # CHECK-IMAFC-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_ilp32f{{$}}
 # CHECK-IMAFC-ILP32F-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC
 # CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zcb_zcmp_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zcb_zcmp_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32gc -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32gc -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D-PIC
 # CHECK-GC-ILP32D-PIC: riscv32-unknown-elf/riscv32gc_ilp32d{{$}}
 # CHECK-GC-ILP32D-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -mabi=ilp32f -fmultilib-flag=no-threads -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -mabi=ilp32f -fmultilib-flag=no-threads -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC
 # CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC: riscv32-unknown-elf/riscv32imaf_zve32f_zvfh_zba_zbb_ilp32f_nothreads{{$}}
 # CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
 # CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC: riscv32-unknown-elf/riscv32im_xqci_ilp32_nothreads_nopic{{$}}
 # CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC-EMPTY:
 
 # Xqci + atomic variant test
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
 # CHECK-IMA-XQCI-ILP32-NO-PIC: riscv32-unknown-elf/riscv32ima_xqci_ilp32_nopic{{$}}
 # CHECK-IMA-XQCI-ILP32-NO-PIC-EMPTY:
 
 # Xqci + atomic + z*inx variant test
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
 # CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC: riscv32-unknown-elf/riscv32ima_zinx_xqci_ilp32_nopic{{$}}
 # CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags
 
 
 ## Check that we only find libraries for `-fcf-protection=none`
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=none | FileCheck %s --check-prefix=FCF-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=none | FileCheck %s --check-prefix=FCF-FOUND
 # FCF-FOUND: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # FCF-FOUND-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=branch 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=return 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=all 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=branch 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=return 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=all 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
 # FCF-NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/riscv32.test
+++ b/qualcomm-software/test/multilib/riscv32.test
@@ -1,105 +1,105 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imazca -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafzca_zcf -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf_zcd -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-NO-THREADS-FNO-PIC
 # CHECK-IMC-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_ilp32_nothreads_nopic{{$}}
 # CHECK-IMC-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMC-SCS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_ilp32_scs_nothreads_nopic{{$}}
 # CHECK-IMC-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc_zba_zbb_zbc_zbs -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imc_zba_zbb_zbc_zbs -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC
 # CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imc_zba_zbb_zbc_zbs_ilp32_nothreads_nopic{{$}}
 # CHECK-IMC-ZBA-ZBB-ZBC-ZBS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC
 # CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32im_zba_zbb_zbc_zbs_zca_zcb_zcmp_ilp32_nothreads_nopic{{$}}
 # CHECK-IM-ZBA-ZBB-ZBC-ZBS-ZCA-ZCB-ZCMP-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-PIC
 # CHECK-IMAC-PIC: riscv32-unknown-elf/riscv32imac_ilp32{{$}}
 # CHECK-IMAC-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-FNO-PIC
 # CHECK-IMAC-SCS-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_scs_nopic{{$}}
 # CHECK-IMAC-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMAC-SCS-NO-THREADS-FNO-PIC: riscv32-unknown-elf/riscv32imac_ilp32_scs_nothreads_nopic{{$}}
 # CHECK-IMAC-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fpic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB
 # CHECK-IMAC-ZBA-ZBB: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32{{$}}
 # CHECK-IMAC-ZBA-ZBB-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zba_zbb -mabi=ilp32 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-ZBA-ZBB-NO-PIC
 # CHECK-IMAC-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-NO-PIC
 # CHECK-IMAC-ZCB-ZCMP-NO-PIC: riscv32-unknown-elf/riscv32imac_zcb_zcmp_ilp32_nopic{{$}}
 # CHECK-IMAC-ZCB-ZCMP-NO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp_zba_zbb -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac_zcb_zcmp_zba_zbb -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC
 # CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC: riscv32-unknown-elf/riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic{{$}}
 # CHECK-IMAC-ZCB-ZCMP-ZBA-ZBB-NO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ILP32F-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ILP32F-PIC
 # CHECK-IMAFC-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_ilp32f{{$}}
 # CHECK-IMAFC-ILP32F-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC
 # CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zcb_zcmp_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafc_zcb_zcmp_zba_zbb -mabi=ilp32f -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC: riscv32-unknown-elf/riscv32imafc_zcb_zcmp_zba_zbb_ilp32f{{$}}
 # CHECK-IMAFC-ZCB-ZCMP-ZBA-ZBB-ILP32F-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32gc -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32gc -mabi=ilp32d -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-GC-ILP32D-PIC
 # CHECK-GC-ILP32D-PIC: riscv32-unknown-elf/riscv32gc_ilp32d{{$}}
 # CHECK-GC-ILP32D-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -mabi=ilp32f -fmultilib-flag=no-threads -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -mabi=ilp32f -fmultilib-flag=no-threads -fpic 2>&1 | FileCheck %s --check-prefix=CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC
 # CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC: riscv32-unknown-elf/riscv32imaf_zve32f_zvfh_zba_zbb_ilp32f_nothreads{{$}}
 # CHECK-IMAF-ZVE32F-ZVFH-ILP32F-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fmultilib-flag=no-threads -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC
 # CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC: riscv32-unknown-elf/riscv32im_xqci_ilp32_nothreads_nopic{{$}}
 # CHECK-IM-XQCI-ILP32-NO-THREADS-NO-PIC-EMPTY:
 
 # Xqci + atomic variant test
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-XQCI-ILP32-NO-PIC
 # CHECK-IMA-XQCI-ILP32-NO-PIC: riscv32-unknown-elf/riscv32ima_xqci_ilp32_nopic{{$}}
 # CHECK-IMA-XQCI-ILP32-NO-PIC-EMPTY:
 
 # Xqci + atomic + z*inx variant test
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqci_xqccmp_xqccmt0p1 -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC
 # CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC: riscv32-unknown-elf/riscv32ima_zinx_xqci_ilp32_nopic{{$}}
 # CHECK-IMA-ZINX-XQCI-ILP32-NO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32ima -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imafdzca_zcf -mabi=ilp32 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags
 
 
 ## Check that we only find libraries for `-fcf-protection=none`
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=none | FileCheck %s --check-prefix=FCF-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=none | FileCheck %s --check-prefix=FCF-FOUND
 # FCF-FOUND: riscv32-unknown-elf/riscv32imac_ilp32_nopic{{$}}
 # FCF-FOUND-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=branch 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=return 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=all 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=branch 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=return 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv32-unknown-elf -march=rv32imac -mabi=ilp32 -fno-pic -fcf-protection=all 2>&1 | FileCheck %s --check-prefix=FCF-NOT-FOUND
 # FCF-NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/riscv64.test
+++ b/qualcomm-software/test/multilib/riscv64.test
@@ -1,43 +1,43 @@
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-NO-THREADS-FNO-PIC
 # CHECK-IMC-LP64-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_nothreads_nopic{{$}}
 # CHECK-IMC-LP64-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_scs_nothreads_nopic{{$}}
 # CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
 # CHECK-GC-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64d_nopic{{$}}
 # CHECK-GC-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64d_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
 # CHECK-GC-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_nopic{{$}}
 # CHECK-GC-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
 # CHECK-IMAC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_scs_nopic{{$}}
 # CHECK-IMAC-LP64-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
 # CHECK-GC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_scs_nopic{{$}}
 # CHECK-GC-LP64-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags

--- a/qualcomm-software/test/multilib/riscv64.test
+++ b/qualcomm-software/test/multilib/riscv64.test
@@ -1,43 +1,43 @@
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafc_zba -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafzca -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca_zcd -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-FNO-PIC
 # CHECK-IMAC-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_nopic{{$}}
 # CHECK-IMAC-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-NO-THREADS-FNO-PIC
 # CHECK-IMC-LP64-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_nothreads_nopic{{$}}
 # CHECK-IMC-LP64-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fsanitize=shadow-call-stack -fmultilib-flag=no-threads -fno-pic | FileCheck %s --check-prefix=CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC
 # CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC: riscv64-unknown-elf/riscv64imc_lp64_scs_nothreads_nopic{{$}}
 # CHECK-IMC-LP64-SCS-NO-THREADS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64D-FNO-PIC
 # CHECK-GC-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64d_nopic{{$}}
 # CHECK-GC-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64d -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64d_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64D-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-FNO-PIC
 # CHECK-GC-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_nopic{{$}}
 # CHECK-GC-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc_zba_zbb -mabi=lp64 -fno-pic | FileCheck %s --check-prefix=CHECK-GC-ZBA-ZBB-LP64-FNO-PIC
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC: riscv64-unknown-elf/riscv64gc_zba_zbb_lp64_nopic{{$}}
 # CHECK-GC-ZBA-ZBB-LP64-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-IMAC-LP64-SCS-FNO-PIC
 # CHECK-IMAC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64imac_lp64_scs_nopic{{$}}
 # CHECK-IMAC-LP64-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64gc -mabi=lp64 -fsanitize=shadow-call-stack -fno-pic | FileCheck %s --check-prefix=CHECK-GC-LP64-SCS-FNO-PIC
 # CHECK-GC-LP64-SCS-FNO-PIC: riscv64-unknown-elf/riscv64gc_lp64_scs_nopic{{$}}
 # CHECK-GC-LP64-SCS-FNO-PIC-EMPTY:
 
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# RUN: %clang -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imac -mabi=lp64 -fpic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imc -mabi=lp64 -fno-pic 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
+# RUN: %clang_with_sysroot -print-multi-directory --target=riscv64-unknown-elf -march=rv64imafdzca -mabi=lp64 -fno-pic  2>&1| FileCheck %s --check-prefix=NOT-FOUND
 # NOT-FOUND: warning: no multilib found matching flags


### PR DESCRIPTION
This should allow us to support multiple different versions of picolibc at
the same time. These are expected to be added roughly like a new libc named
with the 'picolibc' prefix. There are a few exceptions to these new picolibc
versions being handled as a "full" new libc to save duplication:
* Library variants supported by 'picolibc' in json are considered supported by
  all picolibc versions.
* All the build flags (picolibc's base build flags, the flags used by libc++
  when building against picolibc, json library flags etc.) are shared between
  versions.
* xfails.py applies the same xfails for all picolibc versions.

All of these can be changed/overridden as the need arises, but this seemed like
a safe-ish place to start.

Notably though, the base 'picolibc' is still treated as a 'default' library, so
it is disallowed from being in an overlay, has the version file named slightly
differently, etc. This special handling isn't extended to the picolibc version
variants.

Assisted-by: claude