### PR TITLE
[cpullvm] Use cmake 4.4.2 for Linux x86_64 builds

### DIFF
--- a/.github/actions/setup-cmake/action.yml
+++ b/.github/actions/setup-cmake/action.yml
@@ -1,0 +1,24 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Composite action that downloads the cmake version required for cpullvm
+# Linux x86_64 builds. Update the URL and paths here to change the version
+# across all workflows at once.
+# No-op on non-Linux-x86_64 runners (AArch64 GitHub-hosted runners and
+# Windows runners already have a suitable cmake).
+
+name: 'Setup CMake'
+description: 'Downloads cmake required for cpullvm Linux x86_64 builds'
+
+runs:
+  using: composite
+  steps:
+    - name: Download CMake 4.4.2
+      if: runner.os == 'Linux' && runner.arch == 'X64'
+      run: |
+        wget -q \
+          https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-linux-x86_64.tar.gz \
+          -O "${RUNNER_TEMP}/cmake-4.4.2-linux-x86_64.tar.gz"
+        tar -xzf "${RUNNER_TEMP}/cmake-4.4.2-linux-x86_64.tar.gz" -C "${RUNNER_TEMP}"
+        echo "${RUNNER_TEMP}/cmake-4.4.2-linux-x86_64/bin" >> "${GITHUB_PATH}"
+      shell: bash

--- a/.github/workflows/libcxx-test.yml
+++ b/.github/workflows/libcxx-test.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Apply llvm-project patches
         run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
 
+      - uses: ./.github/actions/setup-cmake
+
       - name: Build toolchain
         env:
           EXTRA_CMAKE_ARGS: -DENABLE_LINUX_LIBRARIES=OFF

--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Apply llvm-project patches
         run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
 
+      - uses: ./.github/actions/setup-cmake
+
       - name: Build toolchain
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 

--- a/.github/workflows/native-runtime-nightly.yml
+++ b/.github/workflows/native-runtime-nightly.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Apply llvm-project patches
         run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
 
+      - uses: ./.github/actions/setup-cmake
+
       - name: Build
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,6 +60,8 @@ jobs:
       - name: Apply llvm-project patches
         run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
 
+      - uses: ./.github/actions/setup-cmake
+
       - name: Build
         run: ./qualcomm-software/scripts/build.sh
 
@@ -137,6 +139,8 @@ jobs:
 
       - name: Apply llvm-project patches
         run: python3 qualcomm-software/cmake/patch_repo.py --method apply qualcomm-software/patches/llvm-project
+
+      - uses: ./.github/actions/setup-cmake
 
       - name: Build
         run: ./qualcomm-software/scripts/${{ matrix.build_script }}


### PR DESCRIPTION
LLVM 24 requires cmake >= 3.31.0. The DMZ self-hosted runner has cmake 3.28.3 system-wide which is insufficient.