### PR TITLE
[cpullvm][musl] Switch musl repository from https to git protocol

### DIFF
--- a/qualcomm-software/versions.json
+++ b/qualcomm-software/versions.json
@@ -11,7 +11,7 @@
       "tag": "1.8.10"
     },
     "musl": {
-      "url": "https://git.musl-libc.org/git/musl",
+      "url": "git://git.musl-libc.org/musl",
       "tagType": "tag",
       "tag": "v1.2.5"
     },


### PR DESCRIPTION
The musl HTTP repository endpoint is currently unavailable, which prevents access via the web URL.

However, the Git protocol endpoint (git://git.musl-libc.org/musl) remains operational, and cloning the repository works successfully.

(cherry picked from commit 337ac900d48f5d29378bc9c8a22df822d69cec91)