### PR TITLE
23.x: [cpullvm][Github] Use HEAD of merge branch when testing in linux-premerge.yml (#537)

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -43,8 +43,6 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
           # We build in the repository and rely on clean to cleanup possible
           # old build products if the runner doesn't do it itself.
           clean: true


### PR DESCRIPTION
Currently we use the HEAD commit of the branch that will be merged into our repo for our premerge checks (so, we're using the head commit of the PR requester's branch).

This is a bit unfortunate as:
1. Our builds are then more of a reflection of whether the user's changes work in their branch, not whether they work if they were to be merged into our repo.
2. If there are issues unrelated to the user's code (from unrelated parts of upstream LLVM, eld, etc.) and fixes come in to our main repo, the user still has to update their branch to bring in these new changes.

Instead, let's switch to the default actions/checkout behavior which, for pull_request triggers, is the HEAD commit of the merge branch. [a][b]

So, for 1 above, we'd be testing against the merged result--not just the user's branch.

For 2 above, the user should just be able to retrigger the build without having to update their own branch.

This is also consistent with how pull_request triggers work in our nightlies, etc.

I don't know/remember why the refs were set how they were, but this switch seems like it'll be more correct, more ergonomic for users, and more consistent with our other workflows.

[a] https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
[b] https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#how-the-merge-branch-affects-your-workflow

(cherry-pick of 3bf23bf)