### PR TITLE
[cpullvm] Unify Linux AArch64 Host Compiler to Clang 22.1.8 on GitHub Ubuntu Runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,7 @@
 #
 # Other build configurations such as building the runtimes on non-Linux
 # x86_64 platforms are built and tested separately.
+# clang-22 for linux aarch64 github runner.(testing)
 
 name: Nightly Build and Test
 

--- a/qualcomm-software/scripts/install_dependencies.sh
+++ b/qualcomm-software/scripts/install_dependencies.sh
@@ -1,14 +1,24 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+CLANG_VERSION = 22
+
 sudo apt-get update
+
+# Add LLVM APT repo (required for clang-22)
+wget -qO llvm.sh https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh ${CLANG_VERSION}
+
 # Install swig and libedit-dev used by lldb and
 # libc++-dev required for eld tests
-sudo apt-get install -y swig libedit-dev clang-19 libc++-19-dev
+sudo apt-get install -y swig libedit-dev libc++-${CLANG_VERSION}-dev
 
-# Set default clang version to clang-19
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
+# Set default clang version to clang-22
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 100
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 100
+sudo update-alternatives --set clang /usr/bin/clang-${CLANG_VERSION}
+sudo update-alternatives --set clang++ /usr/bin/clang++-${CLANG_VERSION}
 
 # Install meson. eld support was added in v1.9.0, so we need at least that.
 pip install meson==1.10.0


### PR DESCRIPTION
Align the Linux AArch64 GitHub Ubuntu runner with the host compiler version used across other build environments.

This change installs and uses Clang 22.1.8 on the GitHub-hosted AArch64 Ubuntu runner, ensuring consistent compiler versions across all supported build configurations and reducing toolchain-related variations.