### PR TITLE
release/qualcomm-software/23.x: [libunwind] Add libcxx/test_support to include flags (#596)

### DIFF
--- a/qualcomm-software/embedded-runtimes/test-support/llvm-libunwind-picolibc.cfg.in
+++ b/qualcomm-software/embedded-runtimes/test-support/llvm-libunwind-picolibc.cfg.in
@@ -24,7 +24,7 @@ config.substitutions.append(('%{flags}',
     (' -isysroot {}'.format(local_sysroot) if local_sysroot else '')
 ))
 config.substitutions.append(('%{compile_flags}',
-    '-nostdinc++ -I %{include} '
+    '-nostdinc++ -I %{include} -I %{libcxx}/test/support'
     ' -isystem %{libc-include} '
     + ' '.join(compile_flags)
 ))


### PR DESCRIPTION
Backport 294e097554afc3f9f62a8f67b2bd998b1e4df155

Requested by: @bojle