### PR TITLE
[cpullvm] Add picolibc v1.8.12 overlay 

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -39,14 +39,6 @@ jobs:
             target_os: Linux-x86_64
             runner: cpullvm-ubuntu24-x86_64
 
-          # FIXME: this should maybe go into the nightly instead,
-          # but I don't want to keep triggering those until we're
-          # closer to being ready to merge.
-          - build_script: build_picolibc-v1812_overlay.sh
-            test_script: test_picolibc-v1812_overlay.sh
-            target_os: Linux-x86_64
-            runner: cpullvm-ubuntu24-x86_64
-
     steps:
       - name: Checkout source
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -39,6 +39,14 @@ jobs:
             target_os: Linux-x86_64
             runner: cpullvm-ubuntu24-x86_64
 
+          # FIXME: this should maybe go into the nightly instead,
+          # but I don't want to keep triggering those until we're
+          # closer to being ready to merge.
+          - build_script: build_picolibc-v1812_overlay.sh
+            test_script: test_picolibc-v1812_overlay.sh
+            target_os: Linux-x86_64
+            runner: cpullvm-ubuntu24-x86_64
+
     steps:
       - name: Checkout source
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -47,9 +47,12 @@ jobs:
             runner: ubuntu-24.04-arm
 
           # FIXME: convert to an ordinary build once we are able to source an
-          # up-to-date QEMU.
+          # up-to-date QEMU. Similarly, the oridinary test script can't be used
+          # as it references targets that don't exist with QEMU disabled. So
+          # skip testing as well until we can re-enable QEMU. Little coverage
+          # is lost in the meantime.
           - build_script: build_picolibc-v1812_overlay_no_qemu.sh
-            test_script: test_picolibc-v1812_overlay.sh
+            test_script: ''
             install_script: install_dependencies.sh
             target_os: Linux-AArch64
             runner: ubuntu-24.04-arm

--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -46,6 +46,14 @@ jobs:
             target_os: Linux-AArch64
             runner: ubuntu-24.04-arm
 
+          # FIXME: convert to an ordinary build once we are able to source an
+          # up-to-date QEMU.
+          - build_script: build_picolibc-v1812_overlay_no_qemu.sh
+            test_script: test_picolibc-v1812_overlay.sh
+            install_script: install_dependencies.sh
+            target_os: Linux-AArch64
+            runner: ubuntu-24.04-arm
+
           - build_script: build_musl-embedded_overlay.sh
             test_script: ''
             install_script: ''

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,6 +91,12 @@ jobs:
             target_os: Linux-AArch64
             runner: ubuntu-24.04-arm
 
+          - build_script: build_picolibc-v1812_overlay.sh
+            test_script: test_picolibc-v1812_overlay.sh
+            install_script: ''
+            target_os: Linux-x86_64
+            runner: cpullvm-ubuntu24-x86_64
+
           - build_script: build_musl-embedded_overlay.sh
             test_script: ''
             install_script: ''

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -120,7 +120,7 @@ set(LLVM_TOOLCHAIN_C_LIBRARY
     "Which C library to use."
 )
 set_property(CACHE LLVM_TOOLCHAIN_C_LIBRARY
-    PROPERTY STRINGS picolibc musl-embedded)
+    PROPERTY STRINGS picolibc picolibc-v1812 musl-embedded)
 
 option(
     SHORT_BUILD_PATHS
@@ -819,8 +819,11 @@ install(
     COMPONENT llvm-toolchain-docs
 )
 
-if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^picolibc")
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc)
     string(APPEND LIBC_LICENSE_FILES " - Picolibc: third-party-licenses/COPYING.NEWLIB, third-party-licenses/COPYING.picolibc\n")
+endif()
+if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL picolibc-v1812)
+    string(APPEND LIBC_LICENSE_FILES " - Picolibc: third-party-licenses/COPYING.picolibc\n")
 endif()
 if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded OR ENABLE_LINUX_LIBRARIES)
     string(APPEND LIBC_LICENSE_FILES " - musl-embedded: third-party-licenses/musl-embedded-COPYRIGHT.txt\n")
@@ -867,9 +870,14 @@ list(APPEND third_party_license_files
 
 if(LLVM_TOOLCHAIN_C_LIBRARY MATCHES "^picolibc")
     list(APPEND third_party_license_files
-        ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.NEWLIB           COPYING.NEWLIB
-        ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.picolibc         COPYING.picolibc
+        ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.picolibc COPYING.picolibc
     )
+    # COPYING.NEWLIB has been removed in picolibc 1.8.11 and later.
+    if(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL "picolibc")
+        list(APPEND third_party_license_files
+            ${${LLVM_TOOLCHAIN_C_LIBRARY}_SOURCE_DIR}/COPYING.NEWLIB COPYING.NEWLIB
+        )
+    endif()
 elseif(LLVM_TOOLCHAIN_C_LIBRARY STREQUAL musl-embedded)
     list(APPEND third_party_license_files
         ${musl-embedded_SOURCE_DIR}/COPYRIGHT musl-embedded-COPYRIGHT.txt

--- a/qualcomm-software/embedded-multilib/CMakeLists.txt
+++ b/qualcomm-software/embedded-multilib/CMakeLists.txt
@@ -27,11 +27,11 @@ set(llvmproject_src_dir ${TOOLCHAIN_SOURCE_DIR}/..)
 set(MULTILIB_JSON "" CACHE STRING "JSON file to load library definitions from.")
 set(ENABLE_VARIANTS "all" CACHE STRING "Semicolon separated list of variants to build, or \"all\". Must match entries in the json.")
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
-set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc musl-embedded)
+set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc picolibc-v1812 musl-embedded)
 
 # multilib.json and the per-variant JSON files only know about one
 # "picolibc" entry, shared by every fetched picolibc version (e.g.
