### PR TITLE
[cpullvm][Github] Update actions/github-script version to v9.0.0

### DIFF
--- a/.github/actions/fetch-linux-toolchain/action.yml
+++ b/.github/actions/fetch-linux-toolchain/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Get latest nightly run ID
       id: latest
       if: inputs.run-id == ''
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         JOB_NAME: ${{ inputs.job-name }}
         MAX_AGE_DAYS: ${{ inputs.max-age-days }}


### PR DESCRIPTION
This should hopefully resolve warnings about deprecated Node.js 20 usage in our Zephyr workflow.