### PR TITLE
release/qualcomm-software/23.x: [cpullvm] Enable libunwind tests (#479)

### DIFF
--- a/qualcomm-software/embedded-runtimes/test-support/llvm-libunwind-picolibc.cfg.in
+++ b/qualcomm-software/embedded-runtimes/test-support/llvm-libunwind-picolibc.cfg.in
@@ -31,9 +31,11 @@ config.substitutions.append(('%{compile_flags}',
 config.substitutions.append(('%{link_flags}',
     ' -nostdlib++ -L %{lib}'
     ' -lc++ -lc++abi -lunwind'
-    ' -nostdlib -L %{libc-lib}'
-    ' -lc -lm -lclang_rt.builtins'
+    ' -nostdlib -L %{libc-lib} -lm'
+    ' -Wl,--start-group'
+    ' -lc -lclang_rt.builtins'
     ' %{libc-extra-link-flags}'
+    ' -Wl,--end-group'
 ))
 config.substitutions.append(('%{exec}',
     '%{executor} --execdir %{temp} -- '

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -98,6 +98,27 @@ def main():
 
     xfails = [
         XFail(
+            name="signal unwind picolibc",
+            testnames=[
+                "signal_unwind.pass.cpp",
+                "unwind_leaffunction.pass.cpp",
+            ],
+            result=NewResult.XFAILED,
+            project="libcxx",
+            variants=[
+                "aarch64a_tlsie",
+                "riscv64gc_lp64d_nopic",
+                "riscv64gc_lp64_nopic",
+                "riscv64gc_zba_zbb_lp64d_nopic",
+                "riscv64gc_zba_zbb_lp64_nopic",
+                "riscv64imac_lp64_nopic",
+                "riscv64imc_lp64_nothreads_nopic",
+            ],
+            description="picolibc semihost defines kill as a stub that calls _exit(128 + sig) "
+                "instead of delivering the signal to the registered handler, so signal-based "
+                "unwind tests cannot run on bare-metal targets.",
+        ),
+        XFail(
             name="no frwpi",
             testnames=[
                 "Clang :: Driver/ropi-rwpi.c",

--- a/qualcomm-software/scripts/test.sh
+++ b/qualcomm-software/scripts/test.sh
@@ -24,3 +24,4 @@ cd "${REPO_ROOT}"/build
 ninja check-all
 ninja check-llvm-toolchain
 ninja check-cxxabi
+ninja check-unwind


### PR DESCRIPTION
Backport 6ff88d2

Requested by: @jonathonpenix