### PR TITLE
[cpullvm][Multilib] Add aligned AArch64 variants

### DIFF
--- a/qualcomm-software/embedded-multilib/json/multilib.json
+++ b/qualcomm-software/embedded-multilib/json/multilib.json
@@ -13,6 +13,12 @@
             "libraries_supported": "picolibc"
         },
         {
+            "variant": "aarch64a_aligned_tlsie",
+            "json": "aarch64a_aligned_tlsie.json",
+            "flags": "--target=aarch64-unknown-none-elf -mno-unaligned-access",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "aarch64a_pacret",
             "json": "aarch64a_pacret.json",
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.3-a -mbranch-protection=pac-ret+leaf -munaligned-access"
@@ -35,6 +41,12 @@
             "libraries_supported": "picolibc"
         },
         {
+            "variant": "aarch64a_pacret_bkey_bti_aligned_tlsie",
+            "json": "aarch64a_pacret_bkey_bti_aligned_tlsie.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -mbranch-protection=pac-ret+leaf+b-key+bti -mno-unaligned-access",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "aarch64a_soft_nofp",
             "json": "aarch64a_soft_nofp.json",
             "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -munaligned-access",
@@ -47,9 +59,20 @@
             "libraries_supported": "picolibc"
         },
         {
+            "variant": "aarch64a_soft_nofp_aligned_tlsie",
+            "json": "aarch64a_soft_nofp_aligned_tlsie.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armvX+nofp -march=armvX+nosimd -mabi=aapcs-soft -mno-unaligned-access",
+            "libraries_supported": "picolibc"
+        },
+        {
             "variant": "aarch64a_soft_nofp_pacret_bti",
             "json": "aarch64a_soft_nofp_pacret_bti.json",
             "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -munaligned-access"
+        },
+        {
+            "variant": "aarch64a_soft_nofp_pacret_bti_aligned",
+            "json": "aarch64a_soft_nofp_pacret_bti_aligned.json",
+            "flags": "--target=aarch64-unknown-none-elf -march=armv8.5-a -march=armvX+nofp -march=armvX+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -mno-unaligned-access"
         },
         {
             "variant": "aarch64a_soft_nofp_pacret_bkey_bti",

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_aligned_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_aligned_tlsie.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_aligned_tlsie",
+            "COMPILE_FLAGS": "-march=armv8-a -mno-unaligned-access -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "FLASH_ADDRESS": "0x40000000",
+            "FLASH_SIZE": "0x01000000",
+            "RAM_ADDRESS": "0x41000000",
+            "RAM_SIZE": "0x01000000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
+            "ENABLE_LIBCXX_TESTS": "ON",
+            "TLS_MODEL": "initial-exec"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_aligned_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_pacret_bkey_bti_aligned_tlsie.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_pacret_bkey_bti_aligned_tlsie",
+            "COMPILE_FLAGS": "-march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -mno-unaligned-access -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "FLASH_ADDRESS": "0x40000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x40400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "ON",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "TLS_MODEL": "initial-exec"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_aligned_tlsie.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_aligned_tlsie.json
@@ -1,0 +1,26 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_soft_nofp_aligned_tlsie",
+            "COMPILE_FLAGS": "-march=armv8-a+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "FLASH_ADDRESS": "0x40000000",
+            "FLASH_SIZE": "0x01000000",
+            "RAM_ADDRESS": "0x41000000",
+            "RAM_SIZE": "0x1000000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "ON",
+            "ENABLE_COMPILER_RT_TESTS": "ON",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "TLS_MODEL": "initial-exec"
+        }
+    }
+}

