### PR TITLE
[WIP] Enable LLDB tests.

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -21,16 +21,6 @@ function(add_python_test_target name test_script args comment)
   add_dependencies(${name} lldb-test-depends)
 endfunction()
 
-if (DEFINED LLVM_TARGET_TRIPLE)
-  set(default_lldb_test_triple ${LLVM_TARGET_TRIPLE})
-else()
-  set(default_lldb_test_triple ${LLVM_HOST_TRIPLE})
-endif()
-
-set(LLDB_TEST_TRIPLE
-  ${default_lldb_test_triple}
-  CACHE STRING "The target triple used to build test inferiors.")
-
 # Users can override LLDB_TEST_USER_ARGS to specify arbitrary arguments to pass to the script
 set(LLDB_TEST_USER_ARGS
   ""
@@ -82,22 +72,11 @@ else()
         "sure they are installed and in PATH.")
 endif()
 
-if (TARGET clang)
-  set(LLDB_DEFAULT_TEST_COMPILER "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}")
-else()
-  set(LLDB_DEFAULT_TEST_COMPILER "")
-endif()
-
 set(LLDB_TEST_EXECUTABLE "${LLDB_DEFAULT_TEST_EXECUTABLE}" CACHE PATH "lldb executable used for testing")
-set(LLDB_TEST_COMPILER "${LLDB_DEFAULT_TEST_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors")
 set(LLDB_TEST_DSYMUTIL "${LLDB_DEFAULT_TEST_DSYMUTIL}" CACHE PATH "dsymutil used for generating dSYM bundles")
 set(LLDB_TEST_MAKE "${LLDB_DEFAULT_TEST_MAKE}" CACHE PATH "make tool used for building test executables")
 set(LLDB_TEST_RESOURCE_DIR "" CACHE PATH "Clang resource directory for cross-compiling test inferiors")
 set(LLDB_TEST_SYSROOT "" CACHE PATH "Sysroot for cross-compiling test inferiors")
