### PR TITLE
Disable release/23.x auto-sync to preserve RC3 baseline

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,8 +19,6 @@ jobs:
         branches:
           - from_branch: main
             to_branch: qualcomm-software
-          - from_branch: release/23.x
-            to_branch: release/qualcomm-software/23.x
     steps:
       - name: Configure Access Token
         uses: actions/create-github-app-token@f45685208fd9b88321d74015b5996fc8c3e43d18 # v1.0.0

--- a/.github/workflows/sync_from_upstream.yml
+++ b/.github/workflows/sync_from_upstream.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'qualcomm/cpullvm-toolchain'
     strategy:
       matrix:
-        branch: [main, release/23.x]
+        branch: [main]
     env:
       UPSTREAM_REMOTE: https://github.com/llvm/llvm-project.git
     steps:


### PR DESCRIPTION
Stop automated upstream synchronization for release/23.x to avoid pulling changes beyond the RC3 release candidate. Remaining RC3 updates will be synced manually as needed.