### PR TITLE
release/qualcomm-software/23.x: [cpullvm][Github] Remove eld support patch application from Zephyr tests (#578)

### DIFF
--- a/.github/workflows/zephyr-twister-tests.yml
+++ b/.github/workflows/zephyr-twister-tests.yml
@@ -59,12 +59,6 @@ jobs:
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      # FIXME: Once this has been merged upstream, this step should be removed.
-      - name: Apply eld patch to Zephyr
-        run: |
-          wget https://github.com/zephyrproject-rtos/zephyr/pull/103778.patch
-          git apply 103778.patch
-
       - name: Checkout fetch-linux-toolchain action
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:


### PR DESCRIPTION
Backport ebfad98

Requested by: @jonathonpenix