### PR TITLE
[cpullvm] Tweak musl-embedded, Linux library mentions in user-facing documentation

### DIFF
--- a/qualcomm-software/README.md
+++ b/qualcomm-software/README.md
@@ -13,11 +13,13 @@ including:
 - musl-embedded
 - libc++/libunwind/libc++abi
 
-For Arm and AArch64 embedded environments, picolibc or musl-embedded may be used as the libc.
-For RISC-V, only picolibc may be used.
+For embedded environments, picolibc is used as the libc.
+
+Multiple versions of picolibc are available and may be installed as overlays. Please
+see CPULLVM's [overlay installation and usage documentation](./docs/user.md#overlay-installation-and-usage) for details.
 
 Libraries intended for use in Linux environments may also be built as part of CPULLVM, though these
-are primarily intended for testing and validation. For Arm and AArch64, musl-embedded is used
+are only intended for testing and validation. For Arm and AArch64, musl-embedded is used
 as the libc for Linux. For RISC-V, musl is used.
 
 ## Targets Built


### PR DESCRIPTION
A few misc. small tweaks:
- Remove note that musl-embedded may be used for embedded libraries in the README. They still can be used, but we want to discourage usage and we won't provide any of these libraries in our releases going forward. Make reference to the other versions of picolibc instead.
- Make the language slightly stronger that Linux libraries are for testing only. This came up in #612.

Notes about building/using musl-embedded libraries for baremetal were left as-is in more developer-facing docs (build.md, developing.md).

musl-embedded Linux-related references were also left alone.