### PR TITLE
[cpullvm][musl] Switch musl repository from https to git protocol

### DIFF
--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -11,7 +11,7 @@
       "tag": "01254932e8e81085817ed61fd858648584ffe37c"
     },
     "musl": {
-      "url": "https://git.musl-libc.org/git/musl",
+      "url": "git://git.musl-libc.org/musl",
       "tagType": "tag",
       "tag": "v1.2.5"
     },


### PR DESCRIPTION
The HTTPS endpoint for the musl repository is frequently inaccessible, which can prevent fetching sources. 

The git protocol endpoint (git://git.musl-libc.org/musl) remains available and cloning works
reliably, so switch to using it instead.