--- a/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti_aligned.json
+++ b/qualcomm-software/embedded-multilib/json/variants/aarch64a_soft_nofp_pacret_bti_aligned.json
@@ -1,0 +1,33 @@
+{
+    "args": {
+        "common": {
+            "TARGET_ARCH": "aarch64a",
+            "VARIANT": "aarch64a_soft_nofp_pacret_bti_aligned",
+            "COMPILE_FLAGS": "-march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -mno-unaligned-access -fPIC",
+            "ENABLE_EXCEPTIONS": "OFF",
+            "ENABLE_RTTI": "OFF",
+            "TEST_EXECUTOR": "qemu",
+            "QEMU_MACHINE": "virt",
+            "QEMU_CPU": "cortex-a57",
+            "FLASH_ADDRESS": "0x40000000",
+            "FLASH_SIZE": "0x00400000",
+            "RAM_ADDRESS": "0x40400000",
+            "RAM_SIZE": "0x00200000",
+            "LIBRARY_BUILD_TYPE": "minsizerelease"
+        },
+        "picolibc": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF"
+        },
+        "musl-embedded": {
+            "ENABLE_CXX_LIBS": "OFF",
+            "ENABLE_LIBC_TESTS": "OFF",
+            "ENABLE_COMPILER_RT_TESTS": "OFF",
+            "ENABLE_LIBCXX_TESTS": "OFF",
+            "EXTRA_MUSL-EMBEDDED_CONFIG_FLAGS": "--quic-aarch64-nofp",
+            "EXTRA_MUSL-EMBEDDED_CFLAGS": "-mstrict-align"
+        }
+    }
+}

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -121,6 +121,7 @@ def main():
             project="libcxx",
             variants=[
                 "aarch64a_tlsie",
+                "aarch64a_aligned_tlsie",
                 "riscv64gc_lp64d_nopic",
                 "riscv64gc_lp64_nopic",
                 "riscv64gc_zba_zbb_lp64d_nopic",
@@ -227,7 +228,9 @@ def main():
             project="picolibc",
             variants=[
                 "aarch64a_tlsie",
+                "aarch64a_aligned_tlsie",
                 "aarch64a_soft_nofp_tlsie",
+                "aarch64a_soft_nofp_aligned_tlsie",
             ],
             description="picolibc's `*-raw-*` tests rely on serial port usage "
                         "to exit correctly which our existing wrappers are not "
@@ -264,6 +267,7 @@ def main():
             project="libcxx",
             variants=[
                 "aarch64a_tlsie",
+                "aarch64a_aligned_tlsie",
                 "riscv32imac_ilp32",
                 "riscv32imac_ilp32_nopic",
                 "riscv32imac_zba_zbb_ilp32",
@@ -428,7 +432,9 @@ def main():
             project="compiler-rt",
             variants=[
                 "aarch64a_tlsie",
+                "aarch64a_aligned_tlsie",
                 "aarch64a_soft_nofp_tlsie",
+                "aarch64a_soft_nofp_aligned_tlsie",
             ],
             description="QEMU does not deliver crash signals. The emupac test uses "
                 "%expect_crash which requires the OS to deliver a signal back to the "
@@ -445,6 +451,7 @@ def main():
             project="compiler-rt",
             variants=[
                 "aarch64a_soft_nofp_tlsie",
+                "aarch64a_soft_nofp_aligned_tlsie",
             ],
             description="The test fails to compile because the 'cassert' header is not "
                 "found. This variant has ENABLE_CXX_LIBS=OFF so libcxx headers are not "

--- a/qualcomm-software/scripts/test_libcxx.sh
+++ b/qualcomm-software/scripts/test_libcxx.sh
@@ -25,6 +25,7 @@ REPO_ROOT=$( git -C "${SCRIPT_DIR}" rev-parse --show-toplevel )
 
 cd "${REPO_ROOT}"/build
 ninja check-cxx-aarch64a_tlsie
+ninja check-cxx-aarch64a_aligned_tlsie
 ninja check-cxx-armv7a_hard_vfpv3
 ninja check-cxx-armv7a_soft_neon
 ninja check-cxx-armv7a_soft_nofp

--- a/qualcomm-software/test/multilib/aarch64.test
+++ b/qualcomm-software/test/multilib/aarch64.test
@@ -9,6 +9,11 @@
 # CHECK-AARCH64: aarch64-none-elf/aarch64a_tlsie{{$}}
 # CHECK-AARCH64-EMPTY:
 
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64-ALIGNED
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-AARCH64-ALIGNED
+# CHECK-AARCH64-ALIGNED: aarch64-none-elf/aarch64a_aligned_tlsie{{$}}
+# CHECK-AARCH64-ALIGNED-EMPTY:
+
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.3a -mbranch-protection=pac-ret+leaf | FileCheck %s --check-prefix=CHECK-PACRET
 # CHECK-PACRET: aarch64-none-elf/aarch64a_pacret{{$}}
@@ -24,11 +29,22 @@
 # CHECK-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_pacret_bkey_bti_tlsie{{$}}
 # CHECK-PACRET-BKEY-BTI-EMPTY:
 
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI-ALIGNED
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a -mbranch-protection=pac-ret+leaf+b-key+bti -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-PACRET-BKEY-BTI-ALIGNED
+# CHECK-PACRET-BKEY-BTI-ALIGNED: aarch64-none-elf/aarch64a_pacret_bkey_bti_aligned_tlsie{{$}}
+# CHECK-PACRET-BKEY-BTI-ALIGNED-EMPTY:
+
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP
 # CHECK-NOFP: aarch64-none-elf/aarch64a_soft_nofp_tlsie{{$}}
 # CHECK-NOFP-EMPTY:
+
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-NOFP-ALIGNED
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53+nofp+nosimd -mabi=aapcs-soft -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-NOFP-ALIGNED
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mabi=aapcs-soft -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-NOFP-ALIGNED
+# CHECK-NOFP-ALIGNED: aarch64-none-elf/aarch64a_soft_nofp_aligned_tlsie{{$}}
+# CHECK-NOFP-ALIGNED-EMPTY:
 
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI
@@ -36,11 +52,14 @@
 # CHECK-NOFP-PACRET-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti{{$}}
 # CHECK-NOFP-PACRET-BTI-EMPTY:
 
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI-ALIGNED
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI-ALIGNED
+# RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+bti -mabi=aapcs-soft -mno-unaligned-access | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BTI-ALIGNED
+# CHECK-NOFP-PACRET-BTI-ALIGNED: aarch64-none-elf/aarch64a_soft_nofp_pacret_bti_aligned{{$}}
+# CHECK-NOFP-PACRET-BTI-ALIGNED-EMPTY:
+
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -mcpu=cortex-a53 -march=armv8.5a+nofp+nosimd -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # RUN: %clang_with_libc_cfg -print-multi-directory --target=aarch64-none-elf -march=armv8.5a -mgeneral-regs-only -mllvm -aarch64-enable-simd-scalar=false -mbranch-protection=pac-ret+leaf+b-key+bti -mabi=aapcs-soft | FileCheck %s --check-prefix=CHECK-NOFP-PACRET-BKEY-BTI
 # CHECK-NOFP-PACRET-BKEY-BTI: aarch64-none-elf/aarch64a_soft_nofp_pacret_bkey_bti{{$}}
 # CHECK-NOFP-PACRET-BKEY-BTI-EMPTY:
-
-# RUN: %clang_with_libc_cfg -print-multi-directory -print-multi-directory --target=aarch64-none-elf -mno-unaligned-access 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
-# NOT-FOUND: warning: no multilib found matching flags


### PR DESCRIPTION
Add aligned alternatives of the following variants:
- aarch64a_tlsie
- aarch64a_pacret_bkey_bti_tlsie
- aarch64a_soft_nofp_tlsie
- aarch64a_soft_nofp_pacret_bti

So far these are the only variants where folks have needed unaligned variants, so we're just going to duplicate these for now.

See https://github.com/qualcomm/cpullvm-toolchain/issues/388 for additional context around our Arm/AArch64 variant alignment situation.

This is a port of #448 from 22.x