### PR TITLE
LTO with linker scripts: Disable section markings for globals with type markings.

### DIFF
--- a/qualcomm-software/patches/llvm-project/0005-LTO-with-linker-scripts-vtable-fix.patch
+++ b/qualcomm-software/patches/llvm-project/0005-LTO-with-linker-scripts-vtable-fix.patch
@@ -1,0 +1,27 @@
+commit 44f4616f0d373e237fe8e670e7c3980a7acd2f8b
+Author: Eli Friedman <efriedma@qti.qualcomm.com>
+Date:   Tue Sep 1 14:43:26 2026 -0700
+
+    Disable section markings for globals with type markings.
+    
+    LTO by default emits type metadata on all vtables when LTO is enabled.
+    This is true even when none of the options which would actually
+    consume the metadata are enabled.  We can't control the section of such
+    globals: LowerTypeTests rewrites globals.  So don't try.
+    
+    We might want to expose a clang option to control this.
+
+diff --git a/llvm/lib/CodeGen/AssignSectionsToGlobals.cpp b/llvm/lib/CodeGen/AssignSectionsToGlobals.cpp
+index 608c2c701e09..32402387aa7e 100644
+--- a/llvm/lib/CodeGen/AssignSectionsToGlobals.cpp
++++ b/llvm/lib/CodeGen/AssignSectionsToGlobals.cpp
+@@ -125,7 +125,8 @@ bool AssignSections::run(Module &Mod, TargetMachine *TMIn) {
+   // Iterate over objects, and assign sections
+   for (GlobalObject &GO : M->global_objects()) {
+     if (GO.isDeclarationForLinker() || GO.hasSection() ||
+-        GO.hasCommonLinkage() || GO.getName().starts_with("llvm."))
++        GO.hasCommonLinkage() || GO.getName().starts_with("llvm.") ||
++        GO.hasMetadata(LLVMContext::MD_type))
+       continue;
+ 
+     GO.setSection(getDefaultSectionNameForGlobal(GO));


### PR DESCRIPTION
Cherry-pick of
https://github.com/efriedma-quic/llvm-project/commit/44f4616f0d373e237fe8e670e7c3980a7acd2f8b, from branch https://github.com/llvm/llvm-project/compare/main...efriedma-quic:llvm-project:lto-linker-scripts