### PR TITLE
release/qualcomm-software/23.x: [cpullvm] Add an xqci variant as part of libc++ tests (#620)

### DIFF
--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -270,6 +270,7 @@ def main():
                 "riscv32imac_zba_zbb_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv32ima_xqci_ilp32_nopic",
                 "riscv32imafc_ilp32f",
                 "riscv32imafc_zba_zbb_ilp32f",
                 "riscv32imafc_zcb_zcmp_zba_zbb_ilp32f",
@@ -378,6 +379,7 @@ def main():
                 "riscv32imac_zba_zbb_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv32ima_xqci_ilp32_nopic",
                 "riscv32imafc_ilp32f",
                 "riscv32imafc_zba_zbb_ilp32f",
                 "riscv32imafc_zcb_zcmp_zba_zbb_ilp32f",
@@ -400,6 +402,7 @@ def main():
                 "riscv32imac_zba_zbb_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_ilp32_nopic",
                 "riscv32imac_zcb_zcmp_zba_zbb_ilp32_nopic",
+                "riscv32ima_xqci_ilp32_nopic",
                 "riscv64imac_lp64_nopic",
             ],
             description="cmath.pass.cpp fails on soft-float builds where std::sqrt(long double) "

--- a/qualcomm-software/scripts/test_libcxx.sh
+++ b/qualcomm-software/scripts/test_libcxx.sh
@@ -35,6 +35,7 @@ ninja check-cxx-armv8_soft_neon
 ninja check-cxx-riscv32gc_ilp32d
 ninja check-cxx-riscv32imac_ilp32
 ninja check-cxx-riscv32imac_zba_zbb_ilp32_nopic
+ninja check-cxx-riscv32ima_xqci_ilp32_nopic
 ninja check-cxx-riscv32imafc_zcb_zcmp_zba_zbb_ilp32f
 ninja check-cxx-riscv64gc_lp64_nopic
 ninja check-cxx-riscv64gc_zba_zbb_lp64d_nopic


### PR DESCRIPTION
Backport 1366273

Requested by: @jonathonpenix