-# picolibc-main), not a separate entry per version. So map C_LIBRARY to
+# picolibc-v1812), not a separate entry per version. So map C_LIBRARY to
 # its base library name before looking anything up there.
 if(C_LIBRARY MATCHES "^picolibc")
     set(json_library_key picolibc)

--- a/qualcomm-software/embedded-runtimes/CMakeLists.txt
+++ b/qualcomm-software/embedded-runtimes/CMakeLists.txt
@@ -25,7 +25,7 @@ set(llvmproject_src_dir ${TOOLCHAIN_SOURCE_DIR}/..)
 # CMake arguments are loaded from the JSON file depending on which C
 # library is used, so this must be set before the JSON is processed.
 set(C_LIBRARY "picolibc" CACHE STRING "Which C library to use.")
-set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc musl-embedded)
+set_property(CACHE C_LIBRARY PROPERTY STRINGS picolibc picolibc-v1812 musl-embedded)
 
 set(VARIANT_JSON "" CACHE STRING "JSON file to load args from.")
 if(VARIANT_JSON)

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -96,6 +96,20 @@ def main():
         p = subprocess.run(test_args, capture_output=True, check=False)
         return p.returncode != 0
 
+    # FIXME: Eventualy it might make more sense to add a `libc` member into
+    # `XFail` for more direct use depending on how many libc-specific xfails
+    # are needed. But, while supporting multiple picolibc versions is new,
+    # using the existing conditionals seems an unobtrusive and flexible way
+    # forward.
+    # Test whether picolibc is cpullvm's v1.8.12 version.
+    def check_picolibc_is_v1812():
+        return args.libc == 'picolibc-v1812'
+
+    # Test whether picolibc is cpullvm's "primary" version (currently between
+    # v1.8.10 and v1.8.11).
+    def check_picolibc_is_primary():
+        return args.libc == 'picolibc'
+
     xfails = [
         XFail(
             name="signal unwind picolibc",
@@ -197,6 +211,24 @@ def main():
             description="Disable the tests for now while the issue is being fixed upstream (https://github.com/picolibc/picolibc/pull/1072).",
         ),
         XFail(
+            name="picolibc v1.8.12 hello-raw",
+            testnames=[
+                "test-hello-raw.test",
+                "test-hello-raw-no-flash.test",
+            ],
+            result=NewResult.EXCLUDE,
+            conditional=check_picolibc_is_v1812,
+            project="picolibc",
+            variants=[
+                "aarch64a_tlsie",
+                "aarch64a_soft_nofp_tlsie",
+            ],
+            description="picolibc's `*-raw-*` tests rely on serial port usage "
+                        "to exit correctly which our existing wrappers are not "
+                        "setup to handle. Exclude them for now as we aren't losing "
+                        "any significant test coverage by doing so.",
+        ),
+        XFail(
             name="simd-unary-compiler-crash-armv7a",
             testnames=[
                 "std/experimental/simd/simd.class/simd_unary.pass.cpp",
@@ -277,8 +309,10 @@ def main():
                 "std/language.support/support.start.term/quick_exit.pass.cpp",
             ],
             result=NewResult.XFAILED,
+            conditional=check_picolibc_is_primary,
             project="libcxx",
-            description="at_quick_exit symbol is not found in the picolibc semihosting runtime.",
+            description="quick_exit, at_quick_exit, and __cxa_at_quick_exit were first added "
+                        "in picolibc v1.8.12. Older versions fail with undefined symbols.",
         ),
         XFail(
             name="uchar-cuchar-xpass-picolibc",

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -180,6 +180,8 @@ def main():
             testnames=[
                 "math_errhandling.test",
                 "test-fma.test",
+                # math_errhandling.test was renamed in picolibc v1.8.12
+                "test-math-errhandling.test",
             ],
             result=NewResult.XFAILED,
             project="picolibc",
@@ -199,6 +201,10 @@ def main():
                 "math_errhandling.test",
                 "rounding-mode.test",
                 "test-fma.test",
+                # math_errhandling.test and rounding-mode.test were renamed in
+                # picolibc v1.8.12
+                "test-math-errhandling.test",
+                "test-rounding-mode.test",
             ],
             result=NewResult.XFAILED,
             project="picolibc",

--- a/qualcomm-software/patches/picolibc-v1812/0001-Enable-libcxx-builds.patch
+++ b/qualcomm-software/patches/picolibc-v1812/0001-Enable-libcxx-builds.patch
@@ -1,0 +1,52 @@
+From a59afdaf3697da7a1cfc62e0f957be780d6ae11a Mon Sep 17 00:00:00 2001
+From: Simi Pallipurath <simi.pallipurath@arm.com>
+Date: Thu, 14 Nov 2024 10:07:08 +0000
+Subject: Enable libcxx builds
+
+Modifications to build config and linker script required to enable
+libc++ builds.
+---
+ meson.build    | 12 ++++++++++++
+ picolibc.ld.in |  3 +++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index f33d011b2..2c653de02 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1340,6 +1340,18 @@ NEWLIB_MAJOR_VERSION=4
+ NEWLIB_MINOR_VERSION=3
+ NEWLIB_PATCHLEVEL_VERSION=0
+ 
++conf_data.set('_GNU_SOURCE', '',
++        description: '''Enable GNU functions like strtof_l.
++It's necessary to set this globally because inline functions in
++libc++ headers call the GNU functions.'''
++)
++
++conf_data.set('_PICOLIBC_CTYPE_SMALL', '0',
++        description: '''Disable picolibc's small ctype implementation.
++libc++ expects newlib-style ctype tables, and also expects support for locales
++and extended character sets, so picolibc's small ctype is not compatible with it'''
++)
++
+ conf_data.set('__HAVE_CC_INHIBIT_LOOP_TO_LIBCALL',
+ 	      cc.has_argument('-fno-tree-loop-distribute-patterns'),
+ 	      description: 'Compiler flag to prevent detecting memcpy/memset patterns')
+diff --git a/picolibc.ld.in b/picolibc.ld.in
+index 0bcfe4ca8..c3055c49e 100644
+--- a/picolibc.ld.in
++++ b/picolibc.ld.in
+@@ -69,6 +69,9 @@ SECTIONS
+ 		*(.literal.startup .text.startup .literal.startup.* .text.startup.*)
+ 		*(SORT(.text.sorted.*))
+ 		*(.literal .text .literal.* .text.* .opd .opd.* .branch_lt .branch_lt.* @EXTRA_TEXT_SECTIONS@)
++		PROVIDE (__start___lcxx_override = .);
++		*(__lcxx_override)
++		PROVIDE (__stop___lcxx_override = .);
+ 		*(.gnu.linkonce.t.*)
+ 		KEEP (*(.fini .fini.*))
+ 		@PREFIX@__text_end = .;
+-- 
+2.43.0
+

--- a/qualcomm-software/patches/picolibc-v1812/0002-Add-optimized-memset-memcpy-strcpy-strcmp-for-Xqci.patch
+++ b/qualcomm-software/patches/picolibc-v1812/0002-Add-optimized-memset-memcpy-strcpy-strcmp-for-Xqci.patch
@@ -1,0 +1,814 @@
+From 88e28394e35aa782d2a371742e8502bdf4757c0e Mon Sep 17 00:00:00 2001
+From: Venkata Ramanaiah Nalamothu <vnalamot@qti.qualcomm.com>
+Date: Thu, 6 Aug 2026 15:09:04 -0700
+Subject: [PATCH] Add optimized memset/memcpy/strcpy/strcmp for Xqci
+
+The optimized implementations for Xqci will override the other
+existing corresponding varients when Xqci extenions are enabled.
+
+The orverriding happens using the interface implemented in the
+upstream Picolibc pull requests 1090, 1092 and 1098.
+---
+ libc/machine/riscv/CMakeLists.txt |   4 +
+ libc/machine/riscv/memcpy-xqci.S  | 283 ++++++++++++++++++++++++++++++
+ libc/machine/riscv/memset-xqci.S  | 161 +++++++++++++++++
+ libc/machine/riscv/memset.S       |   7 +-
+ libc/machine/riscv/meson.build    |   4 +
+ libc/machine/riscv/rv_string.h    |  22 ++-
+ libc/machine/riscv/strcmp-xqci.S  |  83 +++++++++
+ libc/machine/riscv/strcmp.S       |   6 +-
+ libc/machine/riscv/strcpy-xqci.S  |  87 +++++++++
+ libc/machine/riscv/strcpy.c       |   5 +
+ 10 files changed, 659 insertions(+), 3 deletions(-)
+ create mode 100644 libc/machine/riscv/memcpy-xqci.S
+ create mode 100644 libc/machine/riscv/memset-xqci.S
+ create mode 100644 libc/machine/riscv/strcmp-xqci.S
+ create mode 100644 libc/machine/riscv/strcpy-xqci.S
+
+diff --git a/libc/machine/riscv/CMakeLists.txt b/libc/machine/riscv/CMakeLists.txt
+index 05b2f0084..35ff47fc0 100644
+--- a/libc/machine/riscv/CMakeLists.txt
++++ b/libc/machine/riscv/CMakeLists.txt
+@@ -38,14 +38,18 @@ add_subdirectory(machine)
+ picolibc_sources_flags("-fno-builtin"
+   ieeefp.c
+   memcpy-asm.S
++  memcpy-xqci.S
+   memcpy.c
+   memmove.S
+   memmove.c
+   memset.S
++  memset-xqci.S
+   setjmp.S
+   stpcpy.c
+   strcmp.S
++  strcmp-xqci.S
+   strcpy.c
++  strcpy-xqci.S
+   strlen.c
+   tls.c
+   )
+diff --git a/libc/machine/riscv/memcpy-xqci.S b/libc/machine/riscv/memcpy-xqci.S
+new file mode 100644
+index 000000000..c3bb96743
+--- /dev/null
++++ b/libc/machine/riscv/memcpy-xqci.S
+@@ -0,0 +1,283 @@
++/*****************************************************************
++Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++SPDX-License-Identifier: BSD-3-Clause-Clear
++*****************************************************************/
++
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_MEMCPY_ASM_XQCI_
++
++.text
++
++/*===========================================================================
++
++  void *memcpy(void *dest, const void *src, size_t n)
++
++  void __xqci_memcpy(void *dest, const void *src, size_t n)
++
++  void __xqci_memcpy_aligned(void *dest, void *src, size_t n)
++
++  void __xqci_memcpy_words(void *dest, void *src, size_t nwords)
++
++===========================================================================*/
++/*!
++    @brief
++    memcpy() is standard libc memcpy().
++    It returns the "dest" argument.
++
++    __xqci_memcpy is called by the compiler memcpy() builtin if it can't
++    inline. It is identical to standard memcpy(), except it does not
++    return a value.
++
++    __xqci_memcpy_aligned assumes that dest/src are 32-bit word aligned,
++    and n is a multiple of words (n==0 is allowed).
++    Alignment is not checked, behavior is undefined if not satisfied.
++
++    __xqci_memcpy_words is like __xqci_memcpy_aligned, except that length
++    is in units of 32-bit words instead of bytes.
++
++    For word-aligned src/dest/size, these functions are guaranteed to
++    do only word accesses, in sequential order, so they are safe to use
++    for HW peripherals.
++    For byte alignment on src/dest/size, access order may be non-sequential,
++    and some locations may be read/written multiple times.
++    In all cases, only bytes strictly within the src/dest regions will be
++    accessed, with no over-read.
++*/
++/*=========================================================================*/
++
++// Inputs:
++#define dest          a0
++#define src           a1
++#define n             a2
++#define nwords        n
++
++#define BUFSZ         4
++
++// Locals:
++#define dst           a3
++#define buf00         a4
++#define buf01         a5
++#define buf02         a6
++#define buf03         a7
++#define buf10         t3
++#define buf11         t4
++#define buf12         t5
++#define buf13         t6
++#define buf_size      t0
++#define len0          t1
++#define len1          t2
++#define tmp           buf00
++#define src_end       len0
++#define dst_end       len1
++
++#ifndef MEMSET_TEST
++.global       memcpy
++.type         memcpy, @function
++memcpy:
++#endif
++
++.global       __xqci_memcpy
++.type         __xqci_memcpy, @function
++__xqci_memcpy:
++    // Check for src/dest/size alignment
++    or        tmp, dest, src
++    or        tmp, tmp, n
++    andi      tmp, tmp, 0x3                           # LSB of dest, src, and n are 0
++    bnez      tmp,.Lunaligned                         # Unaligned, take slow path
++
++.size         memcpy, . - memcpy
++
++.global       __xqci_memcpy_aligned
++.type         __xqci_memcpy_aligned, @function
++__xqci_memcpy_aligned:
++
++    srli      nwords, n, 2                            # Number of words
++
++.global       __xqci_memcpy_words
++.type         __xqci_memcpy_words, @function
++__xqci_memcpy_words:
++    mv        dst, dest
++
++.Lmemcpy_words_cont:
++    qc.bgeui  nwords, (BUFSZ*2+1), .Lmemcpy_words_long
++
++.Lmemcpy_words_short:
++    li        buf_size, BUFSZ
++    minu      len0, nwords, buf_size                  # Limit to nwords or bufsize (can be 0)
++    qc.lwm    buf00, len0, 0(src)                     # Load first buffer (can be 0 size)
++    sub       nwords, nwords, len0                    # adjust remind words number
++    minu      len1, nwords, buf_size                  # Second buffer size (can be 0)
++    qc.lwm    buf10, len1, (BUFSZ*4)(src)             # Load second buffer (can be 0 size)
++    qc.swm    buf00, len0, 0(dst)                     # Store first buffer (can be 0 size)
++    qc.swm    buf10, len1, (BUFSZ*4)(dst)             # Store second buffer (can be 0 size)
++    ret
++
++.Lmemcpy_words_long:
++    addi      dst, dst, -(BUFSZ*4*2)                  # pre-decrement destination pointer
++
++.Lmemcpy_words_loop:
++    qc.lwmi   buf00, BUFSZ, 0(src)                    # Load first buffer (can be 0 size)
++    qc.lwmi   buf10, BUFSZ, (BUFSZ*4)(src)            # Load second buffer (can be 0 size)
++    addi      src, src, (BUFSZ*4*2)                   # Increment source pointer
++    addi      dst, dst, (BUFSZ*4*2)                   # increment destination pointer
++    qc.swmi   buf00, BUFSZ, 0(dst)                    # Store first buffer (can be 0 size)
++    qc.swmi   buf10, BUFSZ, (BUFSZ*4)(dst)            # Store second buffer (can be 0 size)
++    addi      nwords, nwords, -(BUFSZ*2)              # adjust remind words number
++    qc.bgeui  nwords, (BUFSZ*2), .Lmemcpy_words_loop
++
++    addi      dst, dst, (BUFSZ*4*2)                   # increment destination pointer
++    bnez      nwords, .Lmemcpy_words_short
++    ret
++
++// src and/or dest and/or size are not word aligned.
++.Lunaligned:
++    mv        dst, dest
++    qc.bltui  n, 16, .Lbytecopy                       # Buffer is <= 15 bytes, copy directly
++
++    // Copy 3 bytes from the beginning and end of the buffer to handle
++    // realignment and over-read prevention. These will never overlap.
++    // Some of these may be re-copied after realignment.
++
++    lbu       buf00, 0(src)                           # Start of buffer
++    lbu       buf01, 1(src)
++    lbu       buf02, 2(src)
++    add       src_end, src, n                         # doing this add here to avoid bubble
++    sb        buf00, 0(dst)
++    sb        buf01, 1(dst)
++    sb        buf02, 2(dst)
++
++    lbu       buf00, -3(src_end)
++    lbu       buf01, -2(src_end)
++    lbu       buf02, -1(src_end)
++    add       dst_end, dst, n                         # doing this add here to avoid bubble
++    sb        buf00, -3(dst_end)
++    sb        buf01, -2(dst_end)
++    sb        buf02, -1(dst_end)
++
++    // Add 4 to avoid over-read in src, and +3 to round up dest to word boundary.
++    // Subtract 4 to avoid over-read in src_end, and round down to word boundary.
++    addi      dst, dst, 3
++    andi      dst, dst, -4                            # dest+7, rounded down
++    sub       tmp, dst, dest                          # Offset from original dest
++    add       src, src, tmp                           # Offset src by same amount (may not align)
++    andi      dst_end, dst_end, -4                    # -4 and round down on end of dest
++    sub       n, dst_end, dst                         # Updated n. Word multiple, >= 4
++
++    // dest and n are now word aligned.
++    // If src is also aligned, do remainder, as word aligned copy.
++    srli      nwords, n, 2                            # Number of words
++    andi      tmp, src, 0x3
++    beqz      tmp, .Lmemcpy_words_cont                # we are ready to branch to aligned word loop
++
++#define buf04         s2
++#define buf05         s3
++#define buf06         s4
++#define buf07         s5
++#define desc          s0
++#define len           s1
++#define limit         buf_size
++#define LIMIT_WORDS   (BUFSZ*2-1)
++#define LIMIT_BYTES   (LIMIT_WORDS*4)
++
++    // src is not aligned to dest. Realign src data.
++    qc.cm.push {ra,s0-s5}, -32
++    li        desc, 0x200000                          # Width=32 in upper halfword
++    qc.insb   desc, src, 2, 3                         # Byte offset*8 in lower halfword
++    andi      src, src, -4                            # Word align src
++    lw        buf07, 0(src)                           # Load first word
++    addi      dst, dst, -LIMIT_BYTES                  # Pre-subtract dest
++
++    // We don't expect to be doing unaligned access to cache.
++    // Pipeline less aggressively to save code, do bookkeeping
++    // between load and access which should hide memory latency.
++    // This loop copies <= 7 words per iteration.
++
++    li        limit, LIMIT_WORDS
++.Lunaligned_word_loop:
++    mv        buf00, buf07                            # Copy last word from previous buf
++    minu      len, nwords, limit                      # Maximum 7 words per iteration
++    qc.lwm    buf01, len, 4(src)                      # Load next buffer, offset by 1 word
++    addi      src, src, LIMIT_BYTES                   # Inc src for next iteration
++    addi      dst, dst, LIMIT_BYTES                   # Pre-inc dest
++    qc.extdur buf00, buf00, desc                      # Realign each word
++    qc.extdur buf01, buf01, desc
++    qc.extdur buf02, buf02, desc
++    qc.extdur buf03, buf03, desc
++    qc.extdur buf04, buf04, desc
++    qc.extdur buf05, buf05, desc
++    qc.extdur buf06, buf06, desc
++    qc.swm    buf00, len, 0(dst)                      # Store realigned data
++    sub       nwords, nwords, len
++    bnez      nwords, .Lunaligned_word_loop
++    qc.cm.popret {ra,s0-s5}, 32
++
++#undef buf04
++#undef buf05
++#undef buf06
++#undef buf07
++#undef limit
++#undef desc
++#undef LIMIT_WORDS
++#undef LIMIT_BYTES
++
++// Copy buffer directly, size is <= 15 bytes
++// Try to hide load latency, within reason.
++.Lbytecopy:
++    qc.bltui  n, 4, .Lbytecopy_2
++
++.Lbytecopy_4:
++    // Copy 4 bytes per iteration
++    lbu       buf00, 0(src)
++    lbu       buf01, 1(src)
++    lbu       buf02, 2(src)
++    lbu       buf03, 3(src)
++    addi      src, src, 4
++    sb        buf00, 0(dst)
++    sb        buf01, 1(dst)
++    sb        buf02, 2(dst)
++    sb        buf03, 3(dst)
++    addi      dst, dst, 4
++    addi      n, n, -4
++    qc.bgeui  n, 4, .Lbytecopy_4                    # Repeat until < 4 bytes remaining
++
++.Lbytecopy_2:
++    qc.bltui  n, 2, .Lbytecopy_1_check
++    // Copy 2 bytes.
++    lbu       buf00, 0(src)
++    lbu       buf01, 1(src)
++    addi      src, src, 2
++    addi      n, n, -2
++    sb        buf00, 0(dst)
++    sb        buf01, 1(dst)
++    addi      dst, dst, 2
++
++.Lbytecopy_1_check:
++    bnez      n, .Lbytecopy_1
++    ret
++
++.Lbytecopy_1:
++    lbu       buf00, 0(src)
++    sb        buf00, 0(dst)
++    ret
++
++#undef BUFSZ
++#undef src_end
++#undef dst_end
++#undef tmp
++#undef dst
++#undef len0
++#undef len1
++#undef buf_size
++#undef buf00
++#undef buf01
++#undef buf02
++#undef buf03
++#undef buf10
++#undef buf11
++#undef buf12
++#undef buf13
++
++.size         __xqci_memcpy, . - __xqci_memcpy
++
++#endif /*_MACHINE_RISCV_MEMCPY_ASM_XQCI_ */
+diff --git a/libc/machine/riscv/memset-xqci.S b/libc/machine/riscv/memset-xqci.S
+new file mode 100644
+index 000000000..361fdb7b3
+--- /dev/null
++++ b/libc/machine/riscv/memset-xqci.S
+@@ -0,0 +1,161 @@
++/*****************************************************************
++Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++SPDX-License-Identifier: BSD-3-Clause-Clear
++*****************************************************************/
++
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_MEMSET_ASM_XQCI_
++
++.text
++
++/*===========================================================================
++
++  void *memset(void *s, int c, size_t n)
++
++  void __xqci_memset(void *s, int c, size_t n)
++
++  void __xqci_memset_aligned(unsigned *s, int c, size_t n)
++
++  void __xqci_memset_words(unsigned *s, unsigned w, size_t nwords)
++
++===========================================================================*/
++/*!
++    @brief
++    memset() is the standard libc implementation.
++    It returns the "s" argument.
++
++    __xqci_memset() is called by the compiler memset() builtin if it can't
++    inline. It is identical to standard memset(), except it does not
++    return a value.
++
++    __xqci_memset_aligned() works similarly to __xqci_memset(), except it assumes
++    s is 32-bit aligned, and n is a multiple of 32 bits (n==0 is allowed).
++    Alignment is not checked, behavior is undefined if not satisfied.
++
++    __xqci_memset_words() also requires s to be 32-bit aligned.
++    w has the value replicated in each byte, and nwords is the length
++    in units of 32-bit words.
++
++    For word aligned address/length, these functions are guaranteed to do
++    only word access, in sequential order, so they are safe to use for
++    HW peripherals.
++    If address or length have byte alignment, then sequential access
++    is not guaranteed, and some locations may be written multiple times.
++*/
++/*=========================================================================*/
++
++#ifndef MEMSET_TEST
++.global     memset
++.type       memset, @function
++memset:
++#endif
++
++.global     __xqci_memset
++.type       __xqci_memset, @function
++__xqci_memset:
++// Inputs:
++#define s               a0
++#define c               a1
++#define w               c
++#define n               a2
++#define nwords          n
++// Locals:
++#define len             a3
++#define end             a5
++
++#define BLOCK_WORDS     (28)
++#define BLOCK_BYTES     (BLOCK_WORDS*4)
++
++    // Common case: if s and n are word aligned, use aligned function.
++#define a               a4
++    or       a, s, n
++    andi     a, a, 0x3
++    bnez     a, .Lunaligned                          # Skip if unaligned
++#undef a
++    // Fallthrough to aligned memset
++
++#define p               a4
++// External entry for __xqci_memset_aligned
++.global     __xqci_memset_aligned
++.type       __xqci_memset_aligned, @function
++__xqci_memset_aligned:
++    mv       p, s                                    # keep s value since it is return value
++.L__xqci_memset_aligned:
++
++    srli     nwords, n, 2                            # Convert to nwords
++    qc.insb  w, c, 8, 8                              # Splat c over all 4 bytes
++    qc.insb  w, w, 16, 16
++    qc.e.bgeui nwords, 32, .Llong                    # Long memset if >= 32 words
++    qc.setwm w, nwords, 0(p)                         # Short memset (1..31 words) is fast path
++    ret
++
++.Llong:
++    // Long memset, 32 or more words.
++    // Align the address to a 128-bit PDMEM boundary so block stores
++    // are more efficient.
++    qc.extu  len, p, 2, 2                            # Word address mod 4
++    not      len, len
++    addi     len, len, 5                             # Residual to next 4-word multiple
++    qc.setwm w, len, 0(p)                            # Store 1..4 words for alignment
++    sh2add   p, len, p                               # p += alignment words*4
++    sub      nwords, nwords, len                     # nwords -= alignment words
++    qc.e.bltui nwords, 32, .Ltail
++
++    // Store in blocks of 28 words, except for last block.
++.Lblocks:
++    qc.setwmi w, BLOCK_WORDS, 0(p)                   # Store block size words
++    addi     p, p, BLOCK_BYTES                       # Increment ptr, may overflow but not used in
++    addi     nwords, nwords, -BLOCK_WORDS            # nwords -= length
++    qc.bgeui nwords, BLOCK_WORDS, .Lblocks
++
++.Ltail:
++    qc.setwm w, nwords, 0(p)                         # Store reminder of words, if any
++    ret
++
++    // Unaligned start address and/or length.
++.Lunaligned:
++    // Do byte stores at start/end of buffer.
++    // Some locations may be written multiple times for small buffers.
++    mv       p, s                                     # keep s value since it is return value
++    add      end, p, n                                # End of buffer
++    beqz     n, .Lroundup
++    sb       c, 0(p)
++    sb       c, -1(end)
++    addi     n, n, -1
++    beqz     n, .Lroundup
++    sb       c, 1(p)
++    sb       c, -2(end)
++    addi     n, n, -1
++    beqz     n, .Lroundup
++    sb       c, 2(p)
++    sb       c, -3(end)
++
++    // Any residual bytes at start/end of buffer have been set.
++    // Round up starting address and round down size to word boundaries and
++    // continue with alignment memset.
++    // Some bytes may be written again by word writes.
++.Lroundup:
++    addi     p, p, 3
++    andi     p, p, -4                                # Round up p
++    sub      n, end, p                               # n = end - p  (may be negative)
++                                                     # __xqci_memset_aligned will round down n
++    qc.bgei  n, 4, .L__xqci_memset_aligned           # Set middle of buffer as words
++
++    // Short buffer, return immediately
++    ret
++
++// External entry for __xqci_memset_words
++.global     __xqci_memset_words
++.type       __xqci_memset_words, @function
++__xqci_memset_words:
++    mv       p, s                                    # keep s value since it is return value
++    qc.e.bgeui nwords, 32, .Llong                    # Long memset if >= 32 words
++    qc.setwm w, nwords, 0(s)                         # Short memset (1..31 words) is fast path
++    ret
++
++#undef p
++
++.size       __xqci_memset, . - __xqci_memset
++
++#endif /* _MACHINE_RISCV_MEMSET_ASM_XQCI_ */
+diff --git a/libc/machine/riscv/memset.S b/libc/machine/riscv/memset.S
+index eaae02a5b..c1ea0a589 100644
+--- a/libc/machine/riscv/memset.S
++++ b/libc/machine/riscv/memset.S
+@@ -9,7 +9,10 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_MEMSET_ASM_
++
+ #include "asm.h"
+ 
+ 
+@@ -375,3 +378,5 @@ memset:
+   ret
+ #endif
+ .size  memset, .-memset
++
++#endif /* _MACHINE_RISCV_MEMSET_ASM_ */
+diff --git a/libc/machine/riscv/meson.build b/libc/machine/riscv/meson.build
+index b95b78846..4a1d05e7a 100644
+--- a/libc/machine/riscv/meson.build
++++ b/libc/machine/riscv/meson.build
+@@ -35,13 +35,17 @@
+ srcs_machine = [
+   'ieeefp.c',
+   'memcpy-asm.S',
++  'memcpy-xqci.S',
+   'memcpy.c',
+   'memmove.S',
+   'memmove.c',
+   'memset.S',
++  'memset-xqci.S',
+   'setjmp.S',
+   'stpcpy.c',
++  'strcmp-xqci.S',
+   'strcmp.S',
++  'strcpy-xqci.S',
+   'strcpy.c',
+   'strlen.c',
+   'tls.c',
+diff --git a/libc/machine/riscv/rv_string.h b/libc/machine/riscv/rv_string.h
+index 7fd95da09..872b33d9a 100644
+--- a/libc/machine/riscv/rv_string.h
++++ b/libc/machine/riscv/rv_string.h
+@@ -23,7 +23,9 @@
+ 
+ #include <picolibc.h>
+ 
+-#if defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
++#ifdef __riscv_xqci
++# define _MACHINE_RISCV_MEMCPY_ASM_XQCI_
++#elif defined(__PREFER_SIZE_OVER_SPEED) || defined(__OPTIMIZE_SIZE__)
+ #define _MACHINE_RISCV_MEMCPY_ASM_
+ #elif defined(__riscv_vector)
+ #define _MACHINE_RISCV_MEMCPY_VECTOR_
+@@ -39,4 +41,22 @@
+ #define _MACHINE_RISCV_MEMMOVE_GENERIC_
+ #endif
+ 
++#if defined(__riscv_xqci)
++# define _MACHINE_RISCV_MEMSET_ASM_XQCI_
++#else
++# define _MACHINE_RISCV_MEMSET_ASM_
++#endif
++
++#if defined(__riscv_xqci)
++# define _MACHINE_RISCV_STRCMP_ASM_XQCI_
++#else
++# define _MACHINE_RISCV_STRCMP_ASM_
++#endif
++
++#if defined(__riscv_xqci)
++# define _MACHINE_RISCV_STRCPY_ASM_XQCI_
++#else
++# define _MACHINE_RISCV_STRCPY_ASM_
++#endif
++
+ #endif /* _RV_STRING_H_ */
+diff --git a/libc/machine/riscv/strcmp-xqci.S b/libc/machine/riscv/strcmp-xqci.S
+new file mode 100644
+index 000000000..1a7fdda89
+--- /dev/null
++++ b/libc/machine/riscv/strcmp-xqci.S
+@@ -0,0 +1,83 @@
++/*****************************************************************
++Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++SPDX-License-Identifier: BSD-3-Clause-Clear
++*****************************************************************/
++
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_STRCMP_ASM_XQCI_
++
++.text
++
++/*===========================================================================
++
++  int strcmp(const char *s1, const char *s2)
++
++===========================================================================*/
++
++    /*
++     * Returns
++     *   a0 - comparison result, value like strcmp
++     *
++     * Parameters
++     *   a0 - string1
++     *   a1 - string2
++     *
++     * Clobbers
++     *   a2, a3, a4, a5, a6
++     */
++.global strcmp
++.type strcmp, @function
++strcmp:
++    mv      a6, a0
++    or      a5, a6, a1
++    and     a5, a5, 3
++    li      a4, 0
++    bnez    a5, 3f
++
++    /* Main loop for aligned string.  */
++1:
++    qc.lrw  a2, a6, a4, 0
++    qc.lrw  a3, a1, a4, 0
++    orc.b   a5, a2
++    qc.bnei a5, -1, 2f
++    addi    a4, a4, 4
++    beq     a2, a3, 1b
++
++    /*
++     * Words don't match, and no null byte in the first word.
++     * Compute the first differing byte and return unsigned difference.
++     */
++    xor     a5, a2, a3
++    ctz     a5, a5          # bit offset to first differing bit
++    andi    a5, a5, -0x8    # bit offset to first differing byte
++    srl     a0, a2, a5
++    andi    a0, a0, 0xFF
++    srl     a3, a3, a5
++    andi    a3, a3, 0xFF
++    sub     a0, a0, a3
++    ret
++
++2:
++    /*
++     * Found a null byte.
++     * If words don't match, fall back to simple loop.
++     */
++    xor     a0, a2, a3
++    bnez    a0, 3f
++    /* Otherwise, strings are equal. */
++    ret
++
++    /* Simple loop for misaligned strings. */
++3:
++    qc.lrbu a2, a6, a4, 0
++    qc.lrbu a3, a1, a4, 0
++    addi    a4, a4, 1
++    bne     a2, a3, 4f
++    bnez    a2, 3b
++
++4:
++    sub     a0, a2, a3
++    ret
++
++#endif /* _MACHINE_RISCV_STRCMP_ASM_XQCI_ */
+diff --git a/libc/machine/riscv/strcmp.S b/libc/machine/riscv/strcmp.S
+index 52305db3d..0af12436c 100644
+--- a/libc/machine/riscv/strcmp.S
++++ b/libc/machine/riscv/strcmp.S
+@@ -9,7 +9,9 @@
+    http://www.opensource.org/licenses.
+ */
+ 
+-#include <picolibc.h>
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_STRCMP_ASM_
+ 
+ #include "asm.h"
+ 
+@@ -309,3 +311,5 @@ mask:
+ .size	strcmp, .-strcmp
+ 
+ #endif
++
++#endif /* _MACHINE_RISCV_STRCMP_ASM_ */
+diff --git a/libc/machine/riscv/strcpy-xqci.S b/libc/machine/riscv/strcpy-xqci.S
+new file mode 100644
+index 000000000..56d82fe85
+--- /dev/null
++++ b/libc/machine/riscv/strcpy-xqci.S
+@@ -0,0 +1,87 @@
++/*****************************************************************
++Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
++SPDX-License-Identifier: BSD-3-Clause-Clear
++*****************************************************************/
++
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_STRCPY_ASM_XQCI_
++
++.text
++
++/*===========================================================================
++
++  char * strcpy(char *dst, const char *src)
++
++===========================================================================*/
++
++    /*
++     * Returns
++     *   a0 - destination string
++     *
++     * Parameters
++     *   a0 - destination
++     *   a1 - source
++     *
++     * Clobbers
++     *   a2, a3, a4, a5, a6, a7, t3, t4, t5, t6
++     */
++.global strcpy
++.type strcpy, @function
++strcpy:
++    mv      a7, a0
++    or      a2, a0, a1
++    and     a2, a1, 3
++    bnez    a2, 4f
++1:
++    qc.lwmi t3, 4, 0(a1)
++    add     a1, a1, 16
++    li      a2, -1
++    orc.b   a3, t3
++    and     a2, a2, a3
++    orc.b   a4, t4
++    and     a2, a2, a4
++    orc.b   a5, t5
++    and     a2, a2, a5
++    orc.b   a6, t6
++    and     a2, a2, a6
++    qc.bnei a2, -1, 2f
++    qc.swmi t3, 4, 0(a7)
++    add     a7, a7, 16
++    j       1b
++
++2:
++    add     a1, a1, -16
++    li      a2, 0
++    qc.bnei a3, -1, 3f
++    qc.srw  t3, a7, a2, 0
++    add     a2, a2, 4
++    qc.bnei a4, -1, 3f
++    qc.srw  t4, a7, a2, 0
++    add     a2, a2, 4
++    qc.bnei a5, -1, 3f
++    qc.srw  t5, a7, a2, 0
++    add     a2, a2, 4
++
++3:
++    add     a7, a7, a2
++    add     a1, a1, a2
++4:
++    lbu     a2, 0(a1)
++    lbu     a3, 1(a1)
++    lbu     a4, 2(a1)
++    lbu     a5, 3(a1)
++    sb      a2, 0(a7)
++    beqz    a2, 5f
++    sb      a3, 1(a7)
++    beqz    a3, 5f
++    sb      a4, 2(a7)
++    beqz    a4, 5f
++    sb      a5, 3(a7)
++    beqz    a5, 5f
++    li      a2,    4
++    j       3b
++5:
++    ret
++
++#endif /* _MACHINE_RISCV_STRCPY_ASM_XQCI_ */
+diff --git a/libc/machine/riscv/strcpy.c b/libc/machine/riscv/strcpy.c
+index 8ead748bd..b77efb2a5 100644
+--- a/libc/machine/riscv/strcpy.c
++++ b/libc/machine/riscv/strcpy.c
+@@ -11,6 +11,9 @@
+ 
+ #include <stdbool.h>
+ #include "rv_strcpy.h"
++#include "rv_string.h"
++
++#ifdef _MACHINE_RISCV_STRCPY_ASM_
+ 
+ #undef strcpy
+ 
+@@ -19,3 +22,5 @@ strcpy(char *dst, const char *src)
+ {
+     return __libc_strcpy(dst, src, true);
+ }
++
++#endif /* _MACHINE_RISCV_STRCPY_ASM_ */
+-- 
+2.43.0
+

--- a/qualcomm-software/scripts/build_picolibc-v1812_overlay.sh
+++ b/qualcomm-software/scripts/build_picolibc-v1812_overlay.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to build the picolibc-v1812 overlay.
+
+# The script creates a build of the toolchain in the 'build_picolibc-v1812_overlay'
+# directory, inside the repository tree.
+
+set -ex
+
+export CC=clang
+export CXX=clang++
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+BUILD_DIR=${REPO_ROOT}/build_picolibc-v1812_overlay
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+cmake ../qualcomm-software \
+  -GNinja -DFETCHCONTENT_QUIET=OFF \
+  -DLLVM_TOOLCHAIN_C_LIBRARY=picolibc-v1812 \
+  -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=ON \
+  ${EXTRA_CMAKE_ARGS}
+ninja package-llvm-toolchain
+
+# The package-llvm-toolchain target will produce a .tar.xz package, but we also
+# want a zip version for Windows users
+cpack -G ZIP

--- a/qualcomm-software/scripts/build_picolibc-v1812_overlay_no_qemu.sh
+++ b/qualcomm-software/scripts/build_picolibc-v1812_overlay_no_qemu.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A bash script to build the picolibc-v1812 overlay.
+
+# The script creates a build of the toolchain in the 'build_picolibc-v1812_overlay'
+# directory, inside the repository tree.
+
+set -ex
+
+export CC=clang
+export CXX=clang++
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+BUILD_DIR=${REPO_ROOT}/build_picolibc-v1812_overlay
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+cmake ../qualcomm-software \
+  -GNinja -DFETCHCONTENT_QUIET=OFF \
+  -DLLVM_TOOLCHAIN_C_LIBRARY=picolibc-v1812 \
+  -DLLVM_TOOLCHAIN_LIBRARY_OVERLAY_INSTALL=ON \
+  -DENABLE_QEMU_TESTING=OFF \
+  ${EXTRA_CMAKE_ARGS}
+ninja package-llvm-toolchain
+
+# The package-llvm-toolchain target will produce a .tar.xz package, but we also
+# want a zip version for Windows users
+cpack -G ZIP

--- a/qualcomm-software/scripts/test_picolibc-v1812_overlay.sh
+++ b/qualcomm-software/scripts/test_picolibc-v1812_overlay.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2025, Arm Limited and affiliates.
+# Part of the Arm Toolchain project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Changes from Qualcomm Technologies, Inc. are provided under the following license:
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# The script assumes a successful build of the toolchain exists in the
+# 'build_picolibc-v1812_overlay' directory inside the repository tree.
+
+set -ex
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
+
+# Run only the library and multilib lit tests. Run libc++ tests for only a few
+# variants to keep the runtime acceptable.
+cd "${REPO_ROOT}"/build_picolibc-v1812_overlay
+ninja check-llvm-toolchain
+ninja check-cxxabi
+ninja check-unwind
+ninja check-cxx-aarch64a_tlsie
+ninja check-cxx-armv7a_soft_nofp
+ninja check-cxx-riscv32imac_ilp32
+ninja check-cxx-riscv64gc_lp64_nopic

--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -10,6 +10,11 @@
       "tagType": "commithash",
       "tag": "01254932e8e81085817ed61fd858648584ffe37c"
     },
+    "picolibc-v1812": {
+      "url": "https://github.com/picolibc/picolibc.git",
+      "tagType": "tag",
+      "tag": "1.8.12"
+    },
     "musl": {
       "url": "git://git.musl-libc.org/musl",
       "tagType": "tag",


### PR DESCRIPTION
Add a new C library variant for picolibc v1.8.12 (`picolibc-v1812`) and start building it as an overlay.

For now, this shares all the same variants as the main `picolibc` library.

picolibc v1.8.12 includes API-breaking changes to `off_t`, so this is intended to serve users on codebases that expect such changes (Zephyr, for example seems to getting ready to make changes to support picolibc v1.8.12).