### PR TITLE
23.x: [cpullvm] Add Ubuntu major version information to package name by default

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -155,7 +155,7 @@ jobs:
           path: |
             build*/cpullvm-*.tar.xz
             build*/cpullvm-*.zip
-            !build/cpullvm-*-Linux-x86_64.tar.xz
+            !build/cpullvm-*-Linux-x86_64*.tar.xz
           retention-days: 7
 
       - name: Test

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -461,7 +461,18 @@ endif()
 if (PACKAGE_SYSTEM_NAME)
     set(CPACK_SYSTEM_NAME "${PACKAGE_SYSTEM_NAME}-${processor_name}")
 else()
-    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${processor_name}")
+    # If building on Ubuntu, append Ubuntu version info to the package name
+    execute_process(
+        COMMAND lsb_release -irs
+        RESULT_VARIABLE lsb_return_val
+        OUTPUT_VARIABLE linux_flavor
+    )
+    if(lsb_return_val EQUAL 0 AND linux_flavor MATCHES "Ubuntu")
+        string(REGEX MATCH "^([A-Za-z]+)\n([0-9]+)" _ "${linux_flavor}")
+        set(extra_os_information "-${CMAKE_MATCH_1}${CMAKE_MATCH_2}")
+    endif()
+
+    set(CPACK_SYSTEM_NAME "${CMAKE_SYSTEM_NAME}-${processor_name}${extra_os_information}")
 endif()
 
 set(CPACK_PACKAGE_VERSION ${PACKAGE_VERSION})


### PR DESCRIPTION
Old example: cpullvm-24.0.0-Linux-x86_64.tar.xz
New example: cpullvm-24.0.0-Linux-x86_64-Ubuntu24.tar.xz

Non-Ubuntu OS'es should be unaffected.

Note that this changes the final package name only--the "wrapper" packages (ex: cpullvm-packages-build.sh-Linux-x86) are left unchanged. In the past we added the separate Ubuntu versions in different workflows, so things can be distinguished easily still. Maybe this will need to change, but for now just follow what we've done in the past.

Assisted-by: claude