### PR TITLE
[cpullvm] Move, increase RAM for armv7m variants

### DIFF
--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_hard_fpv5_d16_nopic.json
@@ -11,8 +11,8 @@
             "QEMU_CPU": "cortex-m7",
             "FLASH_ADDRESS": "0x00000000",
             "FLASH_SIZE": "0x00400000",
-            "RAM_ADDRESS": "0x20000000",
-            "RAM_SIZE": "0x00800000",
+            "RAM_ADDRESS": "0x60000000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp.json
@@ -11,8 +11,8 @@
             "QEMU_CPU": "cortex-m3",
             "FLASH_ADDRESS": "0x00000000",
             "FLASH_SIZE": "0x00400000",
-            "RAM_ADDRESS": "0x20000000",
-            "RAM_SIZE": "0x00800000",
+            "RAM_ADDRESS": "0x21000000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
+++ b/qualcomm-software/embedded-multilib/json/variants/armv7m_soft_nofp_nopic.json
@@ -11,8 +11,8 @@
             "QEMU_CPU": "cortex-m3",
             "FLASH_ADDRESS": "0x00000000",
             "FLASH_SIZE": "0x00400000",
-            "RAM_ADDRESS": "0x20000000",
-            "RAM_SIZE": "0x00800000",
+            "RAM_ADDRESS": "0x21000000",
+            "RAM_SIZE": "0x00a00000",
             "LIBRARY_BUILD_TYPE": "minsizerelease"
         },
         "picolibc": {

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -197,55 +197,6 @@ def main():
             description="Disable the tests for now while the issue is being fixed upstream (https://github.com/picolibc/picolibc/pull/1072).",
         ),
         XFail(
-            name="Insufficient RAM",
-            testnames=[
-                "dynamic_cast14.pass.cpp",
-            ],
-            result=NewResult.XFAILED,
-            project="libcxx",
-            variants=[
-                "armv7m_hard_fpv5_d16_nopic",
-                "armv7m_soft_nofp",
-                "armv7m_soft_nofp_nopic",
-            ],
-            description="dynamic_cast14.pass.cpp (cxxabi test) fails due to"
-                "insufficient memory. It requires at-least 10MB RAM."
-        ),
-        XFail(
-            name="flat-container-oom-armv7m",
-            testnames=[
-                "std/containers/container.adaptors/flat.map/flat.map.capacity/size.pass.cpp",
-                "std/containers/container.adaptors/flat.set/flat.set.capacity/size.pass.cpp",
-            ],
-            result=NewResult.XFAILED,
-            project="libcxx",
-            variants=[
-                "armv7m_soft_nofp",
-                "armv7m_soft_nofp_nopic",
-                "armv7m_hard_fpv5_d16_nopic",
-            ],
-            description="flat.map/size and flat.set/size insert 1,000,000 elements at "
-                        "runtime, exceeding the 8MB RAM on armv7m bare-metal QEMU targets. "
-                        "armv7a/armv8 have 16MB RAM and pass. The test aborts with exit 1.",
-        ),
-        XFail(
-            name="sort-heap-complexity-armv7m",
-            testnames=[
-                "std/algorithms/alg.sorting/alg.heap.operations/sort.heap/complexity.pass.cpp",
-                "std/algorithms/alg.sorting/alg.heap.operations/sort.heap/ranges_sort_heap.pass.cpp",
-            ],
-            result=NewResult.XFAILED,
-            project="libcxx",
-            variants=[
-                "armv7m_soft_nofp",
-                "armv7m_soft_nofp_nopic",
-                "armv7m_hard_fpv5_d16_nopic",
-            ],
-            description="sort.heap complexity tests use std::random_device which falls "
-                        "back to a fixed seed on armv7m bare-metal, causing the complexity "
-                        "assertion to fail. armv7a/armv8 pass. Exits with code 1.",
-        ),
-        XFail(
             name="simd-unary-compiler-crash-armv7a",
             testnames=[
                 "std/experimental/simd/simd.class/simd_unary.pass.cpp",


### PR DESCRIPTION
The current RAM addresses we use for all armv7m variants point to relatively limited regions of RAM (somewhere between 4-8MB depending on how the appropriate Application Notes/QEMU memory setup should be interpreted).

We've seen a few different issues from this:
* We're xfail'ing a few tests due to insufficient RAM.
* When trying to add picolibc v1.8.12 support, no-flash tests are timing out.
    * This _seems_ to be a result of QEMU having 4MB of RAM in these regions and mirroring it with another 4MB. So, zero-ing out 8MB in these tests _also_ zeroes out the .text section as these tests place .text/.data/.bss/etc. in the same segment).

IIUC from the application notes, both the machines we're using for the armv7m variants (mps2-an385 and mps2-an500) have larger blocks of RAM (16MB) allocated at different addresses that don't have the same quirks.

So I think we can point to this area instead to:
1. Allow us to allocate/use more RAM (and thus remove the xfail'ed tests due to RAM limits)
2. Seemingly sidestep the issues observed with the picolibc v1.8.12 no-flash tests.
 
On actual hardware I think this is a _different_ type of RAM, but for QEMU I don't think it matters.

Note that we still don't have identical RAM layouts to ATfE, but this is closer I think.

Note that the "sort-heap-complexity-armv7m" don't describe RAM issues, but these tests are XPASS-ing with this change. Given that they exit with SIGABRT if only given 4MB of RAM and pass if given 6MB of RAM, it seems more likely to me that this was really a issue with the QEMU RAM mirroring rather than what is described in the xfail.