### PR TITLE
[cpullvm][musl] Switch musl repository from https to git protocol

### DIFF
--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -11,7 +11,7 @@
       "tag": "01254932e8e81085817ed61fd858648584ffe37c"
     },
     "musl": {
-      "url": "https://git.musl-libc.org/git/musl",
+      "url": "git://git.musl-libc.org/musl",
       "tagType": "tag",
       "tag": "v1.2.5"
     },


### PR DESCRIPTION
The musl HTTP repository endpoint if currently unavailable, which prevents access through the web URL.

However, the git protocol enpoint(git://git.musl-libc.org/musl) remains operational and cloning works successfully.


(cherry picked from commit 337ac900d48f5d29378bc9c8a22df822d69cec91)