### PR TITLE
[cpullvm] Add an xqci variant as part of libc++ tests

### DIFF
--- a/.github/workflows/libcxx-test.yml
+++ b/.github/workflows/libcxx-test.yml
@@ -7,8 +7,6 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# DNM, temp change to trigger workflow
-
 name: Run libc++ tests
 
 on:

--- a/.github/workflows/libcxx-test.yml
+++ b/.github/workflows/libcxx-test.yml
@@ -7,6 +7,8 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries. 
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# DNM, temp change to trigger workflow
+
 name: Run libc++ tests
 
 on:

--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -270,6 +270,7 @@ def main():
                 "riscv32imac_zba_zbb_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv32ima_xqci_ilp32_nopic",
                 "riscv32imafc_ilp32f",
                 "riscv32imafc_zba_zbb_ilp32f",
                 "riscv32imafc_zcb_zcmp_zba_zbb_ilp32f",
@@ -378,6 +379,7 @@ def main():
                 "riscv32imac_zba_zbb_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv32ima_xqci_ilp32_nopic",
                 "riscv32imafc_ilp32f",
                 "riscv32imafc_zba_zbb_ilp32f",
                 "riscv32imafc_zcb_zcmp_zba_zbb_ilp32f",
@@ -400,6 +402,7 @@ def main():
                 "riscv32imac_zba_zbb_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv32ima_xqci_ilp32_nopic",
                 "riscv64imac_lp64_nopic",
             ],
             description="cmath.pass.cpp fails on soft-float builds where std::sqrt(long double) "

--- a/qualcomm-software/scripts/test_libcxx.sh
+++ b/qualcomm-software/scripts/test_libcxx.sh
@@ -35,6 +35,7 @@ ninja check-cxx-armv8_soft_neon
 ninja check-cxx-riscv32gc_ilp32d
 ninja check-cxx-riscv32imac_ilp32
 ninja check-cxx-riscv32imac_zba_zbb_ilp32_nopic
+ninja check-cxx-riscv32ima_xqci_ilp32_nopic
 ninja check-cxx-riscv32imafc_zcb_zcmp_zba_zbb_ilp32f
 ninja check-cxx-riscv64gc_lp64_nopic
 ninja check-cxx-riscv64gc_zba_zbb_lp64d_nopic


### PR DESCRIPTION
Previously, xqci variants were omitted as we saw huge numbers of libc++ test
failures in variants without 'a' (see https://github.com/qualcomm/cpullvm-toolchain/pull/469)
and at the time we didn't have any xqci variants with 'a'.

We do now (and these variants turn on C++ libs and `ENABLE_LIBCXX_TESTS`) so
add one such variant in the scheduled libc++ tests--it should be clean.