### PR TITLE
[cpullvm] Remove simd_unary.pass.cpp xfail/exclude

### DIFF
--- a/qualcomm-software/embedded-runtimes/test-support/xfails.py
+++ b/qualcomm-software/embedded-runtimes/test-support/xfails.py
@@ -238,22 +238,6 @@ def main():
                         "any significant test coverage by doing so.",
         ),
         XFail(
-            name="simd-unary-compiler-crash-armv7a",
-            testnames=[
-                "std/experimental/simd/simd.class/simd_unary.pass.cpp",
-            ],
-            result=NewResult.EXCLUDE,
-            project="libcxx",
-            variants=[
-                "armv7a_soft_neon",
-                "armv8_soft_neon",
-            ],
-            description="simd_unary.pass.cpp triggers a clang assertion failure "
-                        "(ScalarizeVecOp_VSETCC: expected v1i1 type) in "
-                        "LegalizeVectorTypes.cpp when compiling std::experimental::simd "
-                         "on ARMv7-A/ARMv8 with NEON. Compiler bug; exclude until fixed.",
-        ),
-        XFail(
             name="long-double-picolibc-aarch64-riscv",
             testnames=[
                 "std/strings/string.conversions/stold.pass.cpp",


### PR DESCRIPTION
These seem to be passing now. I'm not sure what fixed it, but see ex: [1] in community that mentions the same.

[1] https://github.com/llvm/llvm-project/commit/9b1aee96e8897ca7c8bfa363ec87c7acf5d6b656