### PR TITLE
release/qualcomm-software/23.x: [RISCV] Add Tune Flag to riscv32imaf_zve32f_zvfh_zba_zbb_ilp32f_nothreads config (#563)

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/riscv32imaf_zve32f_zvfh_zba_zbb_ilp32f_nothreads.json
+++ b/qualcomm-software/embedded-multilib/json/variants/riscv32imaf_zve32f_zvfh_zba_zbb_ilp32f_nothreads.json
@@ -3,7 +3,7 @@
         "common": {
             "TARGET_ARCH": "riscv32",
             "VARIANT": "riscv32imaf_zve32f_zvfh_zba_zbb_ilp32f_nothreads",
-            "COMPILE_FLAGS": "-march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -menable-experimental-extensions -mabi=ilp32f -fPIC -fcf-protection=none",
+            "COMPILE_FLAGS": "-march=rv32imaf_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_ziccrse_zicond_zifencei_zihintntl_zihintpause_zihpm_zimop_za64rs_zawrs_zfa_zfbfmin_zfh_zce_zcmop_zba_zbb_zbs_zkt_zvbb_zve32f_zvl128b_zvfbfmin_zvfbfwma_zvfh_zvkt_smaia_smcsrind_smrnmi_sscofpmf_xsfvfexpa_zvdot4a8i0p1_zicfilp1p0 -menable-experimental-extensions -mabi=ilp32f -fPIC -fcf-protection=none -mtune=sifive-x160",
             "ENABLE_EXCEPTIONS": "OFF",
             "ENABLE_RTTI": "OFF",
             "TEST_EXECUTOR": "qemu",


### PR DESCRIPTION
Backport 90783f0f1cc128e43657e619f8159e16775e500a

Requested by: @lenary