### PR TITLE
23.x: [cpullvm] Include lldbPluginScriptInterpreterPython in distribution

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -170,9 +170,9 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     clangd
     ld.eld
     liblldb
-    lldbPluginScriptInterpreterPython
     lld
     lldb
+    lldbPluginScriptInterpreterPython
     lldb-argdumper
     lldb-dap
     lldb-instr

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -170,6 +170,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     clangd
     ld.eld
     liblldb
+    lldbPluginScriptInterpreterPython
     lld
     lldb
     lldb-argdumper


### PR DESCRIPTION
Otherwise it is excluded and we have broken symlinks in our final install/distribution (from _lldb.abi3.so to the missing liblldbPluginScriptInterpreterPython.so).