### PR TITLE
release/qualcomm-software/23.x: [CPULLVM] - Prepare for LIBCXX tests enablement RISCV. (#469)

### DIFF
--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -262,7 +262,7 @@ def main():
                          "on ARMv7-A/ARMv8 with NEON. Compiler bug; exclude until fixed.",
         ),
         XFail(
-            name="long-double-picolibc-aarch64",
+            name="long-double-picolibc-aarch64-riscv",
             testnames=[
                 "std/strings/string.conversions/stold.pass.cpp",
                 "std/strings/string.conversions/to_string.pass.cpp",
@@ -275,10 +275,25 @@ def main():
             project="libcxx",
             variants=[
                 "aarch64a_tlsie",
+                "riscv32imac_ilp32",
+                "riscv32imac_ilp32_nopic",
+                "riscv32imac_zba_zbb_ilp32",
+                "riscv32imac_zba_zbb_ilp32_nopic",
+                "riscv32imac_zcb_zcmp_ilp32_nopic",
+                "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv32imafc_ilp32f",
+                "riscv32imafc_zba_zbb_ilp32f",
+                "riscv32imafc_zcb_zcmp_zba_zbb_ilp32f",
+                "riscv32gc_ilp32d",
+                "riscv64gc_lp64_nopic",
+                "riscv64gc_lp64d_nopic",
+                "riscv64gc_zba_zbb_lp64_nopic",
+                "riscv64gc_zba_zbb_lp64d_nopic",
+                "riscv64imac_lp64_nopic",
             ],
             description="Long double is 128-bit on AArch64 and conversion between 128-bit "
-                        "types and strings is broken in picolibc. ARM 32-bit is unaffected "
-                        "(64-bit long double).",
+                        "types and strings is broken. On RISC-V, picolibc does not support "
+                        "stdio for long doubles. ARM 32-bit is unaffected (64-bit long double).",
         ),
         XFail(
             name="aeabi-unwind-cpp-pr0-missing-arm",
@@ -341,11 +356,84 @@ def main():
                 "armv7m_soft_nofp",
                 "armv7m_soft_nofp_nopic",
                 "armv7m_hard_fpv5_d16_nopic",
+                "riscv32imac_ilp32",
+                "riscv32imac_ilp32_nopic",
+                "riscv32imac_zba_zbb_ilp32",
+                "riscv32imac_zba_zbb_ilp32_nopic",
+                "riscv32imac_zcb_zcmp_ilp32_nopic",
+                "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv32imafc_ilp32f",
+                "riscv32imafc_zba_zbb_ilp32f",
+                "riscv32imafc_zcb_zcmp_zba_zbb_ilp32f",
             ],
             description="cas_non_power_of_2.pass.cpp tests atomic operations on structs of "
                         "sizes 3, 5, and 6 bytes, which require the generic (unsized) libcalls "
                         "__atomic_load / __atomic_compare_exchange.  These lock-based fallbacks "
-                        "are not provided by libclang_rt.builtins.a on our bare-metal ARM targets.",
+                        "are not provided by libclang_rt.builtins.a on our bare-metal ARM and "
+                        "RISCV32 targets.",
+        ),
+        XFail(
+            name="simd-riscv32",
+            testnames=[
+                "std/experimental/simd/",
+            ],
+            result=NewResult.EXCLUDE,
+            project="libcxx",
+            variants=[
+                "riscv32gc_ilp32d",
+                "riscv32imac_ilp32",
+                "riscv32imac_ilp32_nopic",
+                "riscv32imac_zba_zbb_ilp32",
+                "riscv32imac_zba_zbb_ilp32_nopic",
+                "riscv32imac_zcb_zcmp_ilp32_nopic",
+                "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv32imafc_ilp32f",
+                "riscv32imafc_zba_zbb_ilp32f",
+                "riscv32imafc_zcb_zcmp_zba_zbb_ilp32f",
+            ],
+            description="std::experimental::simd is not implemented in libc for RISCV32 "
+                        "targets. The tests fail to compile because the <experimental/simd> "
+                         "header does not provide the required specialisations for RISCV32.",
+        ),
+        XFail(
+            name="cmath-soft-float-precision",
+            testnames=[
+                "std/numerics/c.math/cmath.pass.cpp",
+            ],
+            result=NewResult.XFAILED,
+            project="libcxx",
+            variants=[
+                "riscv32imac_ilp32",
+                "riscv32imac_ilp32_nopic",
+                "riscv32imac_zba_zbb_ilp32",
+                "riscv32imac_zba_zbb_ilp32_nopic",
+                "riscv32imac_zcb_zcmp_ilp32_nopic",
+                "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv64imac_lp64_nopic",
+            ],
+            description="cmath.pass.cpp fails on soft-float builds where std::sqrt(long double) "
+                        "gives incorrect results. The 3-argument std::hypot precision assertion "
+                        "fails because it relies on sqrt(2) being accurate."
+                        "soft-nofp builds and RISC-V variants without the F (single-precision "
+                        "float) extension.",
+        ),
+        XFail(
+            name="string-replace-oom-riscv64",
+            testnames=[
+                "std/strings/basic.string/string.modifiers/string_replace/size_size_string_size_size.pass.cpp",
+            ],
+            result=NewResult.XFAILED,
+            project="libcxx",
+            variants=[
+                "riscv64gc_lp64_nopic",
+                "riscv64gc_lp64d_nopic",
+                "riscv64gc_zba_zbb_lp64_nopic",
+                "riscv64gc_zba_zbb_lp64d_nopic",
+                "riscv64imac_lp64_nopic",
+            ],
+            description="The string replace test exits with code 1 on riscv64 "
+                "bare-metal QEMU targets. The cause is unknown; riscv32 variants "
+                "pass.",
         ),
         XFail(
             name="no-c8rtomb-verify-picolibc",

--- a/qualcomm-software/scripts/test_libcxx.sh
+++ b/qualcomm-software/scripts/test_libcxx.sh
@@ -24,11 +24,18 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
 cd "${REPO_ROOT}"/build
-ninja  check-cxx-aarch64a_tlsie 
-ninja  check-cxx-armv7a_hard_vfpv3
-ninja  check-cxx-armv7a_soft_neon 
-ninja  check-cxx-armv7a_soft_nofp 
-ninja  check-cxx-armv7m_hard_fpv5_d16_nopic 
-ninja  check-cxx-armv7m_soft_nofp 
-ninja  check-cxx-armv7m_soft_nofp_nopic 
-ninja  check-cxx-armv8_soft_neon
+ninja check-cxx-aarch64a_tlsie
+ninja check-cxx-armv7a_hard_vfpv3
+ninja check-cxx-armv7a_soft_neon
+ninja check-cxx-armv7a_soft_nofp
+ninja check-cxx-armv7m_hard_fpv5_d16_nopic
+ninja check-cxx-armv7m_soft_nofp
+ninja check-cxx-armv7m_soft_nofp_nopic
+ninja check-cxx-armv8_soft_neon
+ninja check-cxx-riscv32gc_ilp32d
+ninja check-cxx-riscv32imac_ilp32
+ninja check-cxx-riscv32imac_zba_zbb_ilp32_nopic
+ninja check-cxx-riscv32imafc_zcb_zcmp_zba_zbb_ilp32f
+ninja check-cxx-riscv64gc_lp64_nopic
+ninja check-cxx-riscv64gc_zba_zbb_lp64d_nopic
+ninja check-cxx-riscv64imac_lp64_nopic


### PR DESCRIPTION
Backport 5193d63

Requested by: @jonathonpenix