### PR TITLE
[cpullvm] Include lldbPluginScriptInterpreterPython in distribution

### DIFF
--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -178,6 +178,9 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     liblldb
     lld
     lldb
+    # FIXME: this can be removed once https://github.com/llvm/llvm-project/issues/222116
+    # is resolved.
+    lldbPluginScriptInterpreterPython
     lldb-argdumper
     lldb-dap
     lldb-instr


### PR DESCRIPTION
Otherwise it is excluded and we have broken symlinks in our final install/distribution (from _lldb.abi3.so to the missing liblldbPluginScriptInterpreterPython.so).