### PR TITLE
[cpullvm][Github] Don't trigger linux-premerge.yml if only other workflows were changed

### DIFF
--- a/.github/workflows/linux-premerge.yml
+++ b/.github/workflows/linux-premerge.yml
@@ -12,9 +12,14 @@ name: Linux Premerge Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - '.github/workflows/qcom-preflight-checks.yml'
-      - '**/*.md'
+    # This should run only if any non-*.md, non-.github/ files were modified as
+    # neither of these groups currently impact the build here. It still needs
+    # to run for changes to linux-premerge.yml itself though.
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!**/*.md'
+      - '.github/workflows/linux-premerge.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
The goal is to run linux-premerge.yml if any file is modified *except* for other `.github/**` files and `*.md` files.

So, the only intended change here is to avoid launching linux-premerge.yml if other `.github/**/*.yml` files were modified (the `*.md` rule is preserved as-is hopefully).

I think this should work but I'm not sure if there's a nicer way to implement this. I don't really want to list all the other `.github/**/*.yml` files under `paths-ignore` as then we have to update it every time a new workflow is added or renamed.

Assisted-by: claude