-
-if ("${LLDB_TEST_COMPILER}" STREQUAL "")
-  message(FATAL_ERROR "LLDB test compiler not specified. Tests will not run.")
-endif()
 
 if ( CMAKE_SYSTEM_NAME MATCHES "Windows" )
   set(LLDB_TEST_DEBUG_TEST_CRASHES

--- a/lldb/test/API/functionalities/process_save_core_minidump_size_of_image/TestMinidumpSizeOfImage.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump_size_of_image/TestMinidumpSizeOfImage.py
@@ -52,6 +52,7 @@ class MinidumpSizeOfImageTestCase(TestBase):
         subprocess.check_call(
             [
                 self.getCompiler(),
+                *("--target=" + self.getTriple() if self.getTriple() else []),
                 "-shared",
                 "-fPIC",
                 "-Wl,-T," + lds,

--- a/lldb/test/API/functionalities/scripted_process/Makefile
+++ b/lldb/test/API/functionalities/scripted_process/Makefile
@@ -2,10 +2,6 @@ CXX_SOURCES := main.cpp
 ENABLE_THREADS := YES
 LD_EXTRAS := -L. -lbaz -I.
 
-override TRIPLE := $(shell $(CC) -dumpmachine)
-
-CXXFLAGS_EXTRAS := -target $(TRIPLE)
-
 all: libbaz.dylib a.out
 
 libbaz.dylib: baz.cpp

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -287,6 +287,27 @@ if(WIN32 AND LLDB_ENABLE_LIBXML2)
 endif()
 set(LLDB_TEST_USE_LLDB_SERVER ${LLDB_TEST_USE_LLDB_SERVER_DEFAULT} CACHE BOOL "If ON, run the test suites against the lldb-server backend on Windows")
 
+if (TARGET clang)
+  set(LLDB_DEFAULT_TEST_COMPILER "${LLVM_TOOLS_BINARY_DIR}/clang${CMAKE_EXECUTABLE_SUFFIX}")
+else()
+  set(LLDB_DEFAULT_TEST_COMPILER "")
+endif()
+
+if (DEFINED LLVM_TARGET_TRIPLE)
+  set(default_lldb_test_triple ${LLVM_TARGET_TRIPLE})
+else()
+  set(default_lldb_test_triple ${LLVM_HOST_TRIPLE})
+endif()
+
+set(LLDB_TEST_COMPILER "${LLDB_DEFAULT_TEST_COMPILER}" CACHE PATH "C Compiler to use for building LLDB test inferiors")
+set(LLDB_TEST_TRIPLE
+  ${default_lldb_test_triple}
+  CACHE STRING "The target triple used to build test inferiors.")
+
+if ("${LLDB_TEST_COMPILER}" STREQUAL "")
+  message(FATAL_ERROR "LLDB test compiler not specified. Tests will not run.")
+endif()
+
 # These values are not canonicalized within LLVM.
 llvm_canonicalize_cmake_booleans(
   LLDB_BUILD_INTEL_PT

--- a/lldb/test/Shell/helper/build.py
+++ b/lldb/test/Shell/helper/build.py
@@ -36,6 +36,14 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--triple",
+    metavar="triple",
+    dest="triple",
+    required=True,
+    help="Target triple to pass to clang",
+)
+
+parser.add_argument(
     "--libs-dir",
     metavar="directory",
     dest="libs_dir",
@@ -296,6 +304,7 @@ class Builder(object):
         self.obj_ext = obj_ext
         self.lib_paths = args.libs_dir
         self.std = args.std
+        self.triple = args.triple
         assert (
             not args.objc_gnustep or args.objc_gnustep_dir
         ), "--objc-gnustep specified without path to libobjc2"
@@ -682,6 +691,9 @@ class MsvcBuilder(Builder):
         if self.std:
             args.append("/std:" + self.std)
 
+        if self.triple:
+            args.append("--target={0}".format(self.triple))
+
         args.append("/Fo" + obj)
         if self.toolchain_type == "clang-cl":
             args.append("--")
@@ -780,6 +792,9 @@ class GccBuilder(Builder):
         if self.std:
             args.append("-std={0}".format(self.std))
 
+        if self.triple:
+            args.append("--target={0}".format(self.triple))
+
         args.extend(["-o", obj])
         args.append(source)
 
@@ -827,6 +842,9 @@ class GccBuilder(Builder):
                 )
         elif self.sysroot:
             args.extend(["--sysroot", self.sysroot])
+
+        if self.triple:
+            args.append("--target={0}".format(self.triple))
 
         return ("linking", self._obj_file_names(), self._exe_file_name(), None, args)
 

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -99,10 +99,10 @@ def use_lldb_substitutions(config):
     build_script = os.path.join(build_script, "build.py")
     build_script_args = [
         build_script,
-        (
-            "--compiler=clang" if config.enable_remote else "--compiler=any"
-        ),  # Default to best compiler
+        "--compiler=" + config.test_compiler,
+        *(["--triple=" + config.test_triple] if config.test_triple else []),
         "--arch=" + str(config.lldb_bitness),
+        "--verbose",
     ]
     if config.lldb_lit_tools_dir:
         build_script_args.append("--tools-dir={0}".format(config.lldb_lit_tools_dir))

--- a/lldb/test/Shell/lit.site.cfg.py.in
+++ b/lldb/test/Shell/lit.site.cfg.py.in
@@ -43,6 +43,8 @@ config.lldb_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_LLDB@", "lldb-s
 config.clang_module_cache = os.path.join("@LLDB_TEST_MODULE_CACHE_CLANG@", "lldb-shell")
 config.clang_resource_dir = os.path.join("@CLANG_RESOURCE_DIR@")
 config.targets_to_build = "@LLVM_TARGETS_TO_BUILD@"
+config.test_compiler = lit_config.substitute('@LLDB_TEST_COMPILER@')
+config.test_triple = lit_config.substitute('@LLDB_TEST_TRIPLE@')
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -258,11 +258,9 @@ set(LLDB_ENABLE_PYTHON ON CACHE BOOL "")
 if (NOT CMAKE_HOST_WIN32)
   set(LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS ON CACHE BOOL "")
 endif()
-# LLDB tests don't work on x86 because clang defaults to AArch64 target triple.
-# See https://github.com/llvm/llvm-project/issues/203090 .  Using a clang
-# wrapper works around a few of the failures; we don't have any good workaround
-# for the rest.
-set(LLDB_INCLUDE_TESTS OFF CACHE BOOL "")
+set(LLDB_INCLUDE_TESTS ON CACHE BOOL "")
+#set(LLDB_TEST_COMPILER "${CMAKE_BINARY_DIR}/lldb-clang-wrapper.sh" CACHE STRING "" FORCE)
+set(LLDB_TEST_TRIPLE "x86_64-unknown-linux-gnu" CACHE STRING "" FORCE)
 
 # Default to a release build
 # (CMAKE_BUILD_TYPE is a special CMake variable so if you want to set
@@ -461,6 +459,14 @@ else()
     endif()
 endif()
 set(CPACK_PACKAGE_FILE_NAME ${PACKAGE_FILE_NAME})
+
+# Set LLDB_TEST_COMPILER to point to a wrapper script on x86-64 Linux hosts, to fix the default target.
+# (Do this late so CMake variables to detect host are configured.)
+#if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+#  set(LLDB_TEST_COMPILER "${CMAKE_BINARY_DIR}/lldb-clang-wrapper.sh" CACHE STRING "" FORCE)
+#  configure_file(lldb-clang-wrapper.sh.in lldb-clang-wrapper.sh @ONLY)
+#  message(STATUS "Overriding LLDB_TEST_COMPILER: ${LLDB_TEST_COMPILER}")
+#endif()
 
 # Including CPack again after llvm CMakeLists.txt included it
 # resets CPACK_PACKAGE_VERSION to the default MAJOR.MINOR.PATCH format.

--- a/qualcomm-software/lldb-clang-wrapper.sh.in
+++ b/qualcomm-software/lldb-clang-wrapper.sh.in
@@ -1,0 +1,2 @@
+#!/bin/bash
+@CMAKE_CURRENT_BINARY_DIR@/llvm/bin/clang --target=x86_64-linux-gnu "$@" -lstdc++ -lm


### PR DESCRIPTION
Includes work-in-progress LLDB patch to apply
LLDB_TEST_COMPILER/LLDB_TEST_TRIPLE in more places. https://github.com/efriedma-quic/llvm-project/tree/lldb-shell-compiler

The clang wrapper script fixes a few lldb-api tests; maybe we can remove that in a future version.