### PR TITLE
[cpullvm] Add nightly Release build workflow 23.x

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,23 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Nightly Release build — calls nightly.yml with assertions disabled
+# (Release mode) by passing enable_assertions: false.
+
+name: Nightly Release Build and Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/nightly.yml'
+      - '.github/workflows/nightly-release.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  nightly-release:
+    uses: ./.github/workflows/nightly.yml
+    with:
+      enable_assertions: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,17 @@ name: Nightly Build and Test
 
 on:
   workflow_dispatch:
+    inputs:
+      enable_assertions:
+        description: 'Enable LLVM assertions'
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      enable_assertions:
+        description: 'Enable LLVM assertions'
+        type: boolean
+        default: true
   pull_request:
     paths:
       - '.github/workflows/nightly.yml'
@@ -28,6 +39,9 @@ on:
     - cron: '0 7,19 * * *' # 12 AM, 12 PM PT
 permissions:
   contents: read
+
+env:
+  EXTRA_CMAKE_ARGS: ${{ format('{0}', inputs.enable_assertions) == 'false' && '-DLLVM_ENABLE_ASSERTIONS=OFF' || '-DLLVM_ENABLE_ASSERTIONS=ON' }}
 
 jobs:
   build-and-test-Linux-x86:

--- a/qualcomm-software/scripts/build.ps1
+++ b/qualcomm-software/scripts/build.ps1
@@ -27,9 +27,15 @@ mkdir $buildDir
 cd $buildDir
 
 # Omit Linux runtimes, QEMU testing on Windows builds.
+$extraCmakeArgs = @()
+if ($env:EXTRA_CMAKE_ARGS) {
+    $extraCmakeArgs = $env:EXTRA_CMAKE_ARGS -split '\s+'
+}
+
 cmake ..\qualcomm-software `
   -GNinja `
   -DFETCHCONTENT_QUIET=OFF `
-  -DENABLE_QEMU_TESTING=OFF
+  -DENABLE_QEMU_TESTING=OFF `
+  @extraCmakeArgs
 
 ninja package-llvm-toolchain

--- a/qualcomm-software/scripts/build_copy_runtimes.ps1
+++ b/qualcomm-software/scripts/build_copy_runtimes.ps1
@@ -29,10 +29,16 @@ cd $buildDir
 
 python3 ..\qualcomm-software\cmake\copy_target_libraries.py --include-linux-libraries --distribution-file=cpullvm-*.tar.xz --build-dir=$buildDir
 
+$extraCmakeArgs = @()
+if ($env:EXTRA_CMAKE_ARGS) {
+    $extraCmakeArgs = $env:EXTRA_CMAKE_ARGS -split '\s+'
+}
+
 cmake ..\qualcomm-software `
   -GNinja `
   -DFETCHCONTENT_QUIET=OFF `
   -DPREBUILT_TARGET_LIBRARIES=ON `
-  -DENABLE_LINUX_LIBRARIES=ON
+  -DENABLE_LINUX_LIBRARIES=ON `
+  @extraCmakeArgs
 
 ninja package-llvm-toolchain

--- a/qualcomm-software/scripts/build_musl-embedded_overlay.sh
+++ b/qualcomm-software/scripts/build_musl-embedded_overlay.sh
@@ -26,7 +26,7 @@ BUILD_DIR=${REPO_ROOT}/build_musl-embedded_overlay
 mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}"
 
-cmake ../qualcomm-software -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=musl-embedded -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on
+cmake ../qualcomm-software -GNinja -DFETCHCONTENT_QUIET=OFF -DLLVM_TOOLCHAIN_C_LIBRARY=musl-embedded -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=on ${EXTRA_CMAKE_ARGS}
 ninja package-llvm-toolchain
 
 # The package-llvm-toolchain target will produce a .tar.xz package, but we also


### PR DESCRIPTION
Add nightly-release.yml to build all 4 variants in Release mode (assertions disabled) by passing -DLLVM_ENABLE_ASSERTIONS=OFF via EXTRA_CMAKE_ARGS.