### PR TITLE
[cpullvm] Stop automerge for release/23.x (code freeze)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -19,8 +19,6 @@ jobs:
         branches:
           - from_branch: main
             to_branch: qualcomm-software
-          - from_branch: release/23.x
-            to_branch: release/qualcomm-software/23.x
     steps:
       - name: Configure Access Token
         uses: actions/create-github-app-token@f45685208fd9b88321d74015b5996fc8c3e43d18 # v1.0.0


### PR DESCRIPTION
Remove release/23.x from the automerge workflow matrix to stop automatic updates in version.json in the release/qualcomm-software/23.x.