### PR TITLE
22.x: [cpullvm][DNM] Add speed-optimized AArch64 library variants

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -6,6 +6,12 @@
             "flags": "--target=aarch64-unknown-none-elf"
         },
         {
+            "variant": "aarch64a_tlsie_speed",
+            "json": "aarch64a_tlsie_speed.json",
+            "flags": "--target=aarch64-unknown-none-elf -O3",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "aarch64a_pacret",
             "json": "aarch64a_pacret.json",
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -mbranch-protection=pac-ret+leaf"
@@ -21,14 +27,32 @@
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti"
         },
         {
+            "variant": "aarch64a_pacret_bkey_bti_tlsie_speed",
+            "json": "aarch64a_pacret_bkey_bti_tlsie_speed.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti -O3",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "aarch64a_soft_nofp_tlsie",
             "json": "aarch64a_soft_nofp_tlsie.json",
             "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft"
         },
         {
+            "variant": "aarch64a_soft_nofp_tlsie_speed",
+            "json": "aarch64a_soft_nofp_tlsie_speed.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -O3",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "aarch64a_soft_nofp_pacret_bti",
             "json": "aarch64a_soft_nofp_pacret_bti.json",
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft"
+        },
+        {
+            "variant": "aarch64a_soft_nofp_pacret_bti_speed",
+            "json": "aarch64a_soft_nofp_pacret_bti_speed.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -O3",
+            "libraries_supported": "picolibc"
         },
         {
             "variant": "aarch64a_soft_nofp_pacret_bkey_bti",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_tlsie_speed.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_tlsie_speed.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_pacret_bkey_bti_tlsie_speed",
+            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "FLASH_ADDRESS": "0x40000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x40400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "release"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "TLS_MODEL": "initial-exec"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti_speed.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti_speed.json
@@ -1,0 +1,25 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_soft_nofp_pacret_bti_speed",
+            "COMPILE_FLAGS": "-march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "FLASH_ADDRESS": "0x40000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x40400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "release"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie_speed.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_tlsie_speed.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_soft_nofp_tlsie_speed",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "FLASH_ADDRESS": "0x40000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x40400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "release"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "TLS_MODEL": "initial-exec"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie_speed.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_tlsie_speed.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_tlsie_speed",
+            "COMPILE_FLAGS": "-march=armv8-a -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "FLASH_ADDRESS": "0x40000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x40400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "release"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "TLS_MODEL": "initial-exec"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/multilib.yaml.in
+++ b/qualcomm-software/embedded-multilib/multilib.yaml.in
@@ -225,3 +225,17 @@ Mappings:
 - Match: -Oz
   Flags:
   - -Os
+
+# FIXME: if we go forward with something like this, it'd be better to define
+# a custom multilib flag mapping to size/speed libraries, map to them here, and
+# use those in the multilib.json `flags`
+# Ex:
+#   * -O2/-O3 -> -fmultilib-flag=speed
+#   * -Os/-Oz -> -fmultilib-flag=size
+# It'd give people a better way to force override the library they are selecting
+# without actually having to touch the opt flags.
+# But, this is good enough for prototyping and the equivalent -Os/z handling is
+# already in place.
+- Match: -O2
+  Flags:
+  - -O3

--- a/qualcomm-software/patches/llvm-project/0007-Driver-DNM-Pass-all-opt-levels-through-to-multilib-f.patch
+++ b/qualcomm-software/patches/llvm-project/0007-Driver-DNM-Pass-all-opt-levels-through-to-multilib-f.patch
@@ -1,0 +1,86 @@
+From 71dd6a18d50307fbc200153486f24ad5effe9d1e Mon Sep 17 00:00:00 2001
+From: Jonathon Penix <jpenix@qti.qualcomm.com>
+Date: Sat, 1 Aug 2026 17:48:19 -0700
+Subject: [PATCH] [Driver][DNM] Pass all opt levels through to multilib for all
+ targets
+
+Previously, only -Oz and -Os were passed through for only Arm/AArch64 targets.
+We'd like this to include other optimization levels and need it to support
+RISC-V as well.
+
+Note also that -O4 and -Ofast are mapped to -O3 in keeping with the driver
+logic elsewhere.
+
+This should not be merged as-is as it is missing tests and needs to go through
+community review.
+
+For prototyping, our cpullvm multilib tests are enough and we don't yet know
+if we want these sorts of changes.
+---
+ clang/lib/Driver/ToolChain.cpp | 36 ++++++++++++----------------------
+ 1 file changed, 12 insertions(+), 24 deletions(-)
+
+diff --git a/clang/lib/Driver/ToolChain.cpp b/clang/lib/Driver/ToolChain.cpp
+index 703a3f8819cb..ae5be0d7e4fb 100644
+--- a/clang/lib/Driver/ToolChain.cpp
++++ b/clang/lib/Driver/ToolChain.cpp
+@@ -217,18 +217,6 @@ static void getAArch64MultilibFlags(const Driver &D,
+   if (ABIArg) {
+     Result.push_back(ABIArg->getAsString(Args));
+   }
+-
+-  if (const Arg *A = Args.getLastArg(options::OPT_O_Group);
+-      A && A->getOption().matches(options::OPT_O)) {
+-    switch (A->getValue()[0]) {
+-    case 's':
+-      Result.push_back("-Os");
+-      break;
+-    case 'z':
+-      Result.push_back("-Oz");
+-      break;
+-    }
+-  }
+ }
+ 
+ static void getARMMultilibFlags(const Driver &D, const llvm::Triple &Triple,
+@@ -305,18 +293,6 @@ static void getARMMultilibFlags(const Driver &D, const llvm::Triple &Triple,
+     if (Endian->getOption().matches(options::OPT_mbig_endian))
+       Result.push_back(Endian->getAsString(Args));
+   }
+-
+-  if (const Arg *A = Args.getLastArg(options::OPT_O_Group);
+-      A && A->getOption().matches(options::OPT_O)) {
+-    switch (A->getValue()[0]) {
+-    case 's':
+-      Result.push_back("-Os");
+-      break;
+-    case 'z':
+-      Result.push_back("-Oz");
+-      break;
+-    }
+-  }
+ }
+ 
+ static void getRISCVMultilibFlags(const Driver &D, const llvm::Triple &Triple,
+@@ -381,6 +357,18 @@ ToolChain::getMultilibFlags(const llvm::opt::ArgList &Args) const {
+ 
+   processMultilibCustomFlags(Result, Args);
+ 
++  // Pass through the opt level.
++  if (const Arg *A = Args.getLastArg(options::OPT_O_Group)) {
++    if (A->getOption().matches(options::OPT_O)) {
++      Result.push_back(std::string("-O") + A->getValue()[0]);
++    } else if (A->getOption().matches(options::OPT_O0)) {
++      Result.push_back("-O0");
++    } else if (A->getOption().matches(options::OPT_O4) ||
++               A->getOption().matches(options::OPT_Ofast)) {
++      Result.push_back("-O3");
++    }
++  }
++
+   // Include fno-exceptions and fno-rtti
+   // to improve multilib selection
+   if (getRTTIMode() == ToolChain::RTTIMode::RM_Disabled)
+-- 
+2.43.0
+

--- a/qualcomm-software/test/multilib/aarch64.test
+++ b/qualcomm-software/test/multilib/aarch64.test
@@ -5,8 +5,19 @@
 
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf | FileCheck %s --check-prefix=CHECK-AARCH64
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -Oz | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -Os | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -O1 | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -Og | FileCheck %s --check-prefix=CHECK-AARCH64
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -O0 | FileCheck %s --check-prefix=CHECK-AARCH64
 # CHECK-AARCH64: aarch64-none-elf/aarch64a_tlsie{{$}}
 # CHECK-AARCH64-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -O2 | FileCheck %s --check-prefix=CHECK-AARCH64-SPEED
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -O3 | FileCheck %s --check-prefix=CHECK-AARCH64-SPEED
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -Ofast | FileCheck %s --check-prefix=CHECK-AARCH64-SPEED
+# CHECK-AARCH64-SPEED: aarch64-none-elf/aarch64a_tlsie_speed{{$}}
+# CHECK-AARCH64-SPEED-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
@@ -23,17 +34,34 @@
 # CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti_tlsie{{$}}
 # CHECK-PACRET-BKEY-BTI-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -O2 | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI-SPEED
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -O3 | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI-SPEED
+# CHECK-PACRET-BKEY-BTI-SPEED: aarch64-none-elf/aarch64a_pacret_bkey_bti_tlsie_speed{{$}}
+# CHECK-PACRET-BKEY-BTI-SPEED-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp_tlsie{{$}}
 # CHECK-NOFP-EMPTY:
 
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft -O3 | FileCheck %s --check-prefix=CHECK-NOFP-SPEED
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft -O3 | FileCheck %s --check-prefix=CHECK-NOFP-SPEED
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft -O3 | FileCheck %s --check-prefix=CHECK-NOFP-SPEED
+# CHECK-NOFP-SPEED: aarch64-none-elf/aarch64a_soft_nofp_tlsie_speed{{$}}
+# CHECK-NOFP-SPEED-EMPTY:
+
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
 # CHECK-NOFP-PACRET-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti{{$}}
 # CHECK-NOFP-PACRET-BTI-EMPTY:
+
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -O3 | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI-SPEED
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -O3 | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI-SPEED
+# RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -O3 | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI-SPEED
+# CHECK-NOFP-PACRET-BTI-SPEED: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti_speed{{$}}
+# CHECK-NOFP-PACRET-BTI-SPEED-EMPTY:
 
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # RUN: %clang -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI


### PR DESCRIPTION
These are prototype changes for some users who want to experiment with speed optimized libraries.

These changes should not be merged as-is:
* If we go forward with something like this, I think we want to rework the existing -Oz -> -Os mapping and the -O2 -> -O3 mapping added here. That would allow some extra flexibility for folks to select differently optimized library variants without changing their opt flags.
* This includes a patch to upstream clang code to expand the opt level passthrough to handle all targets and all opt levels. This obviously needs to go through community review (and the patch given tests, etc.). Might need to think a bit more about whether we could get away with a smaller change by ordering the variants differently.