### PR TITLE
[cpullvm] Don't add lldbPluginScriptInterpreterPython unless we set LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,8 @@
 # Other build configurations such as building the runtimes on non-Linux
 # x86_64 platforms are built and tested separately.
 
+# DNM: trigger nightly build
+
 name: Nightly Build and Test
 
 on:
@@ -91,29 +93,11 @@ jobs:
             target_os: Linux-AArch64
             runner: ubuntu-24.04-arm
 
-          - build_script: build_picolibc-v1812_overlay.sh
-            test_script: test_picolibc-v1812_overlay.sh
-            install_script: ''
-            target_os: Linux-x86_64
-            runner: cpullvm-ubuntu24-x86_64
-
-          - build_script: build_musl-embedded_overlay.sh
-            test_script: ''
-            install_script: ''
-            target_os: Linux-x86_64
-            runner: cpullvm-ubuntu24-x86_64
-
           - build_script: build_copy_runtimes.ps1
             test_script: test.ps1
             install_script: install_dependencies.ps1
             target_os: Windows-x86_64
             runner: windows-2025
-
-          - build_script: build_copy_runtimes.ps1
-            test_script: test.ps1
-            install_script: install_dependencies.ps1
-            target_os: Windows-AArch64
-            runner: windows-11-arm
 
     steps:
       # Not setting these can cause lit test failures on Windows machines when

--- a/qualcomm-software/CMakeLists.txt
+++ b/qualcomm-software/CMakeLists.txt
@@ -172,7 +172,6 @@ set(LLVM_DISTRIBUTION_COMPONENTS
     liblldb
     lld
     lldb
-    lldbPluginScriptInterpreterPython
     lldb-argdumper
     lldb-dap
     lldb-instr
@@ -260,6 +259,7 @@ set(LLDB_ENABLE_PYTHON ON CACHE BOOL "")
 # Python versions.
 if (NOT CMAKE_HOST_WIN32)
   set(LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS ON CACHE BOOL "")
+  list(APPEND LLVM_DISTRIBUTION_COMPONENTS lldbPluginScriptInterpreterPython)
 endif()
 # LLDB tests don't work on x86 because clang defaults to AArch64 target triple.
 # See https://github.com/llvm/llvm-project/issues/203090 .  Using a clang


### PR DESCRIPTION
Which, we don't set LLDB_ENABLE_DYNAMIC_SCRIPTINTERPRETERS on Windows which causes build failures.