### PR TITLE
23.x: [cpullvm][Github] Add new workflow to test libc++ (#532)

### DIFF
--- a/.github/workflows/libcxx-test.yml
+++ b/.github/workflows/libcxx-test.yml
@@ -1,0 +1,57 @@
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Run libc++ tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 22 * * 6'  # 3 PM PDT (UTC-7), Saturday
+  pull_request:
+    paths:
+      - '.github/workflows/libcxx-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    # Don't run on forks
+    if: github.repository == 'qualcomm/cpullvm-toolchain'
+    name: test_libcxx.sh on Linux-x86_64
+    runs-on: cpullvm-ubuntu24-x86_64
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # We build in the repository and rely on clean to cleanup possible
+          # old build products if the runner doesn't do it itself.
+          clean: true
+
+      - name: Apply llvm-project patches
+        run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
+
+      - name: Build toolchain
+        env:
+          EXTRA_CMAKE_ARGS: -DENABLE_LINUX_LIBRARIES=OFF
+        run: ./qualcomm-software/scripts/build.sh
+
+      # Upload in case it is helpful for debugging any failures
+      - name: Upload built packages
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: success()
+        with:
+          name: cpullvm-packages-build.sh-Linux-x86
+          path: build*/cpullvm-*.tar.xz
+          if-no-files-found: error
+          retention-days: 2
+
+      - name: Test
+        run: ./qualcomm-software/scripts/test_libcxx.sh


### PR DESCRIPTION
It isn't ideal, but for now just do this as a separate build/workflow that will run 2x per week.

For libc++ tests, each variant takes ~15 minutes on QEMU so it adds a fair bit of time to whatever workflows we add these to. A few options considered:
1. Separate build/test workflow (this PR)
2. Add it to our nightly (so test libc++ in addition to the other runs at some frequency)
3. Do something where we upload a *full* build and we can run the tests separately.

I think 2 is a bit painful as our nightlies already take quite a bit of time to run, so I don't think we can run test_libcxx.sh there. Maybe this changes when we have more machines available.

Longer term, we should maybe test a small subset of these in each nightly, but again they already take quite a while to run so will leave that as a separate improvement.

For 2 as well, I think there's ways we could re-work our nightlies so that the Windows/AArch64 Linux builds aren't blocked by the test step (so the total runtime wouldn't be impacted as much when adding test_libcxx.sh). But that is a larger rework and has its own set of drawbacks.

3 I'm a bit unsure about--something like that might also let us split the configs over more machine, but our raw build folders are quite large and it feels odd passing this around.

So for now go with 1--the cost of one build isn't too bad.

(cherry picked from commit ba47e0abc2023308a45095baead70752e2fc8f10)