### PR TITLE
[cpullvm][Github] Don't run nightly-release.yml if nightly.yml is modified

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -10,7 +10,6 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - '.github/workflows/nightly.yml'
       - '.github/workflows/nightly-release.yml'
 
 permissions:


### PR DESCRIPTION
Given that nightly-release.yml calls nightly.yml it isn't a bad idea to test nightly-release.yml in PRs if nightly.yml changes. But, this ends up meaning that any PR that touches nightly.yml kicks off ~7 builds that compete for our 2 Linux x86 builders. Which is way more than we can handle right now, especially if there are multiple changes going on.

So don't trigger nightly-release.yml if nightly.yml changes in a PR.

We'll need to be a bit more careful when changing nightly.yml, but hopefully any breakage will be rare and we can revisit this when our builder situation changes.