### PR TITLE
23.x: [riscv] Add Frame Pointers to Xqci configs

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32im_xqci_ilp32_nothreads_nopic.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "riscv32",
             "VARIANT": "riscv32im_xqci_ilp32_nothreads_nopic",
-            "COMPILE_FLAGS": "-march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fno-pic",
+            "COMPILE_FLAGS": "-march=rv32im_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fno-pic -fno-omit-frame-pointer",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32ima_xqci_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32ima_xqci_ilp32_nopic.json
@@ -3,7 +3,7 @@
     "common": {
       "TARGET_ARCH": "riscv32",
       "VARIANT": "riscv32ima_xqci_ilp32_nopic",
-      "COMPILE_FLAGS": "-march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fno-pic",
+      "COMPILE_FLAGS": "-march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fno-pic -fno-omit-frame-pointer",
       "ENABLE_EXCEPTIONS": "OFF",
       "ENABLE_RTTI": "OFF",
       "TEST_EXECUTOR": "qemu",

--- a/qualcomm-software/embedded-multilib/json/variants/riscv32ima_zinx_xqci_ilp32_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32ima_zinx_xqci_ilp32_nopic.json
@@ -3,7 +3,7 @@
     "common": {
       "TARGET_ARCH": "riscv32",
       "VARIANT": "riscv32ima_zinx_xqci_ilp32_nopic",
-      "COMPILE_FLAGS": "-march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fno-pic",
+      "COMPILE_FLAGS": "-march=rv32ima_zawrs_zacas_zabha_zba_zbb_zbs_zca_zcb_zilsd_zclsd_zdinx_zfinx_zhinx_xqcia_xqciac_xqcibi_xqcibm_xqcicli_xqcicm_xqcics_xqcicsr_xqciint_xqciio_xqcilb_xqcili_xqcilia_xqcilo_xqcilsm_xqcisim_xqcisls_xqcisync_xqccmp_xqccmt0p1 -menable-experimental-extensions -mabi=ilp32 -fno-pic -fno-omit-frame-pointer",
       "ENABLE_EXCEPTIONS": "OFF",
       "ENABLE_RTTI": "OFF",
       "TEST_EXECUTOR": "qemu",


### PR DESCRIPTION
The overheads here are:
- All libraries go from 893690 to 913660 bytes of rodata/text (+2.2%)
- libc.a specifically goes from 406804 to 420806 bytes of rodata/text (+3.5%)

This is a little larger than I expected, but we should have two things in our favour for the effect on user code:
1. Users don't link the entirety of our libraries (via linker GC)
2. Library code should be a small percentage of total application size


(cherry picked from commit a756c78f8bb741d241d0af5c02137b054ac1b